### PR TITLE
chore: Updated semantic conventions for evaluations

### DIFF
--- a/src/strands_evals/dataset.py
+++ b/src/strands_evals/dataset.py
@@ -206,8 +206,8 @@ class Dataset(Generic[InputT, OutputT]):
             with self._tracer.start_as_current_span(
                 f"eval_case {case_name}",
                 attributes={
-                    "gen_ai.eval.case.name": case_name,
-                    "gen_ai.eval.case.input": serialize(case.input),
+                    "gen_ai.evaluation.case.name": case_name,
+                    "gen_ai.evaluation.case.input": serialize(case.input),
                 },
             ) as case_span:
                 try:
@@ -215,18 +215,20 @@ class Dataset(Generic[InputT, OutputT]):
                     with self._tracer.start_as_current_span(
                         "task_execution",
                         attributes={
-                            "gen_ai.eval.task.type": "agent_task",
-                            "gen_ai.eval.case.name": case_name,
+                            "gen_ai.evaluation.task.type": "agent_task",
+                            "gen_ai.evaluation.case.name": case_name,
                         },
                     ) as task_span:
                         evaluation_context = await self._run_task_async(task, case)
                         task_span.set_attributes(
                             {
-                                "gen_ai.eval.data.input": serialize(evaluation_context.input),
-                                "gen_ai.eval.data.expected_output": serialize(evaluation_context.expected_output),
-                                "gen_ai.eval.data.actual_output": serialize(evaluation_context.actual_output),
-                                "gen_ai.eval.data.has_trajectory": (evaluation_context.actual_trajectory is not None),
-                                "gen_ai.eval.data.has_interactions": (
+                                "gen_ai.evaluation.data.input": serialize(evaluation_context.input),
+                                "gen_ai.evaluation.data.expected_output": serialize(evaluation_context.expected_output),
+                                "gen_ai.evaluation.data.actual_output": serialize(evaluation_context.actual_output),
+                                "gen_ai.evaluation.data.has_trajectory": (
+                                    evaluation_context.actual_trajectory is not None
+                                ),
+                                "gen_ai.evaluation.data.has_interactions": (
                                     evaluation_context.actual_interactions is not None
                                 ),
                             }
@@ -236,8 +238,8 @@ class Dataset(Generic[InputT, OutputT]):
                     with self._tracer.start_as_current_span(
                         f"evaluator {self.evaluator.get_type_name()}",
                         attributes={
-                            "gen_ai.eval.evaluator.type": self.evaluator.get_type_name(),
-                            "gen_ai.eval.case.name": case_name,
+                            "gen_ai.evaluation.name": self.evaluator.get_type_name(),
+                            "gen_ai.evaluation.case.name": case_name,
                         },
                     ) as eval_span:
                         evaluation_outputs = await self.evaluator.evaluate_async(evaluation_context)
@@ -246,9 +248,10 @@ class Dataset(Generic[InputT, OutputT]):
                         )
                         eval_span.set_attributes(
                             {
-                                "gen_ai.eval.output.score": aggregate_score,
-                                "gen_ai.eval.output.test_pass": aggregate_pass,
-                                "gen_ai.eval.output.reason": aggregate_reason or "",
+                                # To-do: include gen_ai.evaluation.score.label
+                                "gen_ai.evaluation.score.value": aggregate_score,
+                                "gen_ai.evaluation.test_pass": aggregate_pass,
+                                "gen_ai.evaluation.explanation": aggregate_reason or "",
                             }
                         )
 
@@ -302,8 +305,8 @@ class Dataset(Generic[InputT, OutputT]):
             with self._tracer.start_as_current_span(
                 f"eval_case {case_name}",
                 attributes={
-                    "gen_ai.eval.case.name": case_name,
-                    "gen_ai.eval.case.input": serialize(case.input),
+                    "gen_ai.evaluation.case.name": case_name,
+                    "gen_ai.evaluation.case.input": serialize(case.input),
                 },
             ) as case_span:
                 try:
@@ -311,18 +314,20 @@ class Dataset(Generic[InputT, OutputT]):
                     with self._tracer.start_as_current_span(
                         "task_execution",
                         attributes={
-                            "gen_ai.eval.task.type": "agent_task",
-                            "gen_ai.eval.case.name": case_name,
+                            "gen_ai.evaluation.task.type": "agent_task",
+                            "gen_ai.evaluation.case.name": case_name,
                         },
                     ) as task_span:
                         evaluation_context = self._run_task(task, case)
                         task_span.set_attributes(
                             {
-                                "gen_ai.eval.data.input": serialize(evaluation_context.input),
-                                "gen_ai.eval.data.expected_output": serialize(evaluation_context.expected_output),
-                                "gen_ai.eval.data.actual_output": serialize(evaluation_context.actual_output),
-                                "gen_ai.eval.data.has_trajectory": (evaluation_context.actual_trajectory is not None),
-                                "gen_ai.eval.data.has_interactions": (
+                                "gen_ai.evaluation.data.input": serialize(evaluation_context.input),
+                                "gen_ai.evaluation.data.expected_output": serialize(evaluation_context.expected_output),
+                                "gen_ai.evaluation.data.actual_output": serialize(evaluation_context.actual_output),
+                                "gen_ai.evaluation.data.has_trajectory": (
+                                    evaluation_context.actual_trajectory is not None
+                                ),
+                                "gen_ai.evaluation.data.has_interactions": (
                                     evaluation_context.actual_interactions is not None
                                 ),
                             }
@@ -332,8 +337,8 @@ class Dataset(Generic[InputT, OutputT]):
                     with self._tracer.start_as_current_span(
                         f"evaluator {self.evaluator.get_type_name()}",
                         attributes={
-                            "gen_ai.eval.evaluator.type": self.evaluator.get_type_name(),
-                            "gen_ai.eval.case.name": case_name,
+                            "gen_ai.evaluation.name": self.evaluator.get_type_name(),
+                            "gen_ai.evaluation.case.name": case_name,
                         },
                     ) as eval_span:
                         evaluation_outputs = self.evaluator.evaluate(evaluation_context)
@@ -342,9 +347,10 @@ class Dataset(Generic[InputT, OutputT]):
                         )
                         eval_span.set_attributes(
                             {
-                                "gen_ai.eval.output.score": aggregate_score,
-                                "gen_ai.eval.output.test_pass": aggregate_pass,
-                                "gen_ai.eval.output.reason": aggregate_reason or "",
+                                # To-do: include gen_ai.evaluation.score.label
+                                "gen_ai.evaluation.score.value": aggregate_score,
+                                "gen_ai.evaluation.test_pass": aggregate_pass,
+                                "gen_ai.evaluation.explanation": aggregate_reason or "",
                             }
                         )
 

--- a/tests/strands_evals/test_dataset.py
+++ b/tests/strands_evals/test_dataset.py
@@ -694,9 +694,9 @@ def test_dataset_run_evaluations_creates_case_span(mock_span, simple_task):
         calls = mock_start_span.call_args_list
         case_span_call = calls[0]
         assert case_span_call[0][0] == "eval_case test_case"
-        assert "gen_ai.eval.case.name" in case_span_call[1]["attributes"]
-        assert case_span_call[1]["attributes"]["gen_ai.eval.case.name"] == "test_case"
-        assert "gen_ai.eval.case.input" in case_span_call[1]["attributes"]
+        assert "gen_ai.evaluation.case.name" in case_span_call[1]["attributes"]
+        assert case_span_call[1]["attributes"]["gen_ai.evaluation.case.name"] == "test_case"
+        assert "gen_ai.evaluation.case.input" in case_span_call[1]["attributes"]
 
 
 def test_dataset_run_evaluations_creates_task_span(mock_span, simple_task):
@@ -712,8 +712,8 @@ def test_dataset_run_evaluations_creates_task_span(mock_span, simple_task):
         assert len(calls) >= 2
         task_span_call = calls[1]
         assert task_span_call[0][0] == "task_execution"
-        assert "gen_ai.eval.task.type" in task_span_call[1]["attributes"]
-        assert "gen_ai.eval.case.name" in task_span_call[1]["attributes"]
+        assert "gen_ai.evaluation.task.type" in task_span_call[1]["attributes"]
+        assert "gen_ai.evaluation.case.name" in task_span_call[1]["attributes"]
         # Verify set_attributes was called with data attributes
         mock_span.set_attributes.assert_called()
 
@@ -731,8 +731,8 @@ def test_dataset_run_evaluations_creates_evaluator_span(mock_span, simple_task):
         assert len(calls) >= 3
         evaluator_span_call = calls[2]
         assert evaluator_span_call[0][0] == "evaluator MockEvaluator"
-        assert "gen_ai.eval.evaluator.type" in evaluator_span_call[1]["attributes"]
-        assert "gen_ai.eval.case.name" in evaluator_span_call[1]["attributes"]
+        assert "gen_ai.evaluation.name" in evaluator_span_call[1]["attributes"]
+        assert "gen_ai.evaluation.case.name" in evaluator_span_call[1]["attributes"]
         # Verify set_attributes was called with output attributes
         mock_span.set_attributes.assert_called()
 
@@ -754,7 +754,9 @@ def test_dataset_run_evaluations_with_trajectory_in_span(mock_span):
         # Verify has_trajectory flag is set
         set_attrs_calls = mock_span.set_attributes.call_args_list
         # Find the call that includes has_trajectory
-        has_trajectory_set = any("gen_ai.eval.data.has_trajectory" in call[0][0] for call in set_attrs_calls if call[0])
+        has_trajectory_set = any(
+            "gen_ai.evaluation.data.has_trajectory" in call[0][0] for call in set_attrs_calls if call[0]
+        )
         assert has_trajectory_set
 
 
@@ -776,7 +778,7 @@ def test_dataset_run_evaluations_with_interactions_in_span(mock_span):
         # Verify has_interactions flag is set
         set_attrs_calls = mock_span.set_attributes.call_args_list
         has_interactions_set = any(
-            "gen_ai.eval.data.has_interactions" in call[0][0] for call in set_attrs_calls if call[0]
+            "gen_ai.evaluation.data.has_interactions" in call[0][0] for call in set_attrs_calls if call[0]
         )
         assert has_interactions_set
 
@@ -831,7 +833,7 @@ async def test_dataset_run_evaluations_async_creates_spans(mock_span):
         # Check case span
         case_span_call = calls[0]
         assert case_span_call[0][0] == "eval_case async_test"
-        assert "gen_ai.eval.case.name" in case_span_call[1]["attributes"]
+        assert "gen_ai.evaluation.case.name" in case_span_call[1]["attributes"]
 
 
 @pytest.mark.asyncio
@@ -869,9 +871,11 @@ async def test_dataset_run_evaluations_async_with_dict_output(mock_span):
         mock_span.set_attributes.assert_called()
         # Verify has_trajectory and has_interactions flags are set
         set_attrs_calls = mock_span.set_attributes.call_args_list
-        has_trajectory_set = any("gen_ai.eval.data.has_trajectory" in call[0][0] for call in set_attrs_calls if call[0])
+        has_trajectory_set = any(
+            "gen_ai.evaluation.data.has_trajectory" in call[0][0] for call in set_attrs_calls if call[0]
+        )
         has_interactions_set = any(
-            "gen_ai.eval.data.has_interactions" in call[0][0] for call in set_attrs_calls if call[0]
+            "gen_ai.evaluation.data.has_interactions" in call[0][0] for call in set_attrs_calls if call[0]
         )
         assert has_trajectory_set
         assert has_interactions_set


### PR DESCRIPTION
## Description
Updated some attributes to match the [OTEL evaluation semantic conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-events/#event-eventgen_aievaluationresult).

### What attributes are changed
1. `gen_ai.eval.*` -> `gen_ai.evaluation.*`
2. `gen_ai.eval.evaluator.type` -> `gen_ai_evaluation.name`
  - description: **The name of the evaluation metric used for the GenAI response.**
3. `gen_ai.eval.output.score` -> `gen_ai.evaluation.score.value`
4. `gen_ai.eval.output.reason` -> `gen_ai.evaluation.explanation`

### Notes
1. To-do: include `gen_ai.evaluation.score.label` once we include the label into the EvaluationOutput
2. The rest of the attributes are not mentioned in OTEL. Therefore I keep them as is as custom attributes.
3. The attributes should be as **event attributes** under [gen_ai.evaluation.result Event](https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-events/#event-eventgen_aievaluationresult). However, since we are not sure whether other backend services support event attributes mapping, I'm keeping them as span attributes first.

## Related Issues
https://github.com/strands-agents/evals/issues/33

## Documentation PR

TBD

## Type of Change
Chore update

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.