### PR TITLE
feat: allow trajectoryEvaluator to get data from the traces via extractor

### DIFF
--- a/src/examples/trajectory_evaluator.py
+++ b/src/examples/trajectory_evaluator.py
@@ -86,14 +86,24 @@ async def async_descriptive_tools_trajectory_example():
         response = await agent.invoke_async(case.input)
         trajectory_evaluator.update_trajectory_description(tools_use_extractor.extract_tools_description(agent))
         return TaskOutput(
-            output=str(response), trajectory=tools_use_extractor.extract_agent_tools_used_from_messages(agent.messages)
+            output=str(response), trajectory=tools_use_extractor.extract_agent_tools_used(agent.messages)
         )
 
-        # or
-        # return {
-        #     "output": str(response),
-        #     "trajectory": helper_funcs.extract_agent_tools_used_from_messages(agent.messages),
-        # }
+        # Or construct the trajectory based on the trace for TrajectoryEvaluator
+
+        # agent = Agent(
+        #     trace_attributes={"gen_ai.conversation.id": case.session_id, "session.id": case.session_id},
+        #     tools=[get_balance, modify_balance, collect_debt],
+        #     system_prompt=bank_prompt,
+        #     callback_handler=None,
+        # )
+        # response = agent(case.input)
+        # finished_spans = memory_exporter.get_finished_spans()
+        # mapper = StrandsInMemorySessionMapper()
+        # session = mapper.map_to_session(finished_spans, session_id=case.session_id)
+        # return TaskOutput(
+        #     output=str(response), trajectory=tools_use_extractor.extract_agent_tools_used(session)
+        # )
 
     ### Step 2: Create test cases ###
     case1 = Case(


### PR DESCRIPTION
## Description
Currently, trajectoryEvaluator only extracts the toolUse data from the Strands Agent's message. Therefore added the extraction method to construct the trajectory via traces.

## Related Issues
Internal link

## Documentation PR
N/A

## Type of Change
New feature

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.