### PR TITLE
chore: added InMemoryExporter to StrandsEvalsTelemetry

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,6 +53,43 @@ This project has adopted the [Amazon Open Source Code of Conduct](https://aws.gi
 For more information see the [Code of Conduct FAQ](https://aws.github.io/code-of-conduct-faq) or contact
 opensource-codeofconduct@amazon.com with any additional questions or comments.
 
+## Development Environment
+
+This project uses [hatchling](https://hatch.pypa.io/latest/build/#hatchling) as the build backend and [hatch](https://hatch.pypa.io/latest/) for development workflow management.
+
+### Setting Up Your Development Environment
+```bash
+# Create and activate a virtual environment (recommended)
+python -m venv .venv
+source .venv/bin/activate  # On Windows: .venv\Scripts\activate
+
+# Install the package in development mode with dependencies
+pip install -e .
+
+# Install with test dependencies
+pip install -e ".[test]"
+
+# Install with both test and dev dependencies
+pip install -e ".[test,dev]"
+```
+
+### Format code
+hatch run format
+
+### Check formatting (without making changes)
+hatch run test-format
+
+### Lint code
+hatch run lint
+
+### Check linting (without making changes)
+hatch run test-lint
+
+### Run tests
+pytest tests/
+
+### List available commands
+hatch run list
 
 ## Licensing
 


### PR DESCRIPTION
## Description
- Added `setup_in_memory_exporter` into StrandsEvalsTelemetry to cleanup user setup code.
- Updated `README.md` and `CONTRIBUTING.md` with examples and developer guide.

For trace-based evaluator, instead of asking users to setup the exporter, the behavior is changed to below code.

```
telemetry = StrandsEvalsTelemetry().setup_in_memory_exporter()
...
finished_spans = telemetry.in_memory_exporter.get_finished_spans()
...
```
**Note:** telemetry.in_memory_exporter will throw RuntimeError if `setup_in_memory_exporter` is not called before.

## Related Issues
N/A

## Documentation PR
N/A

## Type of Change
New feature

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.