### PR TITLE
feat: Extract whether tool result was an error

### DIFF
--- a/src/strands_evals/extractors/tools_use_extractor.py
+++ b/src/strands_evals/extractors/tools_use_extractor.py
@@ -33,6 +33,7 @@ def extract_agent_tools_used_from_messages(agent_messages):
                     tool_id = tool.get("toolUseId")
                     # get the tool result from the next message
                     tool_result = None
+                    is_error = False
                     next_message_i = i + 1
                     while next_message_i < len(agent_messages):
                         next_message = agent_messages[next_message_i]
@@ -46,9 +47,12 @@ def extract_agent_tools_used_from_messages(agent_messages):
                                     tool_result_content = tool_result_dict.get("content", [])
                                     if len(tool_result_content) > 0:
                                         tool_result = tool_result_content[0].get("text")
+                                        is_error = tool_result_dict.get("status") == "error"
                                         break
 
-                    tools_used.append({"name": tool_name, "input": tool_input, "tool_result": tool_result})
+                    tools_used.append(
+                        {"name": tool_name, "input": tool_input, "tool_result": tool_result, "is_error": is_error}
+                    )
     return tools_used
 
 

--- a/tests/strands_evals/extractors/test_tools_use_extractor.py
+++ b/tests/strands_evals/extractors/test_tools_use_extractor.py
@@ -45,6 +45,7 @@ def test_tools_use_extractor_extract_from_messages_with_tools():
     assert result[0]["name"] == "calculator"
     assert result[0]["input"] == {"expression": "2+2"}
     assert result[0]["tool_result"] == "Result: 4"
+    assert result[0]["is_error"] is False
 
 
 def test_tools_use_extractor_extract_from_messages_no_tools():
@@ -57,6 +58,38 @@ def test_tools_use_extractor_extract_from_messages_no_tools():
     result = extract_agent_tools_used_from_messages(messages)
 
     assert result == []
+
+
+def test_tools_use_extractor_extract_from_messages_with_error():
+    """Test extracting tool usage from messages with error status"""
+    messages = [
+        {"role": "user", "content": [{"text": "Calculate invalid"}]},
+        {
+            "role": "assistant",
+            "content": [
+                {"toolUse": {"toolUseId": "tool_123", "name": "calculator", "input": {"expression": "invalid"}}},
+            ],
+        },
+        {
+            "role": "user",
+            "content": [
+                {
+                    "toolResult": {
+                        "status": "error",
+                        "content": [{"text": "Invalid expression"}],
+                        "toolUseId": "tool_123",
+                    }
+                }
+            ],
+        },
+    ]
+
+    result = extract_agent_tools_used_from_messages(messages)
+
+    assert len(result) == 1
+    assert result[0]["name"] == "calculator"
+    assert result[0]["tool_result"] == "Invalid expression"
+    assert result[0]["is_error"] is True
 
 
 def test_tools_use_extractor_extract_from_messages_empty():
@@ -96,6 +129,7 @@ def test_tools_use_extractor_extract_from_messages_no_tool_result():
     assert result[0]["name"] == "calculator"
     assert result[0]["input"] == {"expression": "2+2"}
     assert result[0]["tool_result"] is None
+    assert result[0]["is_error"] is False
 
 
 def test_tools_use_extractor_extract_from_messages_malformed_tool_result():


### PR DESCRIPTION
## Description
I have a custom evaluator where I want to determine whether any tool calls resulted in an error.  The tool result message does not always indicate whether it was an error.

## Type of Change

New feature

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.