### PR TITLE
[RFC] feat: change Evaluator.evaluate() to return list[EvaluationOutput]

### DIFF
--- a/src/examples/multi_metric_evaluator.py
+++ b/src/examples/multi_metric_evaluator.py
@@ -1,0 +1,107 @@
+"""
+Simple example demonstrating multi-metric evaluation.
+
+This toy evaluator checks multiple aspects of a response:
+1. Length check (is response long enough?)
+2. Keyword check (does it contain expected keywords?)
+3. Sentiment check (is it positive?)
+
+Each check produces its own metric, and they're aggregated into a final score.
+"""
+
+from strands_evals import Case, Dataset
+from strands_evals.evaluators import Evaluator
+from strands_evals.types import EvaluationData, EvaluationOutput
+
+
+class MultiAspectEvaluator(Evaluator[str, str]):
+    """Evaluates multiple aspects of a text response."""
+
+    def __init__(self, min_length: int = 10, required_keywords: list[str] | None = None):
+        super().__init__()
+        self.min_length = min_length
+        self.required_keywords = required_keywords or []
+
+    def evaluate(self, evaluation_case: EvaluationData[str, str]) -> list[EvaluationOutput]:
+        """Returns one EvaluationOutput per aspect checked."""
+        actual = evaluation_case.actual_output or ""
+        results = []
+
+        # Metric 1: Length check
+        length_ok = len(actual) >= self.min_length
+        results.append(
+            EvaluationOutput(
+                score=1.0 if length_ok else 0.0,
+                test_pass=length_ok,
+                reason=f"Length: {len(actual)} chars ({'✓' if length_ok else '✗'} min {self.min_length})",
+            )
+        )
+
+        # Metric 2: Keyword check
+        keywords_found = [kw for kw in self.required_keywords if kw.lower() in actual.lower()]
+        keyword_score = len(keywords_found) / len(self.required_keywords) if self.required_keywords else 1.0
+        results.append(
+            EvaluationOutput(
+                score=keyword_score,
+                test_pass=keyword_score >= 0.5,
+                reason=f"Keywords: {len(keywords_found)}/{len(self.required_keywords)} found {keywords_found}",
+            )
+        )
+
+        # Metric 3: Sentiment check (simple heuristic)
+        positive_words = ["good", "great", "excellent", "happy", "wonderful"]
+        has_positive = any(word in actual.lower() for word in positive_words)
+        results.append(
+            EvaluationOutput(
+                score=1.0 if has_positive else 0.5,
+                test_pass=True,  # Always pass, just informational
+                reason=f"Sentiment: {'Positive' if has_positive else 'Neutral'}",
+            )
+        )
+
+        return results
+
+    async def evaluate_async(self, evaluation_case: EvaluationData[str, str]) -> list[EvaluationOutput]:
+        # For this simple example, just call sync version
+        return self.evaluate(evaluation_case)
+
+
+# Task function: simple echo with modifications
+def simple_task(query: str) -> str:
+    return f"This is a great response to: {query}. It provides excellent information!"
+
+
+if __name__ == "__main__":
+    # Create test cases
+    test_cases = [
+        Case[str, str](
+            name="short-response",
+            input="Hi",
+            expected_output="Short reply",
+        ),
+        Case[str, str](
+            name="long-response",
+            input="Tell me about Python",
+            expected_output="Python is great",
+        ),
+    ]
+
+    # Create evaluator that checks: length >= 20, contains ["response", "information"]
+    evaluator = MultiAspectEvaluator(min_length=20, required_keywords=["response", "information"])
+
+    # Create dataset and run
+    dataset = Dataset[str, str](cases=test_cases, evaluator=evaluator)
+    report = dataset.run_evaluations(simple_task)
+
+    # Show results
+    print("\n=== Programmatic Access to Detailed Results ===")
+    for i, detailed in enumerate(report.detailed_results):
+        print(f"\nCase {i}: {report.cases[i]['name']}")
+        print(f"  Aggregate Score: {report.scores[i]:.2f}")
+        print(f"  Individual Metrics ({len(detailed)}):")
+        for j, metric in enumerate(detailed):
+            print(f"    {j + 1}. Score={metric.score:.2f}, Pass={metric.test_pass}, Reason={metric.reason}")
+
+    # Interactive display
+    print("\n=== Interactive Display ===")
+    report.run_display()

--- a/src/strands_evals/display/display_console.py
+++ b/src/strands_evals/display/display_console.py
@@ -2,6 +2,7 @@ from rich.console import Console
 from rich.panel import Panel
 from rich.prompt import Prompt
 from rich.table import Table
+from rich.tree import Tree
 
 console = Console()
 
@@ -28,7 +29,8 @@ class CollapsibleTableReportDisplay:
                 "test_pass: bool,
                 "reason": str,
                 ... # will display everything that's given like actual_output etc.
-                }
+                },
+                "detailed_results": list[EvaluationOutput],
             },
             "expanded": bool
         }
@@ -93,7 +95,21 @@ class CollapsibleTableReportDisplay:
                     pass_status,
                 ] + len(other_fields) * ["..."]
             table.add_row(*renderables)
+
         console.print(table)
+
+        for key, item in self.items.items():
+            if item["expanded"] and item.get("detailed_results"):
+                detailed_results = item["detailed_results"]
+                if len(detailed_results) > 1:  # Only show if multiple metrics
+                    tree = Tree(f"[bold cyan]📋 Detailed Metrics for Case {key}[/bold cyan]")
+                    for i, result in enumerate(detailed_results):
+                        status = "✅" if result.test_pass else "❌"
+                        metric_node = tree.add(f"[yellow]Metric {i + 1}[/yellow]: Score={result.score:.2f} {status}")
+                        if result.reason:
+                            metric_node.add(f"[dim]{result.reason}[/dim]")
+                    console.print(tree)
+                    console.print()
 
     def run(self, static: bool = False):
         """

--- a/src/strands_evals/evaluators/helpfulness_evaluator.py
+++ b/src/strands_evals/evaluators/helpfulness_evaluator.py
@@ -60,21 +60,23 @@ class HelpfulnessEvaluator(Evaluator[InputT, OutputT]):
         self.model = model
         self.include_inputs = include_inputs
 
-    def evaluate(self, evaluation_case: EvaluationData[InputT, OutputT]) -> EvaluationOutput:
+    def evaluate(self, evaluation_case: EvaluationData[InputT, OutputT]) -> list[EvaluationOutput]:
         parsed_input = self._get_last_turn(evaluation_case)
         prompt = self._format_prompt(parsed_input)
         evaluator_agent = Agent(model=self.model, system_prompt=self.system_prompt, callback_handler=None)
         rating = evaluator_agent.structured_output(HelpfulnessRating, prompt)
         normalized_score = self._score_mapping[rating.score]
-        return EvaluationOutput(score=normalized_score, test_pass=normalized_score >= 0.5, reason=rating.reasoning)
+        result = EvaluationOutput(score=normalized_score, test_pass=normalized_score >= 0.5, reason=rating.reasoning)
+        return [result]
 
-    async def evaluate_async(self, evaluation_case: EvaluationData[InputT, OutputT]) -> EvaluationOutput:
+    async def evaluate_async(self, evaluation_case: EvaluationData[InputT, OutputT]) -> list[EvaluationOutput]:
         parsed_input = self._get_last_turn(evaluation_case)
         prompt = self._format_prompt(parsed_input)
         evaluator_agent = Agent(model=self.model, system_prompt=self.system_prompt, callback_handler=None)
         rating = await evaluator_agent.structured_output_async(HelpfulnessRating, prompt)
         normalized_score = self._score_mapping[rating.score]
-        return EvaluationOutput(score=normalized_score, test_pass=normalized_score >= 0.5, reason=rating.reasoning)
+        result = EvaluationOutput(score=normalized_score, test_pass=normalized_score >= 0.5, reason=rating.reasoning)
+        return [result]
 
     def _get_last_turn(self, evaluation_case: EvaluationData[InputT, OutputT]) -> TurnLevelInput:
         """Extract the most recent turn from the conversation for evaluation."""

--- a/src/strands_evals/evaluators/output_evaluator.py
+++ b/src/strands_evals/evaluators/output_evaluator.py
@@ -32,7 +32,7 @@ class OutputEvaluator(Evaluator[InputT, OutputT]):
         self.include_inputs = include_inputs
         self.system_prompt = system_prompt
 
-    def evaluate(self, evaluation_case: EvaluationData[InputT, OutputT]) -> EvaluationOutput:
+    def evaluate(self, evaluation_case: EvaluationData[InputT, OutputT]) -> list[EvaluationOutput]:
         """
         Evaluate the performance of the task on the given test cases.
 
@@ -47,9 +47,9 @@ class OutputEvaluator(Evaluator[InputT, OutputT]):
             evaluation_case=evaluation_case, rubric=self.rubric, include_inputs=self.include_inputs
         )
         result = evaluator_agent.structured_output(EvaluationOutput, evaluation_prompt)
-        return result
+        return [result]
 
-    async def evaluate_async(self, evaluation_case: EvaluationData[InputT, OutputT]) -> EvaluationOutput:
+    async def evaluate_async(self, evaluation_case: EvaluationData[InputT, OutputT]) -> list[EvaluationOutput]:
         """
         Evaluate the performance of the task on the given test cases asynchronously.
 
@@ -64,4 +64,4 @@ class OutputEvaluator(Evaluator[InputT, OutputT]):
             evaluation_case=evaluation_case, rubric=self.rubric, include_inputs=self.include_inputs
         )
         result = await evaluator_agent.structured_output_async(EvaluationOutput, evaluation_prompt)
-        return result
+        return [result]

--- a/src/strands_evals/evaluators/trajectory_evaluator.py
+++ b/src/strands_evals/evaluators/trajectory_evaluator.py
@@ -54,7 +54,7 @@ class TrajectoryEvaluator(Evaluator[InputT, OutputT]):
         """
         self.trajectory_description = new_description
 
-    def evaluate(self, evaluation_case: EvaluationData[InputT, OutputT]) -> EvaluationOutput:
+    def evaluate(self, evaluation_case: EvaluationData[InputT, OutputT]) -> list[EvaluationOutput]:
         """
         Evaluate the performance of the task on the given test cases.
 
@@ -74,9 +74,9 @@ class TrajectoryEvaluator(Evaluator[InputT, OutputT]):
             uses_trajectory=True,
         )
         result = evaluator_agent.structured_output(EvaluationOutput, evaluation_prompt)
-        return result
+        return [result]
 
-    async def evaluate_async(self, evaluation_case: EvaluationData[InputT, OutputT]) -> EvaluationOutput:
+    async def evaluate_async(self, evaluation_case: EvaluationData[InputT, OutputT]) -> list[EvaluationOutput]:
         """
         Evaluate the performance of the task on the given test cases asynchronously.
 
@@ -96,4 +96,4 @@ class TrajectoryEvaluator(Evaluator[InputT, OutputT]):
             uses_trajectory=True,
         )
         result = await evaluator_agent.structured_output_async(EvaluationOutput, evaluation_prompt)
-        return result
+        return [result]

--- a/src/strands_evals/types/evaluation_report.py
+++ b/src/strands_evals/types/evaluation_report.py
@@ -5,6 +5,7 @@ from pydantic import BaseModel
 from typing_extensions import TypeVar
 
 from ..display.display_console import CollapsibleTableReportDisplay
+from ..types.evaluation import EvaluationOutput
 
 InputT = TypeVar("InputT")
 OutputT = TypeVar("OutputT")
@@ -27,6 +28,7 @@ class EvaluationReport(BaseModel):
     cases: list[dict]
     test_passes: list[bool]
     reasons: list[str] = []
+    detailed_results: list[list[EvaluationOutput]] = []
 
     def _display(
         self,
@@ -85,7 +87,11 @@ class EvaluationReport(BaseModel):
             if include_meta:
                 details_dict["metadata"] = str(self.cases[i].get("metadata"))
 
-            report_data[str(i)] = {"details": details_dict, "expanded": False}
+            report_data[str(i)] = {
+                "details": details_dict,
+                "detailed_results": self.detailed_results[i] if i < len(self.detailed_results) else [],  # NEW
+                "expanded": False,
+            }
 
         display_console = CollapsibleTableReportDisplay(items=report_data, overall_score=self.overall_score)
         display_console.run(static=static)

--- a/tests/strands_evals/evaluators/test_helpfulness_evaluator.py
+++ b/tests/strands_evals/evaluators/test_helpfulness_evaluator.py
@@ -60,9 +60,10 @@ def test_evaluate(mock_agent_class, evaluation_data):
 
     result = evaluator.evaluate(evaluation_data)
 
-    assert result.score == 0.833
-    assert result.test_pass is True
-    assert result.reason == "The response is helpful"
+    assert len(result) == 1
+    assert result[0].score == 0.833
+    assert result[0].test_pass is True
+    assert result[0].reason == "The response is helpful"
 
 
 @pytest.mark.parametrize(
@@ -86,8 +87,9 @@ def test_score_mapping(mock_agent_class, evaluation_data, score, expected_value,
 
     result = evaluator.evaluate(evaluation_data)
 
-    assert result.score == expected_value
-    assert result.test_pass == expected_pass
+    assert len(result) == 1
+    assert result[0].score == expected_value
+    assert result[0].test_pass == expected_pass
 
 
 @pytest.mark.asyncio
@@ -104,6 +106,7 @@ async def test_evaluate_async(mock_agent_class, evaluation_data):
 
     result = await evaluator.evaluate_async(evaluation_data)
 
-    assert result.score == 0.833
-    assert result.test_pass is True
-    assert result.reason == "The response is helpful"
+    assert len(result) == 1
+    assert result[0].score == 0.833
+    assert result[0].test_pass is True
+    assert result[0].reason == "The response is helpful"

--- a/tests/strands_evals/evaluators/test_interactions_evaluator.py
+++ b/tests/strands_evals/evaluators/test_interactions_evaluator.py
@@ -120,8 +120,8 @@ def test_interactions_evaluator_evaluate_with_full_data(mock_agent_class, evalua
     # Verify structured_output was called twice (for each interaction)
     assert mock_agent.structured_output.call_count == 2
 
-    assert result.score == 0.85
-    assert result.test_pass is True
+    assert result[0].score == 0.85
+    assert result[0].test_pass is True
 
 
 @patch("strands_evals.evaluators.interactions_evaluator.Agent")
@@ -134,8 +134,8 @@ def test_interactions_evaluator_evaluate_without_inputs(mock_agent_class, evalua
 
     # Check that structured_output was called
     assert mock_agent.structured_output.call_count == 2
-    assert result.score == 0.85
-    assert result.test_pass is True
+    assert result[0].score == 0.85
+    assert result[0].test_pass is True
 
     call_args = mock_agent.structured_output.call_args
     prompt = call_args[0][1]
@@ -212,8 +212,8 @@ def test_interactions_evaluator_evaluate_with_dict_rubric(mock_agent_class, mock
     assert "Evaluate planning quality and task breakdown" in first_prompt
     assert "Assess research thoroughness and accuracy" in second_prompt
 
-    assert result.score == 0.85
-    assert result.test_pass is True
+    assert result[0].score == 0.85
+    assert result[0].test_pass is True
 
 
 @patch("strands_evals.evaluators.interactions_evaluator.Agent")
@@ -249,8 +249,8 @@ async def test_interactions_evaluator_evaluate_async_with_dict_rubric(mock_agent
 
     result = await evaluator.evaluate_async(evaluation_data)
 
-    assert result.score == 0.85
-    assert result.test_pass is True
+    assert result[0].score == 0.85
+    assert result[0].test_pass is True
 
 
 def test_interactions_evaluator_compose_prompt_first_interaction():

--- a/tests/strands_evals/evaluators/test_output_evaluator.py
+++ b/tests/strands_evals/evaluators/test_output_evaluator.py
@@ -78,8 +78,9 @@ def test_output_evaluator_evaluate_with_inputs(mock_agent_class, evaluation_data
     assert "<ExpectedOutput>4</ExpectedOutput>" in prompt
     assert "<Rubric>Test rubric</Rubric>" in prompt
 
-    assert result.score == 0.8
-    assert result.test_pass is True
+    assert len(result) == 1
+    assert result[0].score == 0.8
+    assert result[0].test_pass is True
 
 
 @patch("strands_evals.evaluators.output_evaluator.Agent")
@@ -99,8 +100,9 @@ def test_output_evaluator_evaluate_without_inputs(mock_agent_class, evaluation_d
     assert "<ExpectedOutput>4</ExpectedOutput>" in prompt
     assert "<Rubric>Test rubric</Rubric>" in prompt
 
-    assert result.score == 0.8
-    assert result.test_pass is True
+    assert len(result) == 1
+    assert result[0].score == 0.8
+    assert result[0].test_pass is True
 
 
 @patch("strands_evals.evaluators.output_evaluator.Agent")
@@ -142,9 +144,10 @@ async def test_output_evaluator_evaluate_async_with_inputs(mock_agent_class, eva
     # Verify Agent was created with correct parameters
     mock_agent_class.assert_called_once_with(model=None, system_prompt=evaluator.system_prompt, callback_handler=None)
 
-    assert result.score == 0.8
-    assert result.test_pass is True
-    assert result.reason == "Mock async evaluation result"
+    assert len(result) == 1
+    assert result[0].score == 0.8
+    assert result[0].test_pass is True
+    assert result[0].reason == "Mock async evaluation result"
 
 
 @pytest.mark.asyncio
@@ -156,8 +159,9 @@ async def test_output_evaluator_evaluate_async_without_inputs(mock_agent_class, 
 
     result = await evaluator.evaluate_async(evaluation_data)
 
-    assert result.score == 0.8
-    assert result.test_pass is True
+    assert len(result) == 1
+    assert result[0].score == 0.8
+    assert result[0].test_pass is True
 
 
 @pytest.mark.asyncio

--- a/tests/strands_evals/evaluators/test_trajectory_evaluator.py
+++ b/tests/strands_evals/evaluators/test_trajectory_evaluator.py
@@ -92,8 +92,8 @@ def test_trajectory_evaluator_evaluate_with_full_data(mock_agent_class, evaluati
     assert "<Trajectory>['calculator']</Trajectory>" in prompt
     assert "<ExpectedTrajectory>['calculator']</ExpectedTrajectory>" in prompt
     assert "<Rubric>Test rubric</Rubric>" in prompt
-    assert result.score == 0.9
-    assert result.test_pass is True
+    assert result[0].score == 0.9
+    assert result[0].test_pass is True
 
 
 @patch("strands_evals.evaluators.trajectory_evaluator.Agent")
@@ -112,8 +112,8 @@ def test_trajectory_evaluator_evaluate_without_inputs(mock_agent_class, evaluati
     assert "<Trajectory>['calculator']</Trajectory>" in prompt
     assert "<ExpectedTrajectory>['calculator']</ExpectedTrajectory>" in prompt
     assert "<Rubric>Test rubric</Rubric>" in prompt
-    assert result.score == 0.9
-    assert result.test_pass is True
+    assert result[0].score == 0.9
+    assert result[0].test_pass is True
 
 
 @patch("strands_evals.evaluators.trajectory_evaluator.Agent")
@@ -200,9 +200,10 @@ async def test_trajectory_evaluator_evaluate_async_with_full_data(mock_agent_cla
         model=None, system_prompt=evaluator.system_prompt, tools=evaluator._tools, callback_handler=None
     )
 
-    assert result.score == 0.9
-    assert result.test_pass is True
-    assert result.reason == "Mock async trajectory evaluation"
+    assert len(result) == 1
+    assert result[0].score == 0.9
+    assert result[0].test_pass is True
+    assert result[0].reason == "Mock async trajectory evaluation"
 
 
 @pytest.mark.asyncio
@@ -219,9 +220,10 @@ async def test_trajectory_evaluator_evaluate_async_without_inputs(mock_agent_cla
         model=None, system_prompt=evaluator.system_prompt, tools=evaluator._tools, callback_handler=None
     )
 
-    assert result.score == 0.9
-    assert result.test_pass is True
-    assert result.reason == "Mock async trajectory evaluation"
+    assert len(result) == 1
+    assert result[0].score == 0.9
+    assert result[0].test_pass is True
+    assert result[0].reason == "Mock async trajectory evaluation"
 
 
 @pytest.mark.asyncio

--- a/tests/strands_evals/test_dataset.py
+++ b/tests/strands_evals/test_dataset.py
@@ -12,13 +12,13 @@ class MockEvaluator(Evaluator[str, str]):
     def evaluate(self, evaluation_case: EvaluationData[str, str]) -> EvaluationOutput:
         # Simple mock: pass if actual equals expected
         score = 1.0 if evaluation_case.actual_output == evaluation_case.expected_output else 0.0
-        return EvaluationOutput(score=score, test_pass=score > 0.5, reason="Mock evaluation")
+        return [EvaluationOutput(score=score, test_pass=score > 0.5, reason="Mock evaluation")]
 
     async def evaluate_async(self, evaluation_case: EvaluationData[str, str]) -> EvaluationOutput:
         # Add a small delay to simulate async processing
         await asyncio.sleep(0.01)
         score = 1.0 if evaluation_case.actual_output == evaluation_case.expected_output else 0.0
-        return EvaluationOutput(score=score, test_pass=score > 0.5, reason="Async test evaluation")
+        return [EvaluationOutput(score=score, test_pass=score > 0.5, reason="Async test evaluation")]
 
 
 @pytest.fixture

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -13,14 +13,14 @@ class SimpleEvaluator(Evaluator[str, str]):
 
     def evaluate(self, evaluation_case: EvaluationData[str, str]) -> EvaluationOutput:
         score = 1.0 if evaluation_case.actual_output == evaluation_case.expected_output else 0.0
-        return EvaluationOutput(score=score, test_pass=score > 0.5, reason="Integration test")
+        return [EvaluationOutput(score=score, test_pass=score > 0.5, reason="Integration test")]
 
     async def evaluate_async(self, evaluation_case: EvaluationData[str, str]) -> EvaluationOutput:
         """Async version of evaluate"""
         # Add a small delay to simulate async processing
         await asyncio.sleep(0.01)
         score = 1.0 if evaluation_case.actual_output == evaluation_case.expected_output else 0.0
-        return EvaluationOutput(score=score, test_pass=score > 0.5, reason="Async integration test")
+        return [EvaluationOutput(score=score, test_pass=score > 0.5, reason="Async integration test")]
 
 
 @pytest.fixture


### PR DESCRIPTION
## Description
BREAKING CHANGE: `Evaluator.evaluate()` and `evaluate_async()` now returns `list[EvaluationOutput]` instead of single `EvaluationOutput` to support multi-metric evaluation scenarios.



- Add aggregator property to `Evaluator` base class with default mean aggregation
- Update all evaluator implementations to return lists
- `InteractionsEvaluator` now returns all intermediate evaluations instead of only the last
- Add `detailed_results` field to `EvaluationReport` for drill-down into individual metrics
- Dataset aggregates multiple outputs per case using evaluator's aggregator function
- Update display to show detailed metrics tree when cases are expanded. An example of this is shown below (note: this is generated from the example "multi_metric_evaluator" file. This is a basic toy example to help illustrate the changes; we can consider removing this from this PR or as a future standalone PR to minimize cruft)

```
┏━━━━━━━┳━━━━━━━━━━━━━━━━┳━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━┓
┃ index ┃ name           ┃ score ┃ test_pass ┃ reason                                                                                              ┃ input ┃
┡━━━━━━━╇━━━━━━━━━━━━━━━━╇━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━┩
│ ▼ 0   │ short-response │ 1.00  │ ✅        │ Length: 67 chars (✓ min 20) | Keywords: 2/2 found ['response', 'information'] | Sentiment: Positive │ Hi    │
├───────┼────────────────┼───────┼───────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────┼───────┤
│ ▶ 1   │ long-response  │ 1.00  │ ✅        │ ...                                                                                                 │ ...   │
└───────┴────────────────┴───────┴───────────┴─────────────────────────────────────────────────────────────────────────────────────────────────────┴───────┘
📋 Detailed Metrics for Case 0
├── Metric 1: Score=1.00 ✅
│   └── Length: 67 chars (✓ min 20)
├── Metric 2: Score=1.00 ✅
│   └── Keywords: 2/2 found ['response', 'information']
└── Metric 3: Score=1.00 ✅
    └── Sentiment: Positive

```




### Motivation

The current evaluator interface assumes a 1:1 relationship between test cases and evaluation metrics. However, many real-world evaluation scenarios produce multiple metrics per test case. For example, evaluating tool parameter accuracy across a multi-turn conversation should produce one metric per turn, not a single aggregate score. Similarly, the InteractionsEvaluator was already evaluating each interaction individually but discarding all intermediate results except the last one.

This change makes the evaluator interface more expressive by returning a list of metrics. While this is a breaking change to the return type, the evaluation logic itself remains unchanged—existing evaluators simply wrap their single output in a list. The Dataset layer handles aggregation transparently, so the EvaluationReport structure (one score per case) stays intact.

Each evaluator now has a configurable `aggregator` function that determines how multiple metrics combine into a case-level score. The default aggregator computes the mean of scores, requires all metrics to pass for the case to pass, and concatenates reasons with " | " separators. Evaluators can override this with custom aggregation logic (e.g., min, max, weighted average) to match their specific semantics. Detailed individual metrics are preserved in `EvaluationReport.detailed_results` for drill-down analysis.

The attached figure illustrates the modifications to the relevant data models.

<img width="1199" height="1174" alt="jLRDRXit4BxlKmoKoqgLvAJDQU4QDcodDT0uWLCWA591e7P74csQN91SAswKQn-WZzWdwP3SVwyD5q4k0ZMS6NxppJSZ7HlBj2rkHMHkkCoPPhUG2cRCYRMQhmgB5wcI7_XV22-ZoD_0AJDuU27pmlu-XNU5TOSZ-181_03ScHC8jzw2dtDCBMPBvJsJAg9xQJMxffFIzma8Rkod4tc_wBfmQL6pr78bJUbqqPWMqTSAt_aT4mLpnZDcsV" src="https://github.com/user-attachments/assets/8dcc01c8-3f4b-4e79-8aed-7fb3b694e84e" />

## Related Issues

N/A

## Documentation PR

N/A

## Type of Change

Breaking change


## Testing
Ran `pytest` after updating all affected unit tests.

- [x ] I ran `hatch run prepare`

## Checklist
- [ x] I have read the CONTRIBUTING document
- [x ] I have added any necessary tests that prove my fix is effective or my feature works
- [ x] I have updated the documentation accordingly
- [x ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x ] My changes generate no new warnings
- [x ] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.