### PR TITLE
feat(telemetry): enabled trace setup for evaluations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,9 @@ dependencies = [
     "strands-agents>=1.0.0",
     "strands-agents-tools>=0.1.0,<1.0.0",
     "typing-extensions>=4.0",
+    "opentelemetry-api>=1.20.0",
+    "opentelemetry-sdk>=1.20.0",
+    "opentelemetry-instrumentation-threading>=0.51b0,<1.00b0",
 ]
 
 [tool.hatch.build.targets.wheel]
@@ -37,6 +40,8 @@ dev = [
     "pre-commit>=3.2.0,<4.2.0",
     "ruff>=0.4.4,<1.0.0",
 ]
+
+otel = ["opentelemetry-exporter-otlp-proto-http>=1.30.0,<2.0.0"]
 
 [tool.ruff]
 line-length = 120

--- a/src/strands_evals/__init__.py
+++ b/src/strands_evals/__init__.py
@@ -1,7 +1,18 @@
 __version__ = "0.1.0"
 
-from . import evaluators, extractors, generators, types
+from . import evaluators, extractors, generators, telemetry, types
 from .case import Case
 from .dataset import Dataset
+from .telemetry import StrandsEvalsTelemetry, get_tracer
 
-__all__ = ["Dataset", "Case", "evaluators", "extractors", "types", "generators"]
+__all__ = [
+    "Dataset",
+    "Case",
+    "evaluators",
+    "extractors",
+    "types",
+    "generators",
+    "telemetry",
+    "StrandsEvalsTelemetry",
+    "get_tracer",
+]

--- a/src/strands_evals/dataset.py
+++ b/src/strands_evals/dataset.py
@@ -10,6 +10,7 @@ from .evaluators.evaluator import Evaluator
 from .evaluators.interactions_evaluator import InteractionsEvaluator
 from .evaluators.output_evaluator import OutputEvaluator
 from .evaluators.trajectory_evaluator import TrajectoryEvaluator
+from .telemetry import get_tracer, serialize
 from .types.evaluation import EvaluationData
 from .types.evaluation_report import EvaluationReport
 
@@ -47,10 +48,11 @@ class Dataset(Generic[InputT, OutputT]):
     """
 
     def __init__(
-        self, cases: list[Case[InputT, OutputT]] | None = None, evaluator: Evaluator[InputT, OutputT] | None = None
+        self, cases: list[Case[InputT, OutputT]] | None = None, evaluator: Evaluator[InputT, OutputT] | None = None,
     ):
         self._cases = cases or []
         self._evaluator = evaluator or Evaluator()
+        self._tracer = get_tracer()
 
     @property
     def cases(self) -> list[Case[InputT, OutputT]]:
@@ -189,31 +191,71 @@ class Dataset(Generic[InputT, OutputT]):
             except asyncio.QueueEmpty:
                 break
 
-            ## Evaluation ##
-            try:
-                evaluation_context = await self._run_task_async(task, case)
-                evaluation_output = await self.evaluator.evaluate_async(evaluation_context)
-
-                # Store results
-                results.append(
-                    {
-                        "case": evaluation_context.model_dump(),
-                        "test_pass": evaluation_output.test_pass,
-                        "score": evaluation_output.score,
-                        "reason": evaluation_output.reason or "",
-                    }
-                )
-            except Exception as e:
-                results.append(
-                    {
-                        "case": case.model_dump(),
-                        "test_pass": False,
-                        "score": 0,
-                        "reason": f"An error occurred: {str(e)}",
-                    }
-                )
-            finally:
-                queue.task_done()
+            case_name = case.name or f"case_{len(results)}"
+            
+            ## Evaluation with tracing ##
+            with self._tracer.start_as_current_span(
+                f"eval_case {case_name}",
+                attributes={
+                    "gen_ai.eval.case.name": case_name,
+                    "gen_ai.eval.case.input": serialize(case.input),
+                }
+            ) as case_span:
+                try:
+                    # Task execution span
+                    with self._tracer.start_as_current_span(
+                        "task_execution",
+                        attributes={
+                            "gen_ai.eval.task.type": "agent_task",
+                            "gen_ai.eval.case.name": case_name,
+                        }
+                    ) as task_span:
+                        evaluation_context = await self._run_task_async(task, case)
+                        task_span.set_attributes({
+                            "gen_ai.eval.data.input": serialize(evaluation_context.input),
+                            "gen_ai.eval.data.expected_output": serialize(evaluation_context.expected_output),
+                            "gen_ai.eval.data.actual_output": serialize(evaluation_context.actual_output),
+                            "gen_ai.eval.data.has_trajectory": evaluation_context.actual_trajectory is not None,
+                            "gen_ai.eval.data.has_interactions": evaluation_context.actual_interactions is not None,
+                        })
+                    
+                    # Evaluator execution span
+                    with self._tracer.start_as_current_span(
+                        f"evaluator {self.evaluator.get_type_name()}",
+                        attributes={
+                            "gen_ai.eval.evaluator.type": self.evaluator.get_type_name(),
+                            "gen_ai.eval.case.name": case_name,
+                        }
+                    ) as eval_span:
+                        evaluation_output = await self.evaluator.evaluate_async(evaluation_context)
+                        eval_span.set_attributes({
+                            "gen_ai.eval.output.score": evaluation_output.score,
+                            "gen_ai.eval.output.test_pass": evaluation_output.test_pass,
+                            "gen_ai.eval.output.reason": evaluation_output.reason or "",
+                        })
+                    
+                    # Store results
+                    results.append(
+                        {
+                            "case": evaluation_context.model_dump(),
+                            "test_pass": evaluation_output.test_pass,
+                            "score": evaluation_output.score,
+                            "reason": evaluation_output.reason or "",
+                        }
+                    )
+                    
+                except Exception as e:
+                    case_span.record_exception(e)
+                    results.append(
+                        {
+                            "case": case.model_dump(),
+                            "test_pass": False,
+                            "score": 0,
+                            "reason": f"An error occurred: {str(e)}",
+                        }
+                    )
+                finally:
+                    queue.task_done()
 
     def run_evaluations(self, task: Callable[[InputT], OutputT | dict[str, Any]]) -> EvaluationReport:
         """
@@ -229,22 +271,62 @@ class Dataset(Generic[InputT, OutputT]):
         test_passes = []
         cases = []
         reasons = []
+        
         for case in self._cases:
-            try:
-                evaluation_context = self._run_task(task, case)
-                evaluation_output = self.evaluator.evaluate(evaluation_context)
-                cases.append(evaluation_context.model_dump())
-                test_passes.append(evaluation_output.test_pass)
-                scores.append(evaluation_output.score)
-                if evaluation_output.reason:
-                    reasons.append(evaluation_output.reason)
-                else:
-                    reasons.append("")
-            except Exception as e:
-                cases.append(case.model_dump())
-                test_passes.append(False)
-                scores.append(0)
-                reasons.append(f"An error occured : {str(e)}")
+            case_name = case.name or f"case_{len(cases)}"
+            
+            # Create a separate trace for each case
+            with self._tracer.start_as_current_span(
+                f"eval_case {case_name}",
+                attributes={
+                    "gen_ai.eval.case.name": case_name,
+                    "gen_ai.eval.case.input": serialize(case.input),
+                }
+            ) as case_span:
+                try:
+                    # Task execution span
+                    with self._tracer.start_as_current_span(
+                        "task_execution",
+                        attributes={
+                            "gen_ai.eval.task.type": "agent_task",
+                            "gen_ai.eval.case.name": case_name,
+                        }
+                    ) as task_span:
+                        evaluation_context = self._run_task(task, case)
+                        task_span.set_attributes({
+                            "gen_ai.eval.data.input": serialize(evaluation_context.input),
+                            "gen_ai.eval.data.expected_output": serialize(evaluation_context.expected_output),
+                            "gen_ai.eval.data.actual_output": serialize(evaluation_context.actual_output),
+                            "gen_ai.eval.data.has_trajectory": evaluation_context.actual_trajectory is not None,
+                            "gen_ai.eval.data.has_interactions": evaluation_context.actual_interactions is not None,
+                        })
+                    
+                    # Evaluator execution span
+                    with self._tracer.start_as_current_span(
+                        f"evaluator {self.evaluator.get_type_name()}",
+                        attributes={
+                            "gen_ai.eval.evaluator.type": self.evaluator.get_type_name(),
+                            "gen_ai.eval.case.name": case_name,
+                        }
+                    ) as eval_span:
+                        evaluation_output = self.evaluator.evaluate(evaluation_context)
+                        eval_span.set_attributes({
+                            "gen_ai.eval.output.score": evaluation_output.score,
+                            "gen_ai.eval.output.test_pass": evaluation_output.test_pass,
+                            "gen_ai.eval.output.reason": evaluation_output.reason or "",
+                        })
+                    
+                    cases.append(evaluation_context.model_dump())
+                    test_passes.append(evaluation_output.test_pass)
+                    scores.append(evaluation_output.score)
+                    reasons.append(evaluation_output.reason or "")
+                    
+                except Exception as e:
+                    case_span.record_exception(e)
+                    cases.append(case.model_dump())
+                    test_passes.append(False)
+                    scores.append(0)
+                    reasons.append(f"An error occured : {str(e)}")
 
         report = EvaluationReport(
             overall_score=sum(scores) / len(scores) if len(scores) else 0,

--- a/src/strands_evals/telemetry/__init__.py
+++ b/src/strands_evals/telemetry/__init__.py
@@ -1,0 +1,15 @@
+"""
+Tracing module for strands_evals.
+
+This module provides OpenTelemetry-based tracing capabilities for evaluation workflows,
+allowing detailed observability into evaluators, evaluation data, and agent execution.
+"""
+
+from .config import StrandsEvalsTelemetry
+from .tracer import get_tracer, serialize
+
+__all__ = [
+    "StrandsEvalsTelemetry",
+    "get_tracer",
+    "serialize",
+]

--- a/src/strands_evals/telemetry/config.py
+++ b/src/strands_evals/telemetry/config.py
@@ -1,0 +1,160 @@
+"""OpenTelemetry configuration and setup utilities for strands_evals.
+
+This module provides centralized configuration and initialization functionality
+for OpenTelemetry tracing in evaluation workflows.
+"""
+
+import logging
+from typing import Any
+
+import opentelemetry.trace as trace_api
+from opentelemetry import propagate
+from opentelemetry.baggage.propagation import W3CBaggagePropagator
+from opentelemetry.propagators.composite import CompositePropagator
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider as SDKTracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor, ConsoleSpanExporter, SimpleSpanProcessor
+from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
+
+logger = logging.getLogger(__name__)
+
+
+def get_otel_resource() -> Resource:
+    """Create a standard OpenTelemetry resource with service information.
+
+    Returns:
+        Resource object with standard service information.
+    """
+    resource = Resource.create(
+        {
+            "service.name": "strands-evals",
+            "service.version": "0.1.0",
+            "telemetry.sdk.name": "opentelemetry",
+            "telemetry.sdk.language": "python",
+        }
+    )
+
+    return resource
+
+
+class StrandsEvalsTelemetry:
+    """OpenTelemetry configuration and setup for strands_evals.
+
+    Automatically initializes a tracer provider with text map propagators.
+    Trace exporters (console, OTLP) can be set up individually using dedicated methods
+    that support method chaining for convenient configuration.
+
+    Args:
+        tracer_provider: Optional pre-configured SDKTracerProvider. If None,
+            a new one will be created and set as the global tracer provider.
+
+    Environment Variables:
+        Environment variables are handled by the underlying OpenTelemetry SDK:
+        - OTEL_EXPORTER_OTLP_ENDPOINT: OTLP endpoint URL
+        - OTEL_EXPORTER_OTLP_HEADERS: Headers for OTLP requests
+
+    Examples:
+        Quick setup with method chaining:
+        >>> StrandsEvalsTelemetry().setup_console_exporter().setup_otlp_exporter()
+
+        Using a custom tracer provider:
+        >>> StrandsEvalsTelemetry(tracer_provider=my_provider).setup_console_exporter()
+
+        Step-by-step configuration:
+        >>> telemetry = StrandsEvalsTelemetry()
+        >>> telemetry.setup_console_exporter()
+        >>> telemetry.setup_otlp_exporter()
+
+    Note:
+        - The tracer provider is automatically initialized upon instantiation
+        - When no tracer_provider is provided, the instance sets itself as the global provider
+        - Exporters must be explicitly configured using the setup methods
+        - Failed exporter configurations are logged but do not raise exceptions
+        - All setup methods return self to enable method chaining
+    """
+
+    def __init__(
+        self,
+        tracer_provider: SDKTracerProvider | None = None,
+    ) -> None:
+        """Initialize the StrandsEvalsTelemetry instance.
+
+        Args:
+            tracer_provider: Optional pre-configured tracer provider.
+                If None, a new one will be created and set as global.
+
+        The instance is ready to use immediately after initialization, though
+        trace exporters must be configured separately using the setup methods.
+        """
+        self.resource = get_otel_resource()
+        if tracer_provider:
+            self.tracer_provider = tracer_provider
+        else:
+            self._initialize_tracer()
+
+    def _initialize_tracer(self) -> None:
+        """Initialize the OpenTelemetry tracer."""
+        logger.info("Initializing tracer for strands-evals")
+
+        # Create tracer provider
+        self.tracer_provider = SDKTracerProvider(resource=self.resource)
+
+        # Set as global tracer provider
+        trace_api.set_tracer_provider(self.tracer_provider)
+
+        # Set up propagators
+        propagate.set_global_textmap(
+            CompositePropagator(
+                [
+                    W3CBaggagePropagator(),
+                    TraceContextTextMapPropagator(),
+                ]
+            )
+        )
+
+    def setup_console_exporter(self, **kwargs: Any) -> "StrandsEvalsTelemetry":
+        """Set up console exporter for the tracer provider.
+
+        Args:
+            **kwargs: Optional keyword arguments passed directly to
+                OpenTelemetry's ConsoleSpanExporter initializer.
+
+        Returns:
+            self: Enables method chaining.
+
+        This method configures a SimpleSpanProcessor with a ConsoleSpanExporter,
+        allowing trace data to be output to the console. Any additional keyword
+        arguments provided will be forwarded to the ConsoleSpanExporter.
+        """
+        try:
+            logger.info("Enabling console export for strands-evals")
+            console_processor = SimpleSpanProcessor(ConsoleSpanExporter(**kwargs))
+            self.tracer_provider.add_span_processor(console_processor)
+        except Exception as e:
+            logger.exception("error=<%s> | Failed to configure console exporter", e)
+        return self
+
+    def setup_otlp_exporter(self, **kwargs: Any) -> "StrandsEvalsTelemetry":
+        """Set up OTLP exporter for the tracer provider.
+
+        Args:
+            **kwargs: Optional keyword arguments passed directly to
+                OpenTelemetry's OTLPSpanExporter initializer.
+
+        Returns:
+            self: Enables method chaining.
+
+        This method configures a BatchSpanProcessor with an OTLPSpanExporter,
+        allowing trace data to be exported to an OTLP endpoint. Any additional
+        keyword arguments provided will be forwarded to the OTLPSpanExporter.
+        """
+        from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+
+        try:
+            otlp_exporter = OTLPSpanExporter(**kwargs)
+            batch_processor = BatchSpanProcessor(otlp_exporter)
+            self.tracer_provider.add_span_processor(batch_processor)
+            logger.info("OTLP exporter configured for strands-evals")
+        except Exception as e:
+            logger.exception("error=<%s> | Failed to configure OTLP exporter", e)
+        return self

--- a/src/strands_evals/telemetry/tracer.py
+++ b/src/strands_evals/telemetry/tracer.py
@@ -1,0 +1,38 @@
+"""OpenTelemetry tracing for strands_evals.
+
+This module provides a simple way to get the OpenTelemetry tracer
+for evaluation workflows.
+"""
+
+import json
+import logging
+from typing import Any
+
+from opentelemetry.sdk.trace import TracerProvider as SDKTracerProvider
+import opentelemetry.trace as trace_api
+
+logger = logging.getLogger(__name__)
+
+
+def get_tracer() -> trace_api.Tracer:
+    """Get the OpenTelemetry tracer for strands_evals.
+    
+    Returns:
+        OpenTelemetry Tracer instance from the global tracer provider
+    """
+    tracer_provider = trace_api.get_tracer_provider()
+    if not isinstance(tracer_provider, SDKTracerProvider):
+        tracer_provider = trace_api.NoOpTracerProvider()
+    return tracer_provider.get_tracer("strands-evals")
+    
+
+def serialize(obj: Any) -> str:
+    """Serialize an object to JSON string.
+
+    Args:
+        obj: The object to serialize
+
+    Returns:
+        JSON string representation
+    """
+    return json.dumps(obj, ensure_ascii=False, default=str)

--- a/tests/strands_evals/telemetry/test_config.py
+++ b/tests/strands_evals/telemetry/test_config.py
@@ -1,0 +1,217 @@
+"""Tests for strands_evals.telemetry.config module."""
+
+from unittest.mock import MagicMock, patch, call
+
+import pytest
+from opentelemetry.sdk.trace import TracerProvider as SDKTracerProvider
+from opentelemetry.sdk.resources import Resource
+
+from strands_evals.telemetry.config import get_otel_resource, StrandsEvalsTelemetry
+
+
+def test_get_otel_resource():
+    """Test get_otel_resource returns properly configured Resource"""
+    resource = get_otel_resource()
+
+    assert isinstance(resource, Resource)
+    attributes = resource.attributes
+    assert attributes["service.name"] == "strands-evals"
+    assert attributes["service.version"] == "0.1.0"
+    assert attributes["telemetry.sdk.name"] == "opentelemetry"
+    assert attributes["telemetry.sdk.language"] == "python"
+
+
+def test_strands_evals_telemetry_init_without_provider():
+    """Test StrandsEvalsTelemetry initialization without custom provider"""
+    with patch("strands_evals.telemetry.config.trace_api.set_tracer_provider") as mock_set_provider:
+        with patch("strands_evals.telemetry.config.propagate.set_global_textmap") as mock_set_propagator:
+            telemetry = StrandsEvalsTelemetry()
+
+            # Verify tracer provider was created and set
+            assert isinstance(telemetry.tracer_provider, SDKTracerProvider)
+            mock_set_provider.assert_called_once_with(telemetry.tracer_provider)
+            mock_set_propagator.assert_called_once()
+
+            # Verify resource was created
+            assert isinstance(telemetry.resource, Resource)
+
+
+def test_strands_evals_telemetry_init_with_custom_provider():
+    """Test StrandsEvalsTelemetry initialization with custom provider"""
+    custom_provider = MagicMock(spec=SDKTracerProvider)
+
+    with patch("strands_evals.telemetry.config.trace_api.set_tracer_provider") as mock_set_provider:
+        telemetry = StrandsEvalsTelemetry(tracer_provider=custom_provider)
+
+        # Verify custom provider was used
+        assert telemetry.tracer_provider == custom_provider
+        # Should not set global provider when custom one is provided
+        mock_set_provider.assert_not_called()
+
+
+def test_strands_evals_telemetry_setup_console_exporter():
+    """Test setup_console_exporter configures console exporter"""
+    with patch("strands_evals.telemetry.config.SimpleSpanProcessor") as mock_processor_class:
+        with patch("strands_evals.telemetry.config.ConsoleSpanExporter") as mock_exporter_class:
+            mock_processor = MagicMock()
+            mock_processor_class.return_value = mock_processor
+            mock_exporter = MagicMock()
+            mock_exporter_class.return_value = mock_exporter
+
+            # Mock the tracer provider
+            mock_tracer_provider = MagicMock()
+            telemetry = StrandsEvalsTelemetry(tracer_provider=mock_tracer_provider)
+            result = telemetry.setup_console_exporter()
+
+            # Verify console exporter was created
+            mock_exporter_class.assert_called_once_with()
+            mock_processor_class.assert_called_once_with(mock_exporter)
+
+            # Verify processor was added to tracer provider
+            mock_tracer_provider.add_span_processor.assert_called_once_with(mock_processor)
+
+            # Verify method chaining
+            assert result is telemetry
+
+
+def test_strands_evals_telemetry_setup_console_exporter_with_kwargs():
+    """Test setup_console_exporter passes kwargs to ConsoleSpanExporter"""
+    with patch("strands_evals.telemetry.config.SimpleSpanProcessor"):
+        with patch("strands_evals.telemetry.config.ConsoleSpanExporter") as mock_exporter_class:
+            telemetry = StrandsEvalsTelemetry()
+            telemetry.setup_console_exporter(service_name="test-service", formatter=lambda x: x)
+
+            # Verify kwargs were passed to exporter
+            mock_exporter_class.assert_called_once()
+            call_kwargs = mock_exporter_class.call_args[1]
+            assert "service_name" in call_kwargs
+            assert "formatter" in call_kwargs
+
+
+def test_strands_evals_telemetry_setup_console_exporter_handles_exception():
+    """Test setup_console_exporter handles exceptions gracefully"""
+    with patch("strands_evals.telemetry.config.ConsoleSpanExporter", side_effect=Exception("Test error")):
+        telemetry = StrandsEvalsTelemetry()
+
+        # Should not raise exception
+        result = telemetry.setup_console_exporter()
+
+        # Should still return self for chaining
+        assert result is telemetry
+
+
+def test_strands_evals_telemetry_setup_otlp_exporter():
+    """Test setup_otlp_exporter configures OTLP exporter"""
+    with patch("strands_evals.telemetry.config.BatchSpanProcessor") as mock_processor_class:
+        with patch("opentelemetry.exporter.otlp.proto.http.trace_exporter.OTLPSpanExporter") as mock_exporter_class:
+            mock_processor = MagicMock()
+            mock_processor_class.return_value = mock_processor
+            mock_exporter = MagicMock()
+            mock_exporter_class.return_value = mock_exporter
+
+            # Mock the tracer provider
+            mock_tracer_provider = MagicMock()
+            telemetry = StrandsEvalsTelemetry(tracer_provider=mock_tracer_provider)
+            result = telemetry.setup_otlp_exporter()
+
+            # Verify OTLP exporter was created
+            mock_exporter_class.assert_called_once_with()
+            mock_processor_class.assert_called_once_with(mock_exporter)
+
+            # Verify processor was added to tracer provider
+            mock_tracer_provider.add_span_processor.assert_called_once_with(mock_processor)
+
+            # Verify method chaining works
+            assert result is telemetry
+
+
+def test_strands_evals_telemetry_setup_otlp_exporter_with_kwargs():
+    """Test setup_otlp_exporter passes kwargs to OTLPSpanExporter"""
+    with patch("strands_evals.telemetry.config.BatchSpanProcessor"):
+        with patch("opentelemetry.exporter.otlp.proto.http.trace_exporter.OTLPSpanExporter") as mock_exporter_class:
+            mock_tracer_provider = MagicMock()
+            telemetry = StrandsEvalsTelemetry(tracer_provider=mock_tracer_provider)
+            telemetry.setup_otlp_exporter(endpoint="http://localhost:4318", headers={"key": "value"})
+
+            # Verify kwargs were passed to exporter
+            mock_exporter_class.assert_called_once()
+            call_kwargs = mock_exporter_class.call_args[1]
+            assert "endpoint" in call_kwargs
+            assert "headers" in call_kwargs
+
+
+def test_strands_evals_telemetry_setup_otlp_exporter_handles_exception():
+    """Test setup_otlp_exporter handles exceptions gracefully"""
+    with patch("opentelemetry.exporter.otlp.proto.http.trace_exporter.OTLPSpanExporter", side_effect=Exception("Test error")):
+        mock_tracer_provider = MagicMock()
+        telemetry = StrandsEvalsTelemetry(tracer_provider=mock_tracer_provider)
+
+        # Should not raise exception
+        result = telemetry.setup_otlp_exporter()
+
+        # Should still return self for chaining
+        assert result is telemetry
+
+
+def test_strands_evals_telemetry_method_chaining():
+    """Test method chaining works for multiple exporter setups"""
+    with patch("strands_evals.telemetry.config.SimpleSpanProcessor"):
+        with patch("strands_evals.telemetry.config.ConsoleSpanExporter"):
+            with patch("strands_evals.telemetry.config.BatchSpanProcessor"):
+                with patch("opentelemetry.exporter.otlp.proto.http.trace_exporter.OTLPSpanExporter"):
+                    mock_tracer_provider = MagicMock()
+                    telemetry = StrandsEvalsTelemetry(tracer_provider=mock_tracer_provider)
+                    result = telemetry.setup_console_exporter().setup_otlp_exporter()
+
+                    # Verify both processors were added
+                    assert mock_tracer_provider.add_span_processor.call_count == 2
+
+                    # Verify chaining returns the same instance
+                    assert result is telemetry
+
+
+def test_strands_evals_telemetry_one_liner_setup():
+    """Test one-liner setup with method chaining"""
+    with patch("strands_evals.telemetry.config.SimpleSpanProcessor") as mock_simple_processor:
+        with patch("strands_evals.telemetry.config.ConsoleSpanExporter"):
+            with patch("strands_evals.telemetry.config.BatchSpanProcessor") as mock_batch_processor:
+                with patch("opentelemetry.exporter.otlp.proto.http.trace_exporter.OTLPSpanExporter"):
+                    # Mock the tracer provider's add_span_processor method
+                    mock_tracer_provider = MagicMock()
+                    
+                    with patch("strands_evals.telemetry.config.SDKTracerProvider", return_value=mock_tracer_provider):
+                        with patch("strands_evals.telemetry.config.trace_api.set_tracer_provider"):
+                            with patch("strands_evals.telemetry.config.propagate.set_global_textmap"):
+                                # This should work as a one-liner
+                                telemetry = StrandsEvalsTelemetry().setup_console_exporter().setup_otlp_exporter()
+
+                                assert isinstance(telemetry, StrandsEvalsTelemetry)
+                                # Verify both processors were added
+                                assert mock_tracer_provider.add_span_processor.call_count == 2
+
+
+def test_strands_evals_telemetry_propagators_configured():
+    """Test that propagators are configured correctly"""
+    with patch("strands_evals.telemetry.config.propagate.set_global_textmap") as mock_set_propagator:
+        with patch("strands_evals.telemetry.config.CompositePropagator") as mock_composite:
+            with patch("strands_evals.telemetry.config.W3CBaggagePropagator") as mock_baggage:
+                with patch("strands_evals.telemetry.config.TraceContextTextMapPropagator") as mock_trace_context:
+                    mock_baggage_instance = MagicMock()
+                    mock_trace_context_instance = MagicMock()
+                    mock_baggage.return_value = mock_baggage_instance
+                    mock_trace_context.return_value = mock_trace_context_instance
+
+                    telemetry = StrandsEvalsTelemetry()
+
+                    # Verify propagators were created
+                    mock_baggage.assert_called_once()
+                    mock_trace_context.assert_called_once()
+
+                    # Verify composite propagator was created with both propagators
+                    mock_composite.assert_called_once()
+                    composite_args = mock_composite.call_args[0][0]
+                    assert mock_baggage_instance in composite_args
+                    assert mock_trace_context_instance in composite_args
+
+                    # Verify global textmap was set
+                    mock_set_propagator.assert_called_once()

--- a/tests/strands_evals/telemetry/test_tracer.py
+++ b/tests/strands_evals/telemetry/test_tracer.py
@@ -1,0 +1,130 @@
+"""Tests for strands_evals.telemetry.tracer module."""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+from opentelemetry.sdk.trace import TracerProvider as SDKTracerProvider
+from opentelemetry.trace import NoOpTracerProvider
+
+from strands_evals.telemetry.tracer import get_tracer, serialize
+
+
+def test_get_tracer_with_sdk_tracer_provider():
+    """Test get_tracer returns tracer from SDK tracer provider"""
+    mock_provider = MagicMock(spec=SDKTracerProvider)
+    mock_tracer = MagicMock()
+    mock_provider.get_tracer.return_value = mock_tracer
+
+    with patch("strands_evals.telemetry.tracer.trace_api.get_tracer_provider", return_value=mock_provider):
+        tracer = get_tracer()
+
+        mock_provider.get_tracer.assert_called_once_with("strands-evals")
+        assert tracer == mock_tracer
+
+
+def test_get_tracer_with_non_sdk_tracer_provider():
+    """Test get_tracer falls back to NoOpTracerProvider for non-SDK providers"""
+    mock_provider = MagicMock()  # Not an SDKTracerProvider
+    mock_tracer = MagicMock()
+
+    with patch("strands_evals.telemetry.tracer.trace_api.get_tracer_provider", return_value=mock_provider):
+        with patch("strands_evals.telemetry.tracer.trace_api.NoOpTracerProvider") as mock_noop_class:
+            mock_noop_instance = MagicMock(spec=NoOpTracerProvider)
+            mock_noop_instance.get_tracer.return_value = mock_tracer
+            mock_noop_class.return_value = mock_noop_instance
+
+            tracer = get_tracer()
+
+            mock_noop_class.assert_called_once()
+            mock_noop_instance.get_tracer.assert_called_once_with("strands-evals")
+            assert tracer == mock_tracer
+
+
+def test_serialize_simple_string():
+    """Test serialize with a simple string"""
+    result = serialize("hello")
+    assert result == '"hello"'
+    assert isinstance(result, str)
+
+
+def test_serialize_simple_dict():
+    """Test serialize with a simple dictionary"""
+    data = {"key": "value", "number": 42}
+    result = serialize(data)
+    assert json.loads(result) == data
+
+
+def test_serialize_nested_dict():
+    """Test serialize with nested dictionary"""
+    data = {
+        "outer": {
+            "inner": "value",
+            "list": [1, 2, 3]
+        }
+    }
+    result = serialize(data)
+    assert json.loads(result) == data
+
+
+def test_serialize_list():
+    """Test serialize with a list"""
+    data = [1, "two", {"three": 3}]
+    result = serialize(data)
+    assert json.loads(result) == data
+
+
+def test_serialize_with_unicode():
+    """Test serialize preserves unicode characters"""
+    data = {"message": "Hello 世界 🌍"}
+    result = serialize(data)
+    # ensure_ascii=False should preserve unicode
+    assert "世界" in result
+    assert "🌍" in result
+    assert json.loads(result) == data
+
+
+def test_serialize_with_non_serializable_object():
+    """Test serialize handles non-serializable objects with default=str"""
+    class CustomObject:
+        def __str__(self):
+            return "CustomObject instance"
+
+    obj = CustomObject()
+    data = {"object": obj}
+    result = serialize(data)
+    parsed = json.loads(result)
+    assert parsed["object"] == "CustomObject instance"
+
+
+def test_serialize_with_none():
+    """Test serialize handles None value"""
+    result = serialize(None)
+    assert result == "null"
+    assert json.loads(result) is None
+
+
+def test_serialize_with_boolean():
+    """Test serialize handles boolean values"""
+    assert serialize(True) == "true"
+    assert serialize(False) == "false"
+
+
+def test_serialize_with_number():
+    """Test serialize handles numeric values"""
+    assert serialize(42) == "42"
+    assert serialize(3.14) == "3.14"
+
+
+def test_serialize_empty_dict():
+    """Test serialize with empty dictionary"""
+    result = serialize({})
+    assert result == "{}"
+    assert json.loads(result) == {}
+
+
+def test_serialize_empty_list():
+    """Test serialize with empty list"""
+    result = serialize([])
+    assert result == "[]"
+    assert json.loads(result) == []

--- a/tests/strands_evals/test_dataset.py
+++ b/tests/strands_evals/test_dataset.py
@@ -1,4 +1,5 @@
 import asyncio
+from unittest.mock import MagicMock, patch
 
 import pytest
 from strands_evals import Case, Dataset
@@ -22,6 +23,23 @@ class MockEvaluator(Evaluator[str, str]):
 @pytest.fixture
 def mock_evaluator():
     return MockEvaluator()
+
+
+@pytest.fixture
+def mock_span():
+    """Fixture that creates a mock span for tracing tests"""
+    span = MagicMock()
+    span.__enter__ = MagicMock(return_value=span)
+    span.__exit__ = MagicMock(return_value=False)
+    return span
+
+
+@pytest.fixture
+def simple_task():
+    """Fixture that provides a simple echo task function"""
+    def task(input_val):
+        return input_val
+    return task
 
 
 def test_dataset__init__full(mock_evaluator):
@@ -647,3 +665,237 @@ def test_dataset_run_evaluations_with_interactions():
     assert len(report.cases) == 1
     assert report.cases[0]["actual_interactions"] == interactions
     assert report.cases[0]["expected_interactions"] == interactions
+
+
+def test_dataset_init_always_initializes_tracer():
+    """Test that Dataset always initializes tracer in __init__"""
+    with patch("strands_evals.dataset.get_tracer") as mock_get_tracer:
+        mock_tracer = MagicMock()
+        mock_get_tracer.return_value = mock_tracer
+
+        dataset = Dataset(cases=[], evaluator=MockEvaluator())
+
+        mock_get_tracer.assert_called_once()
+        assert dataset._tracer == mock_tracer
+
+
+def test_dataset_run_evaluations_creates_case_span(mock_span, simple_task):
+    """Test that run_evaluations creates a span for each case with correct attributes"""
+    case = Case(name="test_case", input="hello", expected_output="hello")
+    dataset = Dataset(cases=[case], evaluator=MockEvaluator())
+
+    with patch.object(dataset._tracer, "start_as_current_span", return_value=mock_span) as mock_start_span:
+        dataset.run_evaluations(simple_task)
+
+        # Verify case span was created
+        calls = mock_start_span.call_args_list
+        case_span_call = calls[0]
+        assert case_span_call[0][0] == "eval_case test_case"
+        assert "gen_ai.eval.case.name" in case_span_call[1]["attributes"]
+        assert case_span_call[1]["attributes"]["gen_ai.eval.case.name"] == "test_case"
+        assert "gen_ai.eval.case.input" in case_span_call[1]["attributes"]
+
+
+def test_dataset_run_evaluations_creates_task_span(mock_span, simple_task):
+    """Test that run_evaluations creates a task span with correct attributes"""
+    case = Case(name="test_case", input="hello", expected_output="hello")
+    dataset = Dataset(cases=[case], evaluator=MockEvaluator())
+
+    with patch.object(dataset._tracer, "start_as_current_span", return_value=mock_span) as mock_start_span:
+        dataset.run_evaluations(simple_task)
+
+        # Verify task span was created (second call)
+        calls = mock_start_span.call_args_list
+        assert len(calls) >= 2
+        task_span_call = calls[1]
+        assert task_span_call[0][0] == "task_execution"
+        assert "gen_ai.eval.task.type" in task_span_call[1]["attributes"]
+        assert "gen_ai.eval.case.name" in task_span_call[1]["attributes"]
+        # Verify set_attributes was called with data attributes
+        mock_span.set_attributes.assert_called()
+
+
+def test_dataset_run_evaluations_creates_evaluator_span(mock_span, simple_task):
+    """Test that run_evaluations creates an evaluator span with correct attributes"""
+    case = Case(name="test_case", input="hello", expected_output="hello")
+    dataset = Dataset(cases=[case], evaluator=MockEvaluator())
+
+    with patch.object(dataset._tracer, "start_as_current_span", return_value=mock_span) as mock_start_span:
+        dataset.run_evaluations(simple_task)
+
+        # Verify evaluator span was created (third call)
+        calls = mock_start_span.call_args_list
+        assert len(calls) >= 3
+        evaluator_span_call = calls[2]
+        assert evaluator_span_call[0][0] == "evaluator MockEvaluator"
+        assert "gen_ai.eval.evaluator.type" in evaluator_span_call[1]["attributes"]
+        assert "gen_ai.eval.case.name" in evaluator_span_call[1]["attributes"]
+        # Verify set_attributes was called with output attributes
+        mock_span.set_attributes.assert_called()
+
+
+def test_dataset_run_evaluations_with_trajectory_in_span(mock_span):
+    """Test that run_evaluations includes trajectory in task span attributes"""
+    case = Case(name="test_case", input="hello", expected_output="world")
+    dataset = Dataset(cases=[case], evaluator=MockEvaluator())
+
+    with patch.object(dataset._tracer, "start_as_current_span", return_value=mock_span) as mock_start_span:
+
+        def task_with_trajectory(input_val):
+            return {"output": input_val, "trajectory": ["step1", "step2"]}
+
+        dataset.run_evaluations(task_with_trajectory)
+
+        # Check that set_attributes was called (trajectory is set via set_attributes, not initial attributes)
+        mock_span.set_attributes.assert_called()
+        # Verify has_trajectory flag is set
+        set_attrs_calls = mock_span.set_attributes.call_args_list
+        # Find the call that includes has_trajectory
+        has_trajectory_set = any(
+            "gen_ai.eval.data.has_trajectory" in call[0][0] 
+            for call in set_attrs_calls if call[0]
+        )
+        assert has_trajectory_set
+
+
+def test_dataset_run_evaluations_with_interactions_in_span(mock_span):
+    """Test that run_evaluations includes interactions in task span attributes"""
+    interactions = [{"node_name": "agent1", "dependencies": [], "messages": ["hello"]}]
+    case = Case(name="test_case", input="hello", expected_output="world", expected_interactions=interactions)
+    dataset = Dataset(cases=[case], evaluator=MockEvaluator())
+
+    with patch.object(dataset._tracer, "start_as_current_span", return_value=mock_span) as mock_start_span:
+
+        def task_with_interactions(input_val):
+            return {"output": input_val, "interactions": interactions}
+
+        dataset.run_evaluations(task_with_interactions)
+
+        # Check that set_attributes was called (interactions are set via set_attributes)
+        mock_span.set_attributes.assert_called()
+        # Verify has_interactions flag is set
+        set_attrs_calls = mock_span.set_attributes.call_args_list
+        has_interactions_set = any(
+            "gen_ai.eval.data.has_interactions" in call[0][0] 
+            for call in set_attrs_calls if call[0]
+        )
+        assert has_interactions_set
+
+
+def test_dataset_run_evaluations_records_exception_in_span(mock_span):
+    """Test that run_evaluations records exceptions in the case span"""
+    case = Case(name="test_case", input="hello", expected_output="hello")
+    dataset = Dataset(cases=[case], evaluator=MockEvaluator())
+
+    with patch.object(dataset._tracer, "start_as_current_span", return_value=mock_span):
+
+        def failing_task(input_val):
+            raise ValueError("Test error")
+
+        dataset.run_evaluations(failing_task)
+
+        # Verify record_exception was called (set_status is not called in the implementation)
+        mock_span.record_exception.assert_called()
+
+
+def test_dataset_run_evaluations_with_unnamed_case(mock_span, simple_task):
+    """Test that run_evaluations handles unnamed cases correctly"""
+    case = Case(input="hello", expected_output="hello")  # No name
+    dataset = Dataset(cases=[case], evaluator=MockEvaluator())
+
+    with patch.object(dataset._tracer, "start_as_current_span", return_value=mock_span) as mock_start_span:
+        dataset.run_evaluations(simple_task)
+
+        # Verify case span was created with auto-generated name
+        calls = mock_start_span.call_args_list
+        case_span_call = calls[0]
+        assert case_span_call[0][0].startswith("eval_case case_")
+
+
+@pytest.mark.asyncio
+async def test_dataset_run_evaluations_async_creates_spans(mock_span):
+    """Test that run_evaluations_async creates spans with correct attributes"""
+    case = Case(name="async_test", input="hello", expected_output="hello")
+    dataset = Dataset(cases=[case], evaluator=MockEvaluator())
+
+    with patch.object(dataset._tracer, "start_as_current_span", return_value=mock_span) as mock_start_span:
+
+        async def async_task(input_val):
+            return input_val
+
+        await dataset.run_evaluations_async(async_task)
+
+        # Verify spans were created
+        calls = mock_start_span.call_args_list
+        assert len(calls) >= 3  # case, task, evaluator spans
+
+        # Check case span
+        case_span_call = calls[0]
+        assert case_span_call[0][0] == "eval_case async_test"
+        assert "gen_ai.eval.case.name" in case_span_call[1]["attributes"]
+
+
+@pytest.mark.asyncio
+async def test_dataset_run_evaluations_async_records_exception(mock_span):
+    """Test that run_evaluations_async records exceptions in spans"""
+    case = Case(name="async_test", input="hello", expected_output="hello")
+    dataset = Dataset(cases=[case], evaluator=MockEvaluator())
+
+    with patch.object(dataset._tracer, "start_as_current_span", return_value=mock_span):
+
+        async def failing_async_task(input_val):
+            raise ValueError("Async test error")
+
+        await dataset.run_evaluations_async(failing_async_task)
+
+        # Verify record_exception was called (set_status is not called in the implementation)
+        mock_span.record_exception.assert_called()
+
+
+@pytest.mark.asyncio
+async def test_dataset_run_evaluations_async_with_dict_output(mock_span):
+    """Test that run_evaluations_async handles dict output with trajectory/interactions"""
+    interactions = [{"node_name": "agent1", "dependencies": [], "messages": ["hello"]}]
+    case = Case(name="async_test", input="hello", expected_output="world", expected_interactions=interactions)
+    dataset = Dataset(cases=[case], evaluator=MockEvaluator())
+
+    with patch.object(dataset._tracer, "start_as_current_span", return_value=mock_span) as mock_start_span:
+
+        async def async_task_with_dict(input_val):
+            return {"output": input_val, "trajectory": ["step1"], "interactions": interactions}
+
+        await dataset.run_evaluations_async(async_task_with_dict)
+
+        # Check that set_attributes was called (trajectory/interactions are set via set_attributes)
+        mock_span.set_attributes.assert_called()
+        # Verify has_trajectory and has_interactions flags are set
+        set_attrs_calls = mock_span.set_attributes.call_args_list
+        has_trajectory_set = any(
+            "gen_ai.eval.data.has_trajectory" in call[0][0] 
+            for call in set_attrs_calls if call[0]
+        )
+        has_interactions_set = any(
+            "gen_ai.eval.data.has_interactions" in call[0][0] 
+            for call in set_attrs_calls if call[0]
+        )
+        assert has_trajectory_set
+        assert has_interactions_set
+
+
+def test_dataset_run_evaluations_multiple_cases_separate_traces(mock_span, simple_task):
+    """Test that each case gets its own separate trace (case span)"""
+    cases = [
+        Case(name="case1", input="hello", expected_output="hello"),
+        Case(name="case2", input="world", expected_output="world"),
+    ]
+    dataset = Dataset(cases=cases, evaluator=MockEvaluator())
+
+    with patch.object(dataset._tracer, "start_as_current_span", return_value=mock_span) as mock_start_span:
+        dataset.run_evaluations(simple_task)
+
+        # Verify we have separate case spans for each case
+        calls = mock_start_span.call_args_list
+        case_span_calls = [call for call in calls if call[0][0].startswith("eval_case")]
+        assert len(case_span_calls) == 2
+        assert case_span_calls[0][0][0] == "eval_case case1"
+        assert case_span_calls[1][0][0] == "eval_case case2"


### PR DESCRIPTION
## Description
Enable tracing for evaluations, user will be able to view the traces for each evaluation task (including evaluation input / score/ evaluator selection / output / reasoning) as a separate trace along with agent traces.

Trace setup is similar to what currently strands sdk-python has (tracer, config...).


```
from strands_evals import StrandsEvalsTelemetry

StrandsEvalsTelemetry().setup_console_exporter().setup_otlp_exporter()
```

## Related Issues

https://github.com/strands-agents/private-sdk-python-staging/issues/256

## Documentation PR

TBD

## Type of Change

New feature

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.