### PR TITLE
feat: retry task executions and evaluations when throttled

### DIFF
--- a/src/strands_evals/evaluators/evaluator.py
+++ b/src/strands_evals/evaluators/evaluator.py
@@ -63,6 +63,10 @@ class Evaluator(Generic[InputT, OutputT]):
 
     @staticmethod
     def _default_aggregator(outputs: list[EvaluationOutput]) -> tuple[float, bool, str]:
+        # Handle empty outputs list to avoid division by zero
+        if not outputs:
+            return (0.0, False, "No evaluation outputs produced")
+
         avg_score = sum(o.score for o in outputs) / len(outputs)
         all_pass = all(o.test_pass for o in outputs)
         combined_reason = " | ".join(o.reason for o in outputs if o.reason)


### PR DESCRIPTION
## Description
When executing the evaluation, users would get throttled and the whole test case becomes meaningless. Therefore adding the retry mechanism to retry the case execution.

This PR adds retry logic with exponential backoff for handling throttling exceptions during evaluation execution. The changes cover both **task execution** and **evaluator execution** can be retried from throttling errors while maintaining proper error isolation.

## Summary
### Retry Configuration
  - `MAX_RETRY_ATTEMPTS = 6`
  - `INITIAL_RETRY_DELAY = 4` seconds
  - `MAX_RETRY_DELAY = 240` seconds (4 minutes)

### Changes
**- Task Execution Retry Logic**
  - **Async path (`_worker` method)**: Added retry loop around task execution with exponential backoff (4s → 8s → 16s → 32s → 64s → 128s, max 6 attempts)
  - **Sync path (`run_evaluations` method)**: Added retry loop around task execution matching async behavior
  - Both paths now retry on throttling exceptions and fail immediately on non-throttling exceptions

**- Evaluator Error Isolation**
  - Added outer try-catch blocks around evaluator retry loops in both sync and async paths
  - Non-throttling evaluator exceptions are now caught and recorded as failed evaluations (score=0)
  - One evaluator failing no longer prevents other evaluators from running
  - Preserves existing retry logic for throttling exceptions during evaluation

**- Exceptions**
  - Detected the following exception types to retry:
    - strands.types.exceptions.ModelThrottledException
    - strands.types.exceptions.EventLoopException
    - botocore.exceptions.ClientError with ThrottlingException, TooManyRequestsException, RequestLimitExceeded, ServiceUnavailable, 

**- Minor changes**
  - **Division by zero in `_default_aggregator`**: Returns `(0.0, False, "No evaluation outputs produced")` for empty outputs list

## Related Issues

https://github.com/strands-agents/evals/issues/61

## Documentation PR
N/A

## Type of Change
New feature

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.