### PR TITLE
Rename Dataset to Experiment and DatasetGenerator to ExperimentGenerator

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ pip install -e ".[test,dev]"
 
 ```python
 from strands import Agent
-from strands_evals import Case, Dataset
+from strands_evals import Case, Experiment
 from strands_evals.evaluators import OutputEvaluator
 
 # 1. Create test cases
@@ -47,8 +47,8 @@ evaluator = OutputEvaluator(
     rubric="The output should represent a reasonable answer to the input."
 )
 
-# 3. Create a dataset
-dataset = Dataset[str, str](
+# 3. Create an experiment
+experiment = Experiment[str, str](
     cases=test_cases,
     evaluator=evaluator
 )
@@ -59,7 +59,7 @@ def get_response(case: Case) -> str:
     return str(agent(case.input))
 
 # 5. Run evaluations
-report = dataset.run_evaluations(get_response)
+report = experiment.run_evaluations(get_response)
 report.run_display()
 ```
 
@@ -68,7 +68,7 @@ report.run_display()
 ```python
 from strands import Agent
 
-from strands_evals import Case, Dataset
+from strands_evals import Case, Experiment
 from strands_evals.evaluators import HelpfulnessEvaluator
 from strands_evals.telemetry import StrandsEvalsTelemetry
 
@@ -86,8 +86,8 @@ test_cases = [
 # 3. Create an evaluator
 evaluator = HelpfulnessEvaluator()
 
-# 4. Create a dataset
-dataset = Dataset[str, str](cases=test_cases, evaluator=evaluator)
+# 4. Create an experiment
+experiment = Experiment[str, str](cases=test_cases, evaluator=evaluator)
 
 # 5. Define a task function
 def user_task_function(case: Case) -> dict:
@@ -101,18 +101,18 @@ def user_task_function(case: Case) -> dict:
     return {"output": str(agent_response), "trajectory": session}
 
 # 6. Run evaluations
-report = dataset.run_evaluations(user_task_function)
+report = experiment.run_evaluations(user_task_function)
 report.run_display()
 ```
 
-## Saving and Loading Datasets
+## Saving and Loading Experiments
 
 ```python
-# Save dataset to JSON
-dataset.to_file("my_dataset", "json")
+# Save experiment to JSON
+experiment.to_file("my_experiment", "json")
 
-# Load dataset from JSON
-loaded_dataset = Dataset.from_file("./dataset_files/my_dataset.json", "json")
+# Load experiment from JSON
+loaded_experiment = Experiment.from_file("./experiment_files/my_experiment.json", "json")
 ```
 
 ## Custom Evaluators
@@ -138,7 +138,7 @@ class CustomEvaluator(Evaluator[str, str]):
         )
 
 # Use custom evaluator
-dataset = Dataset[str, str](
+experiment = Experiment[str, str](
     cases=test_cases,
     evaluator=CustomEvaluator()
 )
@@ -147,7 +147,7 @@ dataset = Dataset[str, str](
 ## Evaluating Tool Usage
 
 ```python
-from strands_evals import Case, Dataset
+from strands_evals import Case, Experiment
 from strands_evals.evaluators import TrajectoryEvaluator
 from strands_tools import calculator
 
@@ -176,19 +176,19 @@ trajectory_evaluator = TrajectoryEvaluator(
     include_inputs=True
 )
 
-# 4. Create dataset and run evaluations
-dataset = Dataset[str, str](
+# 4. Create experiment and run evaluations
+experiment = Experiment[str, str](
     cases=[test_case],
     evaluator=trajectory_evaluator
 )
 
-report = dataset.run_evaluations(get_response_with_tools)
+report = experiment.run_evaluations(get_response_with_tools)
 ```
 
-## Dataset Generation
+## Experiment Generation
 
 ```python
-from strands_evals.generators import DatasetGenerator
+from strands_evals.generators import ExperimentGenerator
 from strands_evals.evaluators import TrajectoryEvaluator
 
 # 1. Define tool context
@@ -198,19 +198,19 @@ Available tools:
 - web_search(query: str) -> str: Search the web for information
 """
 
-# 2. Generate dataset from context
-generator = DatasetGenerator[str, str](str, str)
+# 2. Generate experiment from context
+generator = ExperimentGenerator[str, str](str, str)
 
-dataset = await generator.generate_dataset(
+experiment = await generator.from_context_async(
     context=tool_context,
     num_cases=10,
-    evaluator_type=TrajectoryEvaluator,
+    evaluator=TrajectoryEvaluator,
     task_description="Math and research assistant with tool usage",
     # num_topics=3  # Optional: Distribute cases across multiple topics
 )
 
-# 3. Save generated dataset
-dataset.to_file("generated_math_research_dataset")
+# 3. Save generated experiment
+experiment.to_file("generated_math_research_experiment")
 ```
 
 ## Available Evaluators

--- a/src/examples/actor_simulator_basic.py
+++ b/src/examples/actor_simulator_basic.py
@@ -2,7 +2,7 @@ from opentelemetry.sdk.trace.export import BatchSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 from strands import Agent
 
-from strands_evals import ActorSimulator, Case, Dataset
+from strands_evals import ActorSimulator, Case, Experiment
 from strands_evals.evaluators import HelpfulnessEvaluator
 from strands_evals.mappers import StrandsInMemorySessionMapper
 from strands_evals.telemetry import StrandsEvalsTelemetry
@@ -61,7 +61,7 @@ test_cases = [
 ]
 
 evaluator = HelpfulnessEvaluator()
-dataset = Dataset[str, str](cases=test_cases, evaluator=evaluator)
+experiment = Experiment[str, str](cases=test_cases, evaluator=evaluator)
 
-report = dataset.run_evaluations(task_function)
+report = experiment.run_evaluations(task_function)
 report.run_display()

--- a/src/examples/agents_as_tools.py
+++ b/src/examples/agents_as_tools.py
@@ -3,7 +3,7 @@ import datetime
 
 from strands import Agent, tool
 
-from strands_evals import Case, Dataset
+from strands_evals import Case, Experiment
 from strands_evals.evaluators import InteractionsEvaluator, TrajectoryEvaluator
 from strands_evals.extractors import tools_use_extractor
 from strands_evals.types import Interaction
@@ -190,8 +190,8 @@ async def async_agents_as_tools_example():
     )
 
     ### Step 4: Create dataset ###
-    dataset_trajectory = Dataset(cases=test_cases, evaluator=trajectory_evaluator)
-    dataset_interactions = Dataset(cases=test_cases, evaluator=interaction_evaluator)
+    dataset_trajectory = Experiment(cases=test_cases, evaluator=trajectory_evaluator)
+    dataset_interactions = Experiment(cases=test_cases, evaluator=interaction_evaluator)
 
     ### Step 5: Run the evaluation ###
     report_trajectory = await dataset_trajectory.run_evaluations_async(customer_support)

--- a/src/examples/evaluate_graph.py
+++ b/src/examples/evaluate_graph.py
@@ -4,7 +4,7 @@ import datetime
 from strands import Agent
 from strands.multiagent import GraphBuilder
 
-from strands_evals import Case, Dataset
+from strands_evals import Case, Experiment
 from strands_evals.evaluators import InteractionsEvaluator, TrajectoryEvaluator
 from strands_evals.extractors import graph_extractor
 
@@ -86,11 +86,11 @@ async def async_graph_example():
     trajectory_evaluator = TrajectoryEvaluator(rubric=basic_rubric)
 
     ### Step 4: Create dataset ###
-    interaction_dataset = Dataset(cases=[test1, test2], evaluator=interaction_evaluator)
-    trajectory_evaluator = Dataset(cases=[test1, test2], evaluator=trajectory_evaluator)
+    interaction_experiment = Experiment(cases=[test1, test2], evaluator=interaction_evaluator)
+    trajectory_evaluator = Experiment(cases=[test1, test2], evaluator=trajectory_evaluator)
 
     ### Step 5: Run evaluation ###
-    interaction_report = await interaction_dataset.run_evaluations_async(research_graph)
+    interaction_report = await interaction_experiment.run_evaluations_async(research_graph)
     trajectory_report = await trajectory_evaluator.run_evaluations_async(research_graph)
 
     return trajectory_report, interaction_report

--- a/src/examples/evaluate_swarm.py
+++ b/src/examples/evaluate_swarm.py
@@ -4,7 +4,7 @@ import datetime
 from strands import Agent
 from strands.multiagent import Swarm
 
-from strands_evals import Case, Dataset
+from strands_evals import Case, Experiment
 from strands_evals.evaluators import InteractionsEvaluator, TrajectoryEvaluator
 from strands_evals.extractors import swarm_extractor
 
@@ -66,12 +66,12 @@ async def async_swarm_example():
     )
 
     ### Step 4: Create dataset ###
-    trajectory_dataset = Dataset(cases=[test1], evaluator=trajectory_evaluator)
-    interaction_dataset = Dataset(cases=[test1], evaluator=interaction_evaluator)
+    trajectory_experiment = Experiment(cases=[test1], evaluator=trajectory_evaluator)
+    interaction_experiment = Experiment(cases=[test1], evaluator=interaction_evaluator)
 
     ### Step 5: Run evaluation ###
-    trajectory_report = await trajectory_dataset.run_evaluations_async(sde_swarm)
-    interaction_report = await interaction_dataset.run_evaluations_async(sde_swarm)
+    trajectory_report = await trajectory_experiment.run_evaluations_async(sde_swarm)
+    interaction_report = await interaction_experiment.run_evaluations_async(sde_swarm)
     return trajectory_report, interaction_report
 
 

--- a/src/examples/experiment_generator/simple_dataset.py
+++ b/src/examples/experiment_generator/simple_dataset.py
@@ -4,17 +4,17 @@ from strands import Agent
 
 from strands_evals import Case
 from strands_evals.evaluators.output_evaluator import OutputEvaluator
-from strands_evals.generators.dataset_generator import DatasetGenerator
+from strands_evals.generators.experiment_generator import ExperimentGenerator
 
 
-async def simple_dataset_generator():
+async def simple_experiment_generator():
     """
-    Demonstrates the a simple dataset generation and evaluation process.
+    Demonstrates the a simple experiment generation and evaluation process.
 
     This function:
     1. Defines a task function that uses an agent to generate responses
-    2. Creates a DatasetGenerator for string input/output types
-    3. Generates a dataset from scratch based on specified topics
+    2. Creates an ExperimentGenerator for string input/output types
+    3. Generates an experiment from scratch based on specified topics
     4. Runs evaluations on the generated test cases
 
     Returns:
@@ -30,28 +30,28 @@ async def simple_dataset_generator():
         response = await agent.invoke_async(case.input)
         return str(response)
 
-    # Step 2: Initialize the dataset generator for string types
-    generator = DatasetGenerator[str, str](str, str)
+    # Step 2: Initialize the experiment generator for string types
+    generator = ExperimentGenerator[str, str](str, str)
 
-    # Step 3: Generate dataset from scratch with specified topics
+    # Step 3: Generate experiment from scratch with specified topics
     # This will create test cases and a rubric automatically
-    dataset = await generator.from_scratch_async(
+    experiment = await generator.from_scratch_async(
         topics=["safety", "red teaming", "leetspeak"],  # Topics to cover in test cases
         task_description="Getting response from an agent given a query",  # What the AI system does
         num_cases=10,  # Number of test cases to generate
         evaluator=OutputEvaluator,  # Type of evaluator to create with generated rubric
     )
 
-    # Step 3.5: (Optional) Save the generated dataset for future use
-    dataset.to_file("generate_simple_dataset")
+    # Step 3.5: (Optional) Save the generated experiment for future use
+    experiment.to_file("generate_simple_experiment")
 
     # Step 4: Run evaluations on the generated test cases
-    report = await dataset.run_evaluations_async(get_response)
+    report = await experiment.run_evaluations_async(get_response)
     return report
 
 
 if __name__ == "__main__":
-    # python -m examples.dataset_generator.simple_dataset
-    report = asyncio.run(simple_dataset_generator())
+    # python -m examples.experiment_generator.simple_experiment
+    report = asyncio.run(simple_experiment_generator())
     report.to_file("generated_safety_judge_output_report", "json")
     report.run_display(include_actual_output=True)

--- a/src/examples/experiment_generator/topic_planning_dataset.py
+++ b/src/examples/experiment_generator/topic_planning_dataset.py
@@ -4,12 +4,12 @@ from strands import Agent
 
 from strands_evals.case import Case
 from strands_evals.evaluators.output_evaluator import OutputEvaluator
-from strands_evals.generators.dataset_generator import DatasetGenerator
+from strands_evals.generators.experiment_generator import ExperimentGenerator
 
 
-async def topic_planning_dataset_generator():
+async def topic_planning_experiment_generator():
     """
-    Demonstrates dataset generation with topic planning for improved diversity.
+    Demonstrates experiment generation with topic planning for improved diversity.
 
     This function shows how to use the num_topics parameter to generate
     more diverse test cases through multi-step topic planning.
@@ -25,11 +25,11 @@ async def topic_planning_dataset_generator():
         response = await agent.invoke_async(case.input)
         return str(response)
 
-    # Step 2: Initialize the dataset generator for string types
-    generator = DatasetGenerator[str, str](str, str)
+    # Step 2: Initialize the experiment generator for string types
+    generator = ExperimentGenerator[str, str](str, str)
 
-    # Step 3: Generate dataset with topic planning for better coverage
-    dataset = await generator.from_context_async(
+    # Step 3: Generate experiment with topic planning for better coverage
+    experiment = await generator.from_context_async(
         context="""Available tools:
         - book_flight(origin, destination, date)
         - cancel_booking(confirmation_id)
@@ -42,16 +42,16 @@ async def topic_planning_dataset_generator():
         evaluator=OutputEvaluator,
     )
 
-    # Step 3.5: (Optional) Save the generated dataset for future use
-    dataset.to_file("topic_planning_travel_dataset")
+    # Step 3.5: (Optional) Save the generated experiment for future use
+    experiment.to_file("topic_planning_travel_experiment")
 
     # Step 4: Run evaluations on the generated test cases
-    report = await dataset.run_evaluations_async(get_response)
+    report = await experiment.run_evaluations_async(get_response)
     return report
 
 
 if __name__ == "__main__":
-    # python -m examples.dataset_generator.topic_planning_dataset
-    report = asyncio.run(topic_planning_dataset_generator())
+    # python -m examples.experiment_generator.topic_planning_experiment
+    report = asyncio.run(topic_planning_experiment_generator())
     report.to_file("topic_planning_travel_report", "json")
     report.run_display(include_actual_output=True)

--- a/src/examples/experiment_generator/trajectory_dataset.py
+++ b/src/examples/experiment_generator/trajectory_dataset.py
@@ -5,7 +5,7 @@ from strands import Agent, tool
 from strands_evals.case import Case
 from strands_evals.evaluators import TrajectoryEvaluator
 from strands_evals.extractors import tools_use_extractor
-from strands_evals.generators import DatasetGenerator
+from strands_evals.generators import ExperimentGenerator
 from strands_evals.types import TaskOutput
 
 # Bank account balances
@@ -34,14 +34,14 @@ def collect_debt() -> list[tuple]:
     return debt
 
 
-async def trajectory_dataset_generator():
+async def trajectory_experiment_generator():
     """
-    Demonstrates generating a dataset for bank tools trajectory evaluation.
+    Demonstrates generating an experiment for bank tools trajectory evaluation.
 
     This function:
     1. Defines a task function that uses banking tools
-    2. Creates a DatasetGenerator for trajectory evaluation
-    3. Generates a dataset from banking-related topics
+    2. Creates an ExperimentGenerator for trajectory evaluation
+    3. Generates an experiment from banking-related topics
     4. Runs evaluations on the generated test cases
 
     Returns:
@@ -65,10 +65,10 @@ async def trajectory_dataset_generator():
         trajectory = tools_use_extractor.extract_agent_tools_used_from_messages(agent.messages)
         return TaskOutput(output=str(response), trajectory=trajectory)
 
-    ### Step 2: Initialize the dataset generator ###
-    generator = DatasetGenerator[str, str](str, str)
+    ### Step 2: Initialize the experiment generator ###
+    generator = ExperimentGenerator[str, str](str, str)
 
-    ### Step 3: Generate dataset with tool context ###
+    ### Step 3: Generate experiment with tool context ###
     tool_context = """
     Available banking tools:
     - get_balance(person: str) -> int: Get the balance of a bank account for a specific person
@@ -81,23 +81,23 @@ async def trajectory_dataset_generator():
     - Always report final balance after transactions
     """
 
-    dataset = await generator.from_context_async(
+    experiment = await generator.from_context_async(
         context=tool_context,
         num_cases=5,
         evaluator=TrajectoryEvaluator,
         task_description="Banking operations with balance checks, spending, and debt collection",
     )
 
-    ### Step 3.5: (Optional) Save the generated dataset ###
-    dataset.to_file("generated_bank_trajectory_dataset")
+    ### Step 3.5: (Optional) Save the generated experiment ###
+    experiment.to_file("generated_bank_trajectory_experiment")
 
     ### Step 4: Run evaluations on the generated test cases ###
-    report = await dataset.run_evaluations_async(bank_task)
+    report = await experiment.run_evaluations_async(bank_task)
     return report
 
 
 if __name__ == "__main__":
-    # python -m examples.dataset_generator.trajectory_dataset
-    report = asyncio.run(trajectory_dataset_generator())
+    # python -m examples.experiment_generator.trajectory_experiment
+    report = asyncio.run(trajectory_experiment_generator())
     report.to_file("generated_bank_trajectory_report", "json")
     report.run_display(include_actual_trajectory=True)

--- a/src/examples/faithfulness_evaluator.py
+++ b/src/examples/faithfulness_evaluator.py
@@ -2,7 +2,7 @@ from opentelemetry.sdk.trace.export import BatchSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 from strands import Agent
 
-from strands_evals import Case, Dataset
+from strands_evals import Case, Experiment
 from strands_evals.evaluators import FaithfulnessEvaluator
 from strands_evals.mappers import StrandsInMemorySessionMapper
 from strands_evals.telemetry import StrandsEvalsTelemetry
@@ -41,7 +41,7 @@ test_cases = [
 
 evaluator = FaithfulnessEvaluator()
 
-dataset = Dataset[str, str](cases=test_cases, evaluator=evaluator)
+experiment = Experiment[str, str](cases=test_cases, evaluator=evaluator)
 
-report = dataset.run_evaluations(user_task_function)
+report = experiment.run_evaluations(user_task_function)
 report.run_display()

--- a/src/examples/goal_success_rate_evaluator.py
+++ b/src/examples/goal_success_rate_evaluator.py
@@ -2,7 +2,7 @@ from opentelemetry.sdk.trace.export import BatchSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 from strands import Agent
 
-from strands_evals import Case, Dataset
+from strands_evals import Case, Experiment
 from strands_evals.evaluators import GoalSuccessRateEvaluator
 from strands_evals.mappers import StrandsInMemorySessionMapper
 from strands_evals.telemetry import StrandsEvalsTelemetry
@@ -48,8 +48,8 @@ test_cases = [
 evaluator = GoalSuccessRateEvaluator()
 
 # 4. Create a dataset
-dataset = Dataset[str, str](cases=test_cases, evaluator=evaluator)
+experiment = Experiment[str, str](cases=test_cases, evaluator=evaluator)
 
 # 5. Run evaluations
-report = dataset.run_evaluations(user_task_function)
+report = experiment.run_evaluations(user_task_function)
 report.run_display()

--- a/src/examples/helpfulness_evaluator.py
+++ b/src/examples/helpfulness_evaluator.py
@@ -2,7 +2,7 @@ from opentelemetry.sdk.trace.export import BatchSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 from strands import Agent
 
-from strands_evals import Case, Dataset
+from strands_evals import Case, Experiment
 from strands_evals.evaluators import HelpfulnessEvaluator
 from strands_evals.mappers import StrandsInMemorySessionMapper
 from strands_evals.telemetry import StrandsEvalsTelemetry
@@ -48,8 +48,8 @@ test_cases = [
 evaluator = HelpfulnessEvaluator()
 
 # 4. Create a dataset
-dataset = Dataset[str, str](cases=test_cases, evaluator=evaluator)
+experiment = Experiment[str, str](cases=test_cases, evaluator=evaluator)
 
 # 5. Run evaluations
-report = dataset.run_evaluations(user_task_function)
+report = experiment.run_evaluations(user_task_function)
 report.run_display()

--- a/src/examples/multi_metric_evaluator.py
+++ b/src/examples/multi_metric_evaluator.py
@@ -9,7 +9,7 @@ This toy evaluator checks multiple aspects of a response:
 Each check produces its own metric, and they're aggregated into a final score.
 """
 
-from strands_evals import Case, Dataset
+from strands_evals import Case, Experiment
 from strands_evals.evaluators import Evaluator
 from strands_evals.types import EvaluationData, EvaluationOutput
 
@@ -90,8 +90,8 @@ if __name__ == "__main__":
     evaluator = MultiAspectEvaluator(min_length=20, required_keywords=["response", "information"])
 
     # Create dataset and run
-    dataset = Dataset[str, str](cases=test_cases, evaluator=evaluator)
-    report = dataset.run_evaluations(simple_task)
+    experiment = Experiment[str, str](cases=test_cases, evaluator=evaluator)
+    report = experiment.run_evaluations(simple_task)
 
     # Show results
     print("\n=== Programmatic Access to Detailed Results ===")

--- a/src/examples/multi_shots.py
+++ b/src/examples/multi_shots.py
@@ -3,7 +3,7 @@ import datetime
 
 from strands import Agent
 
-from strands_evals import Case, Dataset
+from strands_evals import Case, Experiment
 from strands_evals.evaluators import InteractionsEvaluator
 from strands_evals.types import Interaction, TaskOutput
 
@@ -77,13 +77,13 @@ async def async_multi_shots_interactions():
     evaluator = InteractionsEvaluator(rubric="Scoring should measure how well the agent refuse unsafe directions.")
 
     ### Step 4: Create dataset ###
-    dataset = Dataset(cases=[test_case1, test_case2], evaluator=evaluator)
+    experiment = Experiment(cases=[test_case1, test_case2], evaluator=evaluator)
 
     ### Step 4.5: (Optional) Save the dataset ###
-    dataset.to_file("multi_shots")
+    experiment.to_file("multi_shots")
 
     ### Step 5: Run evaluation ###
-    report = await dataset.run_evaluations_async(multi_turns_hacking)
+    report = await experiment.run_evaluations_async(multi_turns_hacking)
 
     return report
 

--- a/src/examples/output_evaluator.py
+++ b/src/examples/output_evaluator.py
@@ -3,7 +3,7 @@ import datetime
 
 from strands import Agent
 
-from strands_evals import Case, Dataset
+from strands_evals import Case, Experiment
 from strands_evals.evaluators import OutputEvaluator
 
 
@@ -15,7 +15,7 @@ async def async_safety_output_judge_example():
     1. Defines a task function that uses an agent to generate responses
     2. Creates test cases
     3. Creates an OutputEvaluator with a specified rubric
-    4. Creates a dataset with the test cases and evaluator
+    4. Creates an experiment with the test cases and evaluator
     5. Runs evaluations and analyze the report
 
     Returns:
@@ -66,13 +66,13 @@ async def async_safety_output_judge_example():
         include_inputs=True,
     )
 
-    ### Step 4: Create dataset ###
-    dataset = Dataset[str, str](cases=[test_case1, test_case2, test_case3, test_case4], evaluator=LLM_judge)
-    ### Step 4.5: (Optional) Save the dataset ###
-    dataset.to_file("async_safety_judge_output_dataset", "json")
+    ### Step 4: Create experiment ###
+    experiment = Experiment[str, str](cases=[test_case1, test_case2, test_case3, test_case4], evaluator=LLM_judge)
+    ### Step 4.5: (Optional) Save the experiment ###
+    experiment.to_file("async_safety_judge_output_experiment", "json")
 
     ### Step 5: Run evaluation ###
-    report = await dataset.run_evaluations_async(get_response)
+    report = await experiment.run_evaluations_async(get_response)
     return report
 
 

--- a/src/examples/third_party_evaluator.py
+++ b/src/examples/third_party_evaluator.py
@@ -7,7 +7,7 @@ from langchain.evaluation.criteria import CriteriaEvalChain
 from langchain_aws import BedrockLLM
 from strands import Agent
 
-from strands_evals import Case, Dataset
+from strands_evals import Case, Experiment
 from strands_evals.evaluators import Evaluator
 from strands_evals.types import EvaluationData, EvaluationOutput
 
@@ -77,15 +77,15 @@ def third_party_example():
             )
 
     ### Step 4: Create dataset ###
-    dataset = Dataset[str, str](
+    experiment = Experiment[str, str](
         cases=[test_case1, test_case2, test_case3, test_case4], evaluator=LangChainCriteriaEvaluator()
     )
 
     ### Step 4.5: (Optional) Save the dataset ###
-    dataset.to_file("third_party_dataset", "json")
+    experiment.to_file("third_party_dataset", "json")
 
     ### Step 5: Run evaluation ###
-    report = dataset.run_evaluations(get_response)
+    report = experiment.run_evaluations(get_response)
     return report
 
 
@@ -160,15 +160,15 @@ async def async_third_party_example():
             return self.evaluate(evaluation_case)
 
     ### Step 4: Create dataset ###
-    dataset = Dataset[str, str](
+    experiment = Experiment[str, str](
         cases=[test_case1, test_case2, test_case3, test_case4], evaluator=LangChainCriteriaEvaluator()
     )
 
     ### Step 4.5: (Optional) Save the dataset ###
-    dataset.to_file("async_third_party_dataset", "json")
+    experiment.to_file("async_third_party_dataset", "json")
 
     ### Step 5: Run evaluation ###
-    report = await dataset.run_evaluations_async(get_response)
+    report = await experiment.run_evaluations_async(get_response)
     return report
 
 

--- a/src/examples/tool_parameter_accuracy_evaluator.py
+++ b/src/examples/tool_parameter_accuracy_evaluator.py
@@ -3,7 +3,7 @@ from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanE
 from strands import Agent
 from strands_tools import calculator
 
-from strands_evals import Case, Dataset
+from strands_evals import Case, Experiment
 from strands_evals.evaluators import ToolParameterAccuracyEvaluator
 from strands_evals.mappers import StrandsInMemorySessionMapper
 from strands_evals.telemetry import StrandsEvalsTelemetry
@@ -55,8 +55,8 @@ test_cases = [
 # Create an evaluator
 # The evaluator will check if tool parameters are faithful to the context
 evaluator = ToolParameterAccuracyEvaluator()
-dataset = Dataset[str, str](cases=test_cases, evaluator=evaluator)
+experiment = Experiment[str, str](cases=test_cases, evaluator=evaluator)
 
 # Run evaluations
-report = dataset.run_evaluations(user_task_function)
+report = experiment.run_evaluations(user_task_function)
 report.run_display()

--- a/src/examples/tool_selection_accuracy_evaluator.py
+++ b/src/examples/tool_selection_accuracy_evaluator.py
@@ -3,7 +3,7 @@ from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanE
 from strands import Agent
 from strands_tools import calculator
 
-from strands_evals import Case, Dataset
+from strands_evals import Case, Experiment
 from strands_evals.evaluators import ToolSelectionAccuracyEvaluator
 from strands_evals.mappers import StrandsInMemorySessionMapper
 from strands_evals.telemetry import StrandsEvalsTelemetry
@@ -40,6 +40,6 @@ test_cases = [
 ]
 
 evaluator = ToolSelectionAccuracyEvaluator()
-dataset = Dataset[str, str](cases=test_cases, evaluator=evaluator)
-report = dataset.run_evaluations(user_task_function)
+experiment = Experiment[str, str](cases=test_cases, evaluator=evaluator)
+report = experiment.run_evaluations(user_task_function)
 report.run_display()

--- a/src/examples/trajectory_evaluator.py
+++ b/src/examples/trajectory_evaluator.py
@@ -3,7 +3,7 @@ import datetime
 
 from strands import Agent, tool
 
-from strands_evals import Case, Dataset
+from strands_evals import Case, Experiment
 from strands_evals.evaluators import TrajectoryEvaluator
 from strands_evals.extractors import tools_use_extractor
 from strands_evals.types import TaskOutput
@@ -66,7 +66,7 @@ async def async_descriptive_tools_trajectory_example():
        and returns both the response and the tools used
     2. Creates test cases with expected outputs and tool trajectories
     3. Creates a TrajectoryEvaluator to assess tool usage
-    4. Creates a dataset with the test cases and evaluator
+    4. Creates an experiment with the test cases and evaluator
     5. Runs evaluations and returns the report
 
     Returns:
@@ -131,14 +131,14 @@ async def async_descriptive_tools_trajectory_example():
         include_inputs=True,
     )
 
-    ### Step 4: Create dataset ###
-    dataset = Dataset[str, str](cases=[case1, case2, case3, case4], evaluator=trajectory_evaluator)
+    ### Step 4: Create experiment ###
+    experiment = Experiment[str, str](cases=[case1, case2, case3, case4], evaluator=trajectory_evaluator)
 
-    ### Step 4.5: (Optional) Save the dataset ###
-    dataset.to_file("async_bank_tools_trajectory_dataset", "json")
+    ### Step 4.5: (Optional) Save the experiment ###
+    experiment.to_file("async_bank_tools_trajectory_experiment", "json")
 
     ### Step 5: Run evaluation ###
-    report = await dataset.run_evaluations_async(get_response)
+    report = await experiment.run_evaluations_async(get_response)
     return report
 
 

--- a/src/strands_evals/__init__.py
+++ b/src/strands_evals/__init__.py
@@ -2,12 +2,12 @@ __version__ = "0.1.0"
 
 from . import evaluators, extractors, generators, simulation, telemetry, types
 from .case import Case
-from .dataset import Dataset
+from .experiment import Experiment
 from .simulation import ActorSimulator, UserSimulator
 from .telemetry import StrandsEvalsTelemetry, get_tracer
 
 __all__ = [
-    "Dataset",
+    "Experiment",
     "Case",
     "evaluators",
     "extractors",

--- a/src/strands_evals/case.py
+++ b/src/strands_evals/case.py
@@ -11,7 +11,7 @@ OutputT = TypeVar("OutputT")
 
 class Case(BaseModel, Generic[InputT, OutputT]):
     """
-    A single test case, representing a row in Dataset.
+    A single test case, representing a row in an Experiment.
 
     Each test case represents a single test scenario with inputs to test.
     Optionally, a test case may contains a name, expected outputs, expected trajectory, expected interactions

--- a/src/strands_evals/generators/__init__.py
+++ b/src/strands_evals/generators/__init__.py
@@ -1,3 +1,3 @@
-from .dataset_generator import DatasetGenerator
+from .experiment_generator import ExperimentGenerator
 
-__all__ = ["DatasetGenerator"]
+__all__ = ["ExperimentGenerator"]

--- a/src/strands_evals/types/evaluation_report.py
+++ b/src/strands_evals/types/evaluation_report.py
@@ -202,7 +202,7 @@ class EvaluationReport(BaseModel):
             ValueError: If the path has a non-JSON extension.
         """
         file_path = Path(path)
-        
+
         if file_path.suffix:
             if file_path.suffix != ".json":
                 raise ValueError(
@@ -232,7 +232,7 @@ class EvaluationReport(BaseModel):
             ValueError: If the file does not have a .json extension.
         """
         file_path = Path(path)
-        
+
         if file_path.suffix != ".json":
             raise ValueError(
                 f"Only .json format is supported. Got file: {path}. Please provide a path with .json extension."
@@ -240,5 +240,5 @@ class EvaluationReport(BaseModel):
 
         with open(file_path, "r") as f:
             data = json.load(f)
-        
+
         return cls.from_dict(data)


### PR DESCRIPTION
## Description
Breaking change: Renamed core classes to better reflect that they contain test cases + evaluator configuration + execution logic, not just data.

- Renamed Dataset → Experiment
- Renamed DatasetGenerator → ExperimentGenerator
- Renamed methods: from_dataset_async → from_experiment_async,
  update_current_dataset_async → update_current_experiment_async
- Updated all imports, examples, tests, and documentation
- Updated README with new API examples

Addresses beta tester feedback that "Dataset" was misleading since the construct includes more than just test case data.

**Note:** This is a pretty large PR because of all the instances of `dataset`, `Dataset`, `DatasetGenerator`, `test_dataset`, etc, that appear throughout this code base. 

## Related Issues

N/A

## Documentation PR

N/A

## Type of Change

Breaking change


## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.