### PR TITLE
fix: preserve non-ASCII characters in JSON file output

### DIFF
--- a/src/strands_evals/experiment.py
+++ b/src/strands_evals/experiment.py
@@ -577,8 +577,8 @@ class Experiment(Generic[InputT, OutputT]):
 
         file_path.parent.mkdir(parents=True, exist_ok=True)
 
-        with open(file_path, "w") as f:
-            json.dump(self.to_dict(), f, indent=2)
+        with open(file_path, "w", encoding="utf-8") as f:
+            json.dump(self.to_dict(), f, indent=2, ensure_ascii=False)
 
     @classmethod
     def from_dict(cls, data: dict, custom_evaluators: list[type[Evaluator]] | None = None):
@@ -646,7 +646,7 @@ class Experiment(Generic[InputT, OutputT]):
                 f"Only .json format is supported. Got file: {path}. Please provide a path with .json extension."
             )
 
-        with open(file_path, "r") as f:
+        with open(file_path, "r", encoding="utf-8") as f:
             data = json.load(f)
 
         return cls.from_dict(data, custom_evaluators)


### PR DESCRIPTION
## Summary

Fix Unicode escape sequences appearing in JSON files exported via `Experiment.to_file()`. Non-ASCII characters (e.g., Japanese, Chinese, Korean) are now properly preserved as readable text.

## Problem

When exporting experiments containing non-ASCII characters (e.g., Japanese text), the `to_file()` method was escaping these characters to Unicode sequences (`\uXXXX`), making the output files difficult to read:

```json
{
  "input": "\u73fe\u5728\u306e\u6642\u523b\u3092\u6559\u3048\u3066\u304f\u3060\u3055\u3044"
}
```

## Solution

- Added `ensure_ascii=False` parameter to `json.dump()` in `to_file()` method
- Explicitly specified `encoding="utf-8"` for both `to_file()` and `from_file()` methods for consistency

## Result

Non-ASCII characters are now properly preserved in the output:

```json
{
  "input": "現在の時刻を教えてください"
}
```

## Testing

- Verified Japanese, English, and mixed-language content are all correctly saved and loaded
- Confirmed no regression for ASCII-only content
- Existing tests continue to pass

## Changes

- `src/strands_evals/experiment.py`
  - `to_file()`: Added `encoding="utf-8"` and `ensure_ascii=False`
  - `from_file()`: Added `encoding="utf-8"` for consistency