### PR TITLE
chore: allow trace_id and use_current_context for filtering traces in the mapper

### DIFF
--- a/src/strands_evals/mappers/session_mapper.py
+++ b/src/strands_evals/mappers/session_mapper.py
@@ -13,7 +13,9 @@ class SessionMapper(ABC):
     """Base class for mapping telemetry data to Session format for evaluation."""
 
     @abstractmethod
-    def map_to_session(self, spans: list[Any], session_id: str) -> Session:
+    def map_to_session(
+        self, spans: list[Any], session_id: str, trace_id: str | None = None, use_current_context: bool = False
+    ) -> Session:
         """
         Map spans to Session format.
 


### PR DESCRIPTION
## Description
When executing the dataset asynchronously, the memory exporter stores all of the spans. As the evaluation should focus on certain case (trace_id), the mapper should be able to filter out the target trace.

- Add `trace_id: str` and `use_current_context: bool` to get the trace_id and filter the traces out.

## Related Issues

#43 

## Documentation PR

N/A

## Type of Change
Bug fix
New feature

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.