### PR TITLE
fix(extractors): Add null check for toolResult in message extraction

### DIFF
--- a/src/strands_evals/extractors/tools_use_extractor.py
+++ b/src/strands_evals/extractors/tools_use_extractor.py
@@ -43,7 +43,7 @@ def extract_agent_tools_used_from_messages(agent_messages):
                             content = next_message.get("content")
                             if content:
                                 tool_result_dict = content[0].get("toolResult")
-                                if tool_result_dict.get("toolUseId") == tool_id:
+                                if tool_result_dict and tool_result_dict.get("toolUseId") == tool_id:
                                     tool_result_content = tool_result_dict.get("content", [])
                                     if len(tool_result_content) > 0:
                                         tool_result = tool_result_content[0].get("text")

--- a/tests/strands_evals/extractors/test_tools_use_extractor.py
+++ b/tests/strands_evals/extractors/test_tools_use_extractor.py
@@ -243,3 +243,38 @@ def test_tools_use_extractor_extract_tools_description_empty():
     result = extract_tools_description(mock_agent, is_short=True)
 
     assert result == {}
+
+
+def test_tools_use_extractor_extract_from_messages_user_message_without_tool_result():
+    """Test extracting tool usage when user message content lacks toolResult key."""
+    messages = [
+        {
+            "role": "assistant",
+            "content": [
+                {"toolUse": {"toolUseId": "tool_abc", "name": "calculator", "input": {"expression": "5+5"}}},
+            ],
+        },
+        {
+            "role": "user",
+            "content": [{"text": "Some user text without toolResult"}],  # No toolResult key
+        },
+        {
+            "role": "user",
+            "content": [
+                {
+                    "toolResult": {
+                        "status": "success",
+                        "content": [{"text": "Result: 10"}],
+                        "toolUseId": "tool_abc",
+                    }
+                }
+            ],
+        },
+    ]
+    result = extract_agent_tools_used_from_messages(messages)
+
+    assert len(result) == 1
+    assert result[0]["name"] == "calculator"
+    assert result[0]["input"] == {"expression": "5+5"}
+    assert result[0]["tool_result"] == "Result: 10"
+    assert result[0]["is_error"] is False


### PR DESCRIPTION

## Description
Prevent AttributeError when user message content lacks a toolResult key. The extraction loop now verifies tool_result_dict is truthy before calling .get("toolUseId"), handling cases where content[0].get("toolResult") returns None.

## Related Issues

#83 
## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

Bug fix

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.