### PR TITLE
adding `label` field in the `EvaluationOutput` following GenAI semantic conventions

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/src/strands_evals/evaluators/faithfulness_evaluator.py
+++ b/src/strands_evals/evaluators/faithfulness_evaluator.py
@@ -60,7 +60,12 @@ class FaithfulnessEvaluator(Evaluator[InputT, OutputT]):
         evaluator_agent = Agent(model=self.model, system_prompt=self.system_prompt, callback_handler=None)
         rating = evaluator_agent.structured_output(FaithfulnessRating, prompt)
         normalized_score = self._score_mapping[rating.score]
-        result = EvaluationOutput(score=normalized_score, test_pass=normalized_score >= 0.5, reason=rating.reasoning)
+        result = EvaluationOutput(
+            score=normalized_score,
+            test_pass=normalized_score >= 0.5,
+            reason=rating.reasoning,
+            label=rating.score,
+        )
         return [result]
 
     async def evaluate_async(self, evaluation_case: EvaluationData[InputT, OutputT]) -> list[EvaluationOutput]:
@@ -69,7 +74,12 @@ class FaithfulnessEvaluator(Evaluator[InputT, OutputT]):
         evaluator_agent = Agent(model=self.model, system_prompt=self.system_prompt, callback_handler=None)
         rating = await evaluator_agent.structured_output_async(FaithfulnessRating, prompt)
         normalized_score = self._score_mapping[rating.score]
-        result = EvaluationOutput(score=normalized_score, test_pass=normalized_score >= 0.5, reason=rating.reasoning)
+        result = EvaluationOutput(
+            score=normalized_score,
+            test_pass=normalized_score >= 0.5,
+            reason=rating.reasoning,
+            label=rating.score,
+        )
         return [result]
 
     def _get_last_turn(self, evaluation_case: EvaluationData[InputT, OutputT]) -> TraceLevelInput:

--- a/src/strands_evals/evaluators/goal_success_rate_evaluator.py
+++ b/src/strands_evals/evaluators/goal_success_rate_evaluator.py
@@ -54,7 +54,12 @@ class GoalSuccessRateEvaluator(Evaluator[InputT, OutputT]):
         evaluator_agent = Agent(model=self.model, system_prompt=self.system_prompt, callback_handler=None)
         rating = evaluator_agent.structured_output(GoalSuccessRating, prompt)
         normalized_score = self._score_mapping[rating.score]
-        result = EvaluationOutput(score=normalized_score, test_pass=normalized_score >= 1.0, reason=rating.reasoning)
+        result = EvaluationOutput(
+            score=normalized_score,
+            test_pass=normalized_score >= 1.0,
+            reason=rating.reasoning,
+            label=rating.score,
+        )
         return [result]
 
     async def evaluate_async(self, evaluation_case: EvaluationData[InputT, OutputT]) -> list[EvaluationOutput]:
@@ -63,7 +68,12 @@ class GoalSuccessRateEvaluator(Evaluator[InputT, OutputT]):
         evaluator_agent = Agent(model=self.model, system_prompt=self.system_prompt, callback_handler=None)
         rating = await evaluator_agent.structured_output_async(GoalSuccessRating, prompt)
         normalized_score = self._score_mapping[rating.score]
-        result = EvaluationOutput(score=normalized_score, test_pass=normalized_score >= 1.0, reason=rating.reasoning)
+        result = EvaluationOutput(
+            score=normalized_score,
+            test_pass=normalized_score >= 1.0,
+            reason=rating.reasoning,
+            label=rating.score,
+        )
         return [result]
 
     def _format_prompt(self, session_input: SessionLevelInput) -> str:

--- a/src/strands_evals/evaluators/helpfulness_evaluator.py
+++ b/src/strands_evals/evaluators/helpfulness_evaluator.py
@@ -66,7 +66,12 @@ class HelpfulnessEvaluator(Evaluator[InputT, OutputT]):
         evaluator_agent = Agent(model=self.model, system_prompt=self.system_prompt, callback_handler=None)
         rating = evaluator_agent.structured_output(HelpfulnessRating, prompt)
         normalized_score = self._score_mapping[rating.score]
-        result = EvaluationOutput(score=normalized_score, test_pass=normalized_score >= 0.5, reason=rating.reasoning)
+        result = EvaluationOutput(
+            score=normalized_score,
+            test_pass=normalized_score >= 0.5,
+            reason=rating.reasoning,
+            label=rating.score,
+        )
         return [result]
 
     async def evaluate_async(self, evaluation_case: EvaluationData[InputT, OutputT]) -> list[EvaluationOutput]:
@@ -75,7 +80,12 @@ class HelpfulnessEvaluator(Evaluator[InputT, OutputT]):
         evaluator_agent = Agent(model=self.model, system_prompt=self.system_prompt, callback_handler=None)
         rating = await evaluator_agent.structured_output_async(HelpfulnessRating, prompt)
         normalized_score = self._score_mapping[rating.score]
-        result = EvaluationOutput(score=normalized_score, test_pass=normalized_score >= 0.5, reason=rating.reasoning)
+        result = EvaluationOutput(
+            score=normalized_score,
+            test_pass=normalized_score >= 0.5,
+            reason=rating.reasoning,
+            label=rating.score,
+        )
         return [result]
 
     def _get_last_turn(self, evaluation_case: EvaluationData[InputT, OutputT]) -> TraceLevelInput:

--- a/src/strands_evals/evaluators/tool_parameter_accuracy_evaluator.py
+++ b/src/strands_evals/evaluators/tool_parameter_accuracy_evaluator.py
@@ -58,7 +58,7 @@ class ToolParameterAccuracyEvaluator(Evaluator[InputT, OutputT]):
             rating = evaluator_agent.structured_output(ToolParameterAccuracyRating, prompt)
             normalized_score = self._score_mapping[rating.score]
             result = EvaluationOutput(
-                score=normalized_score, test_pass=normalized_score == 1.0, reason=rating.reasoning
+                score=normalized_score, test_pass=normalized_score == 1.0, reason=rating.reasoning, label=rating.score
             )
             results.append(result)
 
@@ -74,7 +74,7 @@ class ToolParameterAccuracyEvaluator(Evaluator[InputT, OutputT]):
             rating = await evaluator_agent.structured_output_async(ToolParameterAccuracyRating, prompt)
             normalized_score = self._score_mapping[rating.score]
             result = EvaluationOutput(
-                score=normalized_score, test_pass=normalized_score == 1.0, reason=rating.reasoning
+                score=normalized_score, test_pass=normalized_score == 1.0, reason=rating.reasoning, label=rating.score
             )
             results.append(result)
 

--- a/src/strands_evals/evaluators/tool_selection_accuracy_evaluator.py
+++ b/src/strands_evals/evaluators/tool_selection_accuracy_evaluator.py
@@ -58,7 +58,7 @@ class ToolSelectionAccuracyEvaluator(Evaluator[InputT, OutputT]):
             rating = evaluator_agent.structured_output(ToolSelectionRating, prompt)
             normalized_score = self._score_mapping[rating.score]
             result = EvaluationOutput(
-                score=normalized_score, test_pass=normalized_score == 1.0, reason=rating.reasoning
+                score=normalized_score, test_pass=normalized_score == 1.0, reason=rating.reasoning, label=rating.score
             )
             results.append(result)
 
@@ -74,7 +74,7 @@ class ToolSelectionAccuracyEvaluator(Evaluator[InputT, OutputT]):
             rating = await evaluator_agent.structured_output_async(ToolSelectionRating, prompt)
             normalized_score = self._score_mapping[rating.score]
             result = EvaluationOutput(
-                score=normalized_score, test_pass=normalized_score == 1.0, reason=rating.reasoning
+                score=normalized_score, test_pass=normalized_score == 1.0, reason=rating.reasoning, label=rating.score
             )
             results.append(result)
 

--- a/src/strands_evals/types/evaluation.py
+++ b/src/strands_evals/types/evaluation.py
@@ -96,8 +96,10 @@ class EvaluationOutput(BaseModel):
         score: The score of the test case.
         test_pass: Whether the test pass or fail.
         reason: The reason for the score for each test case.
+        label: The categorical label corresponding to the score.
     """
 
     score: float
     test_pass: bool
     reason: str | None = None
+    label: str | None = None

--- a/tests/strands_evals/evaluators/test_faithfulness_evaluator.py
+++ b/tests/strands_evals/evaluators/test_faithfulness_evaluator.py
@@ -62,6 +62,7 @@ def test_evaluate(mock_agent_class, evaluation_data):
     assert result[0].score == 1.0
     assert result[0].test_pass is True
     assert result[0].reason == "The response is faithful"
+    assert result[0].label == FaithfulnessScore.COMPLETELY_YES
 
 
 @pytest.mark.parametrize(
@@ -86,6 +87,7 @@ def test_score_mapping(mock_agent_class, evaluation_data, score, expected_value,
     assert len(result) == 1
     assert result[0].score == expected_value
     assert result[0].test_pass == expected_pass
+    assert result[0].label == score
 
 
 @pytest.mark.asyncio
@@ -106,3 +108,4 @@ async def test_evaluate_async(mock_agent_class, evaluation_data):
     assert result[0].score == 1.0
     assert result[0].test_pass is True
     assert result[0].reason == "The response is faithful"
+    assert result[0].label == FaithfulnessScore.COMPLETELY_YES

--- a/tests/strands_evals/evaluators/test_goal_success_rate_evaluator.py
+++ b/tests/strands_evals/evaluators/test_goal_success_rate_evaluator.py
@@ -79,6 +79,7 @@ def test_evaluate(mock_agent_class, evaluation_data):
     assert result[0].score == 1.0
     assert result[0].test_pass is True
     assert result[0].reason == "All goals achieved"
+    assert result[0].label == GoalSuccessScore.YES
 
 
 @pytest.mark.parametrize(
@@ -100,6 +101,7 @@ def test_score_mapping(mock_agent_class, evaluation_data, score, expected_value,
     assert len(result) == 1
     assert result[0].score == expected_value
     assert result[0].test_pass == expected_pass
+    assert result[0].label == score
 
 
 @pytest.mark.asyncio
@@ -120,3 +122,4 @@ async def test_evaluate_async(mock_agent_class, evaluation_data):
     assert result[0].score == 1.0
     assert result[0].test_pass is True
     assert result[0].reason == "All goals achieved"
+    assert result[0].label == GoalSuccessScore.YES

--- a/tests/strands_evals/evaluators/test_helpfulness_evaluator.py
+++ b/tests/strands_evals/evaluators/test_helpfulness_evaluator.py
@@ -64,6 +64,7 @@ def test_evaluate(mock_agent_class, evaluation_data):
     assert result[0].score == 0.833
     assert result[0].test_pass is True
     assert result[0].reason == "The response is helpful"
+    assert result[0].label == HelpfulnessScore.VERY_HELPFUL
 
 
 @pytest.mark.parametrize(
@@ -90,6 +91,7 @@ def test_score_mapping(mock_agent_class, evaluation_data, score, expected_value,
     assert len(result) == 1
     assert result[0].score == expected_value
     assert result[0].test_pass == expected_pass
+    assert result[0].label == score
 
 
 @pytest.mark.asyncio
@@ -110,3 +112,4 @@ async def test_evaluate_async(mock_agent_class, evaluation_data):
     assert result[0].score == 0.833
     assert result[0].test_pass is True
     assert result[0].reason == "The response is helpful"
+    assert result[0].label == HelpfulnessScore.VERY_HELPFUL

--- a/tests/strands_evals/evaluators/test_tool_parameter_accuracy_evaluator.py
+++ b/tests/strands_evals/evaluators/test_tool_parameter_accuracy_evaluator.py
@@ -89,6 +89,7 @@ def test_evaluate(mock_agent_class, evaluation_data):
     assert result[0].score == 1.0
     assert result[0].test_pass is True
     assert result[0].reason == "Parameters are faithful to context"
+    assert result[0].label == ToolParameterAccuracyScore.YES
 
 
 @pytest.mark.parametrize(
@@ -110,6 +111,7 @@ def test_score_mapping(mock_agent_class, evaluation_data, score, expected_value,
     assert len(result) == 1
     assert result[0].score == expected_value
     assert result[0].test_pass == expected_pass
+    assert result[0].label == score
 
 
 @pytest.mark.asyncio
@@ -132,3 +134,4 @@ async def test_evaluate_async(mock_agent_class, evaluation_data):
     assert result[0].score == 1.0
     assert result[0].test_pass is True
     assert result[0].reason == "Parameters are faithful to context"
+    assert result[0].label == ToolParameterAccuracyScore.YES

--- a/tests/strands_evals/evaluators/test_tool_selection_accuracy_evaluator.py
+++ b/tests/strands_evals/evaluators/test_tool_selection_accuracy_evaluator.py
@@ -81,6 +81,7 @@ def test_evaluate(mock_agent_class, evaluation_data):
     assert result[0].score == 1.0
     assert result[0].test_pass is True
     assert result[0].reason == "Tool call is appropriate"
+    assert result[0].label == ToolSelectionScore.YES
 
 
 @pytest.mark.parametrize(
@@ -102,6 +103,7 @@ def test_score_mapping(mock_agent_class, evaluation_data, score, expected_value,
     assert len(result) == 1
     assert result[0].score == expected_value
     assert result[0].test_pass == expected_pass
+    assert result[0].label == score
 
 
 @pytest.mark.asyncio
@@ -122,3 +124,4 @@ async def test_evaluate_async(mock_agent_class, evaluation_data):
     assert result[0].score == 1.0
     assert result[0].test_pass is True
     assert result[0].reason == "Tool call is appropriate"
+    assert result[0].label == ToolSelectionScore.YES


### PR DESCRIPTION


## Description
GenAI semantic conventions now call for a "label" field in evaluation data (https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-events/#event-eventgen_aievaluationresult). This change adds the label field in the `EvaluationOutput`, where `label` field is the corresponding key from `_score_mapping` for the respective evaluator.

## Related Issues

NA
## Documentation PR
NA

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

Feature Enhancement

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.