### PR TITLE
feat: add GoalSuccessRateEvaluator for conversation goal tracking

### DIFF
--- a/src/examples/goal_success_rate_evaluator.py
+++ b/src/examples/goal_success_rate_evaluator.py
@@ -1,0 +1,53 @@
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from strands import Agent
+from strands_tools import calculator
+
+from strands_evals import Case, Dataset
+from strands_evals.evaluators import GoalSuccessRateEvaluator
+from strands_evals.mappers import StrandsInMemorySessionMapper
+from strands_evals.telemetry import StrandsEvalsTelemetry
+
+# ======================================
+# SETUP TELEMETRY
+# ======================================
+# 1. Set up the tracer provider
+telemetry = StrandsEvalsTelemetry()
+
+# 2. Set up the in-memory exporter
+memory_exporter = InMemorySpanExporter()
+span_processor = BatchSpanProcessor(memory_exporter)
+telemetry.tracer_provider.add_span_processor(span_processor)
+
+
+# ======================================
+# SETUP AND RUN STRANDS EVAL
+# ======================================
+
+
+# 1. Define a task function
+def user_task_function(query: str) -> dict:
+    agent = Agent(tools=[calculator], callback_handler=None)
+    agent_response = agent(query)
+    finished_spans = memory_exporter.get_finished_spans()
+    mapper = StrandsInMemorySessionMapper()
+    session = mapper.map_to_session(finished_spans, session_id="test-session")
+
+    return {"output": str(agent_response), "trajectory": session}
+
+
+# 2. Create test cases
+test_cases = [
+    Case[str, str](name="math-1", input="What is 25 * 4?", metadata={"category": "math"}),
+    Case[str, str](name="math-2", input="Calculate the square root of 144", metadata={"category": "math"}),
+]
+
+# 3. Create an evaluator
+evaluator = GoalSuccessRateEvaluator()
+
+# 4. Create a dataset
+dataset = Dataset[str, str](cases=test_cases, evaluator=evaluator)
+
+# 5. Run evaluations
+report = dataset.run_evaluations(user_task_function)
+report.run_display()

--- a/src/strands_evals/evaluators/__init__.py
+++ b/src/strands_evals/evaluators/__init__.py
@@ -1,7 +1,15 @@
 from .evaluator import Evaluator
+from .goal_success_rate_evaluator import GoalSuccessRateEvaluator
 from .helpfulness_evaluator import HelpfulnessEvaluator
 from .interactions_evaluator import InteractionsEvaluator
 from .output_evaluator import OutputEvaluator
 from .trajectory_evaluator import TrajectoryEvaluator
 
-__all__ = ["Evaluator", "OutputEvaluator", "TrajectoryEvaluator", "InteractionsEvaluator", "HelpfulnessEvaluator"]
+__all__ = [
+    "Evaluator",
+    "OutputEvaluator",
+    "TrajectoryEvaluator",
+    "InteractionsEvaluator",
+    "HelpfulnessEvaluator",
+    "GoalSuccessRateEvaluator",
+]

--- a/src/strands_evals/evaluators/goal_success_rate_evaluator.py
+++ b/src/strands_evals/evaluators/goal_success_rate_evaluator.py
@@ -1,0 +1,79 @@
+from enum import Enum
+
+from pydantic import BaseModel, Field
+from strands import Agent
+from typing_extensions import TypeVar
+
+from ..types.evaluation import EvaluationData, EvaluationOutput
+from ..types.trace import ConversationLevelInput, EvaluationLevel
+from .evaluator import Evaluator
+from .prompt_templates.goal_success_rate import get_template
+
+InputT = TypeVar("InputT")
+OutputT = TypeVar("OutputT")
+
+
+class GoalSuccessScore(str, Enum):
+    """Binary goal success ratings."""
+
+    YES = "Yes"
+    NO = "No"
+
+
+class GoalSuccessRating(BaseModel):
+    """Structured output for goal success evaluation."""
+
+    reasoning: str = Field(description="Step by step reasoning to derive the final score")
+    score: GoalSuccessScore = Field(description="Score should be one of 'Yes' or 'No'")
+
+
+class GoalSuccessRateEvaluator(Evaluator[InputT, OutputT]):
+    """Evaluates whether all user goals were successfully achieved in a conversation."""
+
+    evaluation_level = EvaluationLevel.CONVERSATION_LEVEL
+
+    _score_mapping = {
+        GoalSuccessScore.YES: 1.0,
+        GoalSuccessScore.NO: 0.0,
+    }
+
+    def __init__(
+        self,
+        version: str = "v0",
+        model: str | None = None,
+        system_prompt: str | None = None,
+    ):
+        super().__init__()
+        self.system_prompt = system_prompt if system_prompt is not None else get_template(version).SYSTEM_PROMPT
+        self.version = version
+        self.model = model
+
+    def evaluate(self, evaluation_case: EvaluationData[InputT, OutputT]) -> EvaluationOutput:
+        conversation_input = self._parse_trajectory(evaluation_case)
+        prompt = self._format_prompt(conversation_input)
+        evaluator_agent = Agent(model=self.model, system_prompt=self.system_prompt, callback_handler=None)
+        rating = evaluator_agent.structured_output(GoalSuccessRating, prompt)
+        normalized_score = self._score_mapping[rating.score]
+        return EvaluationOutput(score=normalized_score, test_pass=normalized_score >= 1.0, reason=rating.reasoning)
+
+    async def evaluate_async(self, evaluation_case: EvaluationData[InputT, OutputT]) -> EvaluationOutput:
+        conversation_input = self._parse_trajectory(evaluation_case)
+        prompt = self._format_prompt(conversation_input)
+        evaluator_agent = Agent(model=self.model, system_prompt=self.system_prompt, callback_handler=None)
+        rating = await evaluator_agent.structured_output_async(GoalSuccessRating, prompt)
+        normalized_score = self._score_mapping[rating.score]
+        return EvaluationOutput(score=normalized_score, test_pass=normalized_score >= 1.0, reason=rating.reasoning)
+
+    def _format_prompt(self, conversation_input: ConversationLevelInput) -> str:
+        """Format evaluation prompt from conversation-level input."""
+        parts = []
+
+        if conversation_input.available_tools:
+            parts.append(f"# Available tools\n{self._format_tools(conversation_input.available_tools)}")
+
+        if conversation_input.conversation_history:
+            parts.append(
+                f"# Conversation record\n{self._format_conversation_history(conversation_input.conversation_history)}"
+            )
+
+        return "\n\n".join(parts)

--- a/src/strands_evals/evaluators/prompt_templates/goal_success_rate/__init__.py
+++ b/src/strands_evals/evaluators/prompt_templates/goal_success_rate/__init__.py
@@ -1,0 +1,11 @@
+from . import goal_success_rate_v0
+
+VERSIONS = {
+    "v0": goal_success_rate_v0,
+}
+
+DEFAULT_VERSION = "v0"
+
+
+def get_template(version: str = DEFAULT_VERSION):
+    return VERSIONS[version]

--- a/src/strands_evals/evaluators/prompt_templates/goal_success_rate/goal_success_rate_v0.py
+++ b/src/strands_evals/evaluators/prompt_templates/goal_success_rate/goal_success_rate_v0.py
@@ -1,0 +1,17 @@
+SYSTEM_PROMPT = """You are an objective judge evaluating the quality of an AI assistant as to whether a conversation between a User and the AI assistant successfully completed all User goals. You will be provided with:
+1. The list of available tools the AI assistant can use. There are descriptions for each tool about when to use it and how to use it.
+2. The complete conversation record with multiple turns including:
+    - User messages (User:)
+    - Assistant responses (Assistant:)
+    - Tool selected by the assistant (Action:)
+    - Tool outputs (Tool:)
+3. The final assistant response that concludes the conversation.
+    
+Your task is to carefully analyze the conversation and determine if all User goals were successfully achieved. In order to achieve a User goal, the AI assistant usually need to use some tools and respond to User about the outcome. Please assess the goals one by one, following the steps below:
+1. First, analyze the list of available tools, reason about what tools the AI assistant should use, and what response it should provide to the User in order to achieve the goal;
+2. Next, check the conversation record and the final assistant response to decide whether the AI assistant used the expected tools and got the expected output, got the expected information, and responded to the User in the expected way. If the AI assistant did all expected work in the conversation record and provided an appropriate final response, the goal was achieved.
+3. After judging about all the goals, decide whether the conversation achieved all user goals or not.
+
+# Evaluation Rubric
+- Yes: All user goals were achieved. The agent successfully completed all requested tasks, provided accurate information, and the user received satisfactory outcomes.
+- No: Not all user goals were achieved. The agent failed to complete one or more requested tasks, provided incomplete/incorrect information, or the user's needs were not fully met."""

--- a/tests/strands_evals/evaluators/test_evaluator_parsing.py
+++ b/tests/strands_evals/evaluators/test_evaluator_parsing.py
@@ -134,11 +134,17 @@ def test_parse_trajectory_raises_on_invalid_type():
         evaluator._parse_trajectory(evaluation_data)
 
 
-def test_parse_trajectory_raises_on_unsupported_level(session_with_conversation):
+def test_parse_trajectory_conversation_level(session_with_conversation):
     evaluator = Evaluator()
     evaluator.evaluation_level = EvaluationLevel.CONVERSATION_LEVEL
 
     evaluation_data = EvaluationData(input="test", actual_output="output", actual_trajectory=session_with_conversation)
 
-    with pytest.raises(ValueError, match="Unsupported evaluation level"):
-        evaluator._parse_trajectory(evaluation_data)
+    result = evaluator._parse_trajectory(evaluation_data)
+
+    assert result.conversation_history is not None
+    assert len(result.conversation_history) == 2
+    assert result.conversation_history[0].user_prompt.text == "What is 2+2?"
+    assert result.conversation_history[0].agent_response.text == "4"
+    assert result.conversation_history[1].user_prompt.text == "What is 3+3?"
+    assert result.conversation_history[1].agent_response.text == "6"

--- a/tests/strands_evals/evaluators/test_goal_success_rate_evaluator.py
+++ b/tests/strands_evals/evaluators/test_goal_success_rate_evaluator.py
@@ -1,0 +1,119 @@
+from datetime import datetime
+from unittest.mock import Mock, patch
+
+import pytest
+
+from strands_evals.evaluators import GoalSuccessRateEvaluator
+from strands_evals.evaluators.goal_success_rate_evaluator import GoalSuccessRating, GoalSuccessScore
+from strands_evals.types import EvaluationData
+from strands_evals.types.trace import (
+    AgentInvocationSpan,
+    EvaluationLevel,
+    Session,
+    SpanInfo,
+    ToolCall,
+    ToolConfig,
+    ToolExecutionSpan,
+    ToolResult,
+    Trace,
+)
+
+
+@pytest.fixture
+def evaluation_data():
+    now = datetime.now()
+    span_info = SpanInfo(session_id="test-session", start_time=now, end_time=now)
+
+    tool_config = ToolConfig(name="calculator", description="Evaluate mathematical expressions")
+
+    agent_span = AgentInvocationSpan(
+        span_info=span_info,
+        user_prompt="What is 2 + 2?",
+        agent_response="The answer is 4.",
+        available_tools=[tool_config],
+    )
+
+    tool_span = ToolExecutionSpan(
+        span_info=span_info,
+        tool_call=ToolCall(name="calculator", arguments={"expression": "2+2"}, tool_call_id="1"),
+        tool_result=ToolResult(content="4", tool_call_id="1"),
+    )
+
+    trace = Trace(spans=[agent_span, tool_span], trace_id="trace1", session_id="test-session")
+    session = Session(traces=[trace], session_id="test-session")
+
+    return EvaluationData(
+        input="What is 2 + 2?", actual_output="The answer is 4.", actual_trajectory=session, name="test"
+    )
+
+
+def test_init_with_defaults():
+    evaluator = GoalSuccessRateEvaluator()
+
+    assert evaluator.version == "v0"
+    assert evaluator.model is None
+    assert evaluator.system_prompt is not None
+    assert evaluator.evaluation_level == EvaluationLevel.CONVERSATION_LEVEL
+
+
+def test_init_with_custom_values():
+    evaluator = GoalSuccessRateEvaluator(version="v1", model="gpt-4", system_prompt="Custom")
+
+    assert evaluator.version == "v1"
+    assert evaluator.model == "gpt-4"
+    assert evaluator.system_prompt == "Custom"
+
+
+@patch("strands_evals.evaluators.goal_success_rate_evaluator.Agent")
+def test_evaluate(mock_agent_class, evaluation_data):
+    mock_agent = Mock()
+    mock_agent.structured_output.return_value = GoalSuccessRating(
+        reasoning="All goals achieved", score=GoalSuccessScore.YES
+    )
+    mock_agent_class.return_value = mock_agent
+    evaluator = GoalSuccessRateEvaluator()
+
+    result = evaluator.evaluate(evaluation_data)
+
+    assert result.score == 1.0
+    assert result.test_pass is True
+    assert result.reason == "All goals achieved"
+
+
+@pytest.mark.parametrize(
+    "score,expected_value,expected_pass",
+    [
+        (GoalSuccessScore.YES, 1.0, True),
+        (GoalSuccessScore.NO, 0.0, False),
+    ],
+)
+@patch("strands_evals.evaluators.goal_success_rate_evaluator.Agent")
+def test_score_mapping(mock_agent_class, evaluation_data, score, expected_value, expected_pass):
+    mock_agent = Mock()
+    mock_agent.structured_output.return_value = GoalSuccessRating(reasoning="Test", score=score)
+    mock_agent_class.return_value = mock_agent
+    evaluator = GoalSuccessRateEvaluator()
+
+    result = evaluator.evaluate(evaluation_data)
+
+    assert result.score == expected_value
+    assert result.test_pass == expected_pass
+
+
+@pytest.mark.asyncio
+@patch("strands_evals.evaluators.goal_success_rate_evaluator.Agent")
+async def test_evaluate_async(mock_agent_class, evaluation_data):
+    mock_agent = Mock()
+
+    async def mock_structured_output_async(*args, **kwargs):
+        return GoalSuccessRating(reasoning="All goals achieved", score=GoalSuccessScore.YES)
+
+    mock_agent.structured_output_async = mock_structured_output_async
+    mock_agent_class.return_value = mock_agent
+    evaluator = GoalSuccessRateEvaluator()
+
+    result = await evaluator.evaluate_async(evaluation_data)
+
+    assert result.score == 1.0
+    assert result.test_pass is True
+    assert result.reason == "All goals achieved"


### PR DESCRIPTION


## Description
Add conversation-level evaluator that assesses whether all user goals
were successfully achieved using binary Yes/No scoring with structured
reasoning output.

## Related Issues


1. Related to #16 .

## Documentation PR

N/A

## Type of Change

New feature


## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.