### PR TITLE
Added CoherenceEvaluator

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,18 +348,34 @@ tool_parameter_evaluator = ToolParameterAccuracyEvaluator(
 
 ## Available Evaluators
 
-### Core Evaluators
-- **OutputEvaluator**: Flexible LLM-based evaluation with custom rubrics
-- **TrajectoryEvaluator**: Action sequence evaluation with built-in scoring tools
-- **HelpfulnessEvaluator**: Seven-level helpfulness assessment from user perspective
-- **FaithfulnessEvaluator**: Evaluates if responses are grounded in conversation history
-- **GoalSuccessRateEvaluator**: Measures if user goals were achieved
+### Output-Based Evaluators
+These evaluators work directly with inputs and outputs without requiring OpenTelemetry traces:
 
-### Specialized Evaluators
-- **ToolSelectionAccuracyEvaluator**: Evaluates appropriateness of tool choices
-- **ToolParameterAccuracyEvaluator**: Evaluates correctness of tool parameters
+- **OutputEvaluator**: Flexible LLM-based evaluation with custom rubrics
+- **TrajectoryEvaluator**: Action sequence evaluation with built-in scoring tools (supports both list-based trajectories and Session traces via extractors)
 - **InteractionsEvaluator**: Multi-agent interaction and handoff evaluation
 - **Custom Evaluators**: Extensible base class for domain-specific logic
+
+### Trace-Based Evaluators
+These evaluators require OpenTelemetry traces (Session objects) to analyze agent behavior:
+
+#### Tool-Level Evaluators
+Evaluate individual tool calls within a conversation:
+- **ToolSelectionAccuracyEvaluator**: Evaluates appropriateness of tool choices at specific points
+- **ToolParameterAccuracyEvaluator**: Evaluates correctness of tool parameters based on context
+
+#### Trace-Level Evaluators
+Evaluate the most recent turn in a conversation:
+- **HelpfulnessEvaluator**: Seven-level helpfulness assessment from user perspective
+- **FaithfulnessEvaluator**: Evaluates if responses are grounded in conversation history
+- **CoherenceEvaluator**: Assesses logical cohesion and reasoning quality with five-level scoring
+- **ConcisenessEvaluator**: Evaluates response brevity with three-level scoring
+- **ResponseRelevanceEvaluator**: Evaluates relevance of responses to user questions
+- **HarmfulnessEvaluator**: Binary evaluation for harmful content detection
+
+#### Session-Level Evaluators
+Evaluate entire conversation sessions:
+- **GoalSuccessRateEvaluator**: Measures if user goals were achieved across the full conversation
 
 ## Experiment Management and Serialization
 

--- a/src/strands_evals/evaluators/__init__.py
+++ b/src/strands_evals/evaluators/__init__.py
@@ -1,3 +1,4 @@
+from .coherence_evaluator import CoherenceEvaluator
 from .conciseness_evaluator import ConcisenessEvaluator
 from .evaluator import Evaluator
 from .faithfulness_evaluator import FaithfulnessEvaluator
@@ -24,4 +25,5 @@ __all__ = [
     "ToolSelectionAccuracyEvaluator",
     "ToolParameterAccuracyEvaluator",
     "ConcisenessEvaluator",
+    "CoherenceEvaluator",
 ]

--- a/src/strands_evals/evaluators/coherence_evaluator.py
+++ b/src/strands_evals/evaluators/coherence_evaluator.py
@@ -1,0 +1,152 @@
+from enum import Enum
+from typing import cast
+
+from pydantic import BaseModel, Field
+from strands import Agent
+from strands.models.model import Model
+from typing_extensions import Union
+
+from ..types.evaluation import EvaluationData, EvaluationOutput, InputT, OutputT
+from ..types.trace import EvaluationLevel, TextContent, ToolExecution, TraceLevelInput
+from .evaluator import Evaluator
+from .prompt_templates.coherence import get_template
+
+
+class CoherenceScore(str, Enum):
+    """Categorical coherence ratings."""
+
+    NOT_AT_ALL = "Not At All"
+    NOT_GENERALLY = "Not Generally"
+    NEUTRAL_MIXED = "Neutral/Mixed"
+    GENERALLY_YES = "Generally Yes"
+    COMPLETELY_YES = "Completely Yes"
+
+
+class CoherenceRating(BaseModel):
+    """Structured output for coherence evaluation."""
+
+    reasoning: str = Field(description="step by step reasoning to derive the final score, using no more than 250 words")
+    score: CoherenceScore = Field(description="Categorical coherence rating")
+
+
+class CoherenceEvaluator(Evaluator[InputT, OutputT]):
+    """Evaluates the logical cohesion of the assistant's response.
+    
+    This evaluator assesses whether the assistant's response maintains logical consistency,
+    flows naturally, and presents ideas in a well-organized manner. It uses an LLM-as-judge
+    approach to provide categorical ratings that are then normalized to numeric scores.
+    
+    Scores:
+    - NOT_AT_ALL (0.0): Response is completely incoherent or contradictory
+    - NOT_GENERALLY (0.25): Response has significant logical gaps or inconsistencies
+    - NEUTRAL_MIXED (0.5): Response has both coherent and incoherent elements
+    - GENERALLY_YES (0.75): Response is mostly coherent with minor reasoning issues
+    - COMPLETELY_YES (1.0): Response is fully coherent and logically consistent
+    """
+
+    evaluation_level = EvaluationLevel.TRACE_LEVEL
+
+    _score_mapping = {
+        CoherenceScore.NOT_AT_ALL: 0.0,
+        CoherenceScore.NOT_GENERALLY: 0.25,
+        CoherenceScore.NEUTRAL_MIXED: 0.5,
+        CoherenceScore.GENERALLY_YES: 0.75,
+        CoherenceScore.COMPLETELY_YES: 1.0,
+    }
+
+    def __init__(
+        self,
+        version: str = "v0",
+        model: Union[Model, str, None] = None,
+        system_prompt: str | None = None,
+        include_inputs: bool = True,
+    ):
+        super().__init__()
+        self.system_prompt = system_prompt or get_template(version).SYSTEM_PROMPT
+        self.version = version
+        self.model = model
+        self.include_inputs = include_inputs
+
+    def evaluate(self, evaluation_case: EvaluationData[InputT, OutputT]) -> list[EvaluationOutput]:
+        parsed_input = self._get_last_turn(evaluation_case)
+        prompt = self._format_prompt(parsed_input)
+        evaluator_agent = Agent(model=self.model, system_prompt=self.system_prompt, callback_handler=None)
+        result = evaluator_agent(prompt, structured_output_model=CoherenceRating)
+        return self._create_evaluation_output(result)
+
+    async def evaluate_async(self, evaluation_case: EvaluationData[InputT, OutputT]) -> list[EvaluationOutput]:
+        parsed_input = self._get_last_turn(evaluation_case)
+        prompt = self._format_prompt(parsed_input)
+        evaluator_agent = Agent(model=self.model, system_prompt=self.system_prompt, callback_handler=None)
+        result = await evaluator_agent.invoke_async(prompt, structured_output_model=CoherenceRating)
+        return self._create_evaluation_output(result)
+
+    def _create_evaluation_output(self, result) -> list[EvaluationOutput]:
+        rating = cast(CoherenceRating, result.structured_output)
+        normalized_score = self._score_mapping[rating.score]
+        return [
+            EvaluationOutput(
+                score=normalized_score,
+                test_pass=normalized_score >= 0.5,
+                reason=rating.reasoning,
+                label=rating.score,
+            )
+        ]
+
+    def _get_last_turn(self, evaluation_case: EvaluationData[InputT, OutputT]) -> TraceLevelInput:
+        """Extract the most recent turn from the conversation for evaluation."""
+        parsed_inputs = self._parse_trajectory(evaluation_case)
+        if not parsed_inputs:
+            raise ValueError(
+                "No turn-level inputs could be parsed from the trajectory. "
+                "Ensure actual_trajectory is a Session with at least one AgentInvocationSpan."
+            )
+        return parsed_inputs[-1]
+
+    def _extract_user_prompt(self, parsed_input: TraceLevelInput) -> str:
+        """Extract user prompt from last message in session history.
+
+        Args:
+            parsed_input: Trace-level input containing session history
+
+        Returns:
+            User prompt text, or empty string if not available
+        """
+        if not parsed_input.session_history:
+            return ""
+
+        last_msg = parsed_input.session_history[-1]
+        if not isinstance(last_msg, list) and self._has_text_content(last_msg):
+            first_content = last_msg.content[0]
+            if isinstance(first_content, TextContent):
+                return first_content.text
+
+        return ""
+
+    def _format_prompt(self, parsed_input: TraceLevelInput) -> str:
+        """Format evaluation prompt from parsed trace data.
+
+        Args:
+            parsed_input: Trace-level input containing agent response and session history
+
+        Returns:
+            Formatted prompt string with conversation history and target turn
+        """
+        parts = []
+
+        if parsed_input.session_history:
+            history_lines = []
+            for msg in parsed_input.session_history:
+                if isinstance(msg, list) and msg and isinstance(msg[0], ToolExecution):
+                    continue  # Skip tool execution lists
+                if not isinstance(msg, list) and self._has_text_content(msg):
+                    first_content = msg.content[0]
+                    if isinstance(first_content, TextContent):
+                        history_lines.append(f"{msg.role.value.capitalize()}: {first_content.text}")
+            history_str = "\n".join(history_lines)
+            parts.append(f"# Previous turns:\n{history_str}")
+
+        user_prompt = self._extract_user_prompt(parsed_input)
+        parts.append(f"# Target turn to evaluate:\nUser: {user_prompt}\nAssistant: {parsed_input.agent_response.text}")
+
+        return "\n\n".join(parts)

--- a/src/strands_evals/evaluators/prompt_templates/coherence/__init__.py
+++ b/src/strands_evals/evaluators/prompt_templates/coherence/__init__.py
@@ -1,0 +1,11 @@
+from . import coherence_v0
+
+VERSIONS = {
+    "v0": coherence_v0,
+}
+
+DEFAULT_VERSION = "v0"
+
+
+def get_template(version: str = DEFAULT_VERSION):
+    return VERSIONS[version]

--- a/src/strands_evals/evaluators/prompt_templates/coherence/coherence_v0.py
+++ b/src/strands_evals/evaluators/prompt_templates/coherence/coherence_v0.py
@@ -1,0 +1,23 @@
+SYSTEM_PROMPT = """You are a helpful agent that can assess LLM response according to the given rubrics.
+
+Evaluate the logical cohesion of the response based on the following criteria:
+1. Self-contradictions:
+- Does the response contradict itself or previous statements in the conversation history?
+2. Logic gaps or errors in reasoning:
+- Are there false conclusions, skipped steps, or mutually exclusive statements?
+3. Soundness of reasoning (not claims):
+- Base the evaluation on the provided assumptions, regardless of their truth.
+4. Logical cohesion vs correctness:
+- Focus on the reasoning process, not the final answer's accuracy.
+- Penalize flawed reasoning even if the answer is correct.
+5. Relevance of logical reasoning:
+- If no reasoning is required, rate the logical cohesion as 'Completely Yes' by default.
+
+Rate the logical cohesion on the following scale:
+- Not At All: Too many errors of reasoning, contradictions, or major gaps.
+- Not Generally: A few instances of coherent reasoning, but errors reduce quality.
+- Neutral/Mixed: Unclear whether the reasoning is correct or not.
+- Generally Yes: Small reasoning issues, but the main point is well-argued.
+- Completely Yes: No issues with logical cohesion. The reasoning is sound and consistent.
+
+**IMPORTANT**: The tool output ALWAYS takes priority over your own knowledge."""

--- a/tests/strands_evals/evaluators/test_coherence_evaluator.py
+++ b/tests/strands_evals/evaluators/test_coherence_evaluator.py
@@ -1,0 +1,291 @@
+from datetime import datetime
+from unittest.mock import Mock, patch
+
+import pytest
+
+from strands_evals.evaluators.coherence_evaluator import CoherenceEvaluator, CoherenceRating, CoherenceScore
+from strands_evals.types import EvaluationData
+from strands_evals.types.trace import (
+    AgentInvocationSpan,
+    EvaluationLevel,
+    Session,
+    SpanInfo,
+    Trace,
+)
+
+
+@pytest.fixture
+def evaluation_data():
+    now = datetime.now()
+    span_info = SpanInfo(session_id="test-session", start_time=now, end_time=now)
+    agent_span = AgentInvocationSpan(
+        span_info=span_info,
+        user_prompt="Explain why the sky is blue.",
+        agent_response="The sky appears blue due to Rayleigh scattering of sunlight by the atmosphere.",
+        available_tools=[],
+    )
+    trace = Trace(spans=[agent_span], trace_id="trace1", session_id="test-session")
+    session = Session(traces=[trace], session_id="test-session")
+
+    return EvaluationData(
+        input="Explain why the sky is blue.",
+        actual_output="The sky appears blue due to Rayleigh scattering of sunlight by the atmosphere.",
+        actual_trajectory=session,
+        name="test",
+    )
+
+
+def test_init_with_defaults():
+    evaluator = CoherenceEvaluator()
+
+    assert evaluator.version == "v0"
+    assert evaluator.model is None
+    assert evaluator.include_inputs is True
+    assert evaluator.system_prompt is not None
+    assert evaluator.evaluation_level == EvaluationLevel.TRACE_LEVEL
+
+
+def test_init_with_custom_values():
+    evaluator = CoherenceEvaluator(version="v1", model="gpt-4", system_prompt="Custom", include_inputs=False)
+
+    assert evaluator.version == "v1"
+    assert evaluator.model == "gpt-4"
+    assert evaluator.include_inputs is False
+    assert evaluator.system_prompt == "Custom"
+
+
+@patch("strands_evals.evaluators.coherence_evaluator.Agent")
+def test_evaluate(mock_agent_class, evaluation_data):
+    mock_agent = Mock()
+    mock_result = Mock()
+    mock_result.structured_output = CoherenceRating(
+        reasoning="The response is logically coherent with no contradictions", score=CoherenceScore.COMPLETELY_YES
+    )
+    mock_agent.return_value = mock_result
+    mock_agent_class.return_value = mock_agent
+    evaluator = CoherenceEvaluator()
+
+    result = evaluator.evaluate(evaluation_data)
+
+    assert len(result) == 1
+    assert result[0].score == 1.0
+    assert result[0].test_pass is True
+    assert result[0].reason == "The response is logically coherent with no contradictions"
+    assert result[0].label == CoherenceScore.COMPLETELY_YES
+
+
+@pytest.mark.parametrize(
+    "score,expected_value,expected_pass",
+    [
+        (CoherenceScore.NOT_AT_ALL, 0.0, False),
+        (CoherenceScore.NOT_GENERALLY, 0.25, False),
+        (CoherenceScore.NEUTRAL_MIXED, 0.5, True),
+        (CoherenceScore.GENERALLY_YES, 0.75, True),
+        (CoherenceScore.COMPLETELY_YES, 1.0, True),
+    ],
+)
+@patch("strands_evals.evaluators.coherence_evaluator.Agent")
+def test_score_mapping(mock_agent_class, evaluation_data, score, expected_value, expected_pass):
+    mock_agent = Mock()
+    mock_result = Mock()
+    mock_result.structured_output = CoherenceRating(reasoning="Test reasoning", score=score)
+    mock_agent.return_value = mock_result
+    mock_agent_class.return_value = mock_agent
+    evaluator = CoherenceEvaluator()
+
+    result = evaluator.evaluate(evaluation_data)
+
+    assert len(result) == 1
+    assert result[0].score == expected_value
+    assert result[0].test_pass == expected_pass
+    assert result[0].label == score
+
+
+@pytest.mark.asyncio
+@patch("strands_evals.evaluators.coherence_evaluator.Agent")
+async def test_evaluate_async(mock_agent_class, evaluation_data):
+    mock_agent = Mock()
+
+    async def mock_invoke_async(*args, **kwargs):
+        mock_result = Mock()
+        mock_result.structured_output = CoherenceRating(
+            reasoning="The response is logically coherent with no contradictions", score=CoherenceScore.COMPLETELY_YES
+        )
+        return mock_result
+
+    mock_agent.invoke_async = mock_invoke_async
+    mock_agent_class.return_value = mock_agent
+    evaluator = CoherenceEvaluator()
+
+    result = await evaluator.evaluate_async(evaluation_data)
+
+    assert len(result) == 1
+    assert result[0].score == 1.0
+    assert result[0].test_pass is True
+    assert result[0].reason == "The response is logically coherent with no contradictions"
+    assert result[0].label == CoherenceScore.COMPLETELY_YES
+
+
+def test_coherence_score_enum_values():
+    """Test that CoherenceScore enum has all expected values."""
+    assert CoherenceScore.NOT_AT_ALL.value == "Not At All"
+    assert CoherenceScore.NOT_GENERALLY.value == "Not Generally"
+    assert CoherenceScore.NEUTRAL_MIXED.value == "Neutral/Mixed"
+    assert CoherenceScore.GENERALLY_YES.value == "Generally Yes"
+    assert CoherenceScore.COMPLETELY_YES.value == "Completely Yes"
+
+
+def test_score_mapping_completeness():
+    """Test that all CoherenceScore enum values are in the score mapping."""
+    evaluator = CoherenceEvaluator()
+    for score in CoherenceScore:
+        assert score in evaluator._score_mapping
+
+
+@patch("strands_evals.evaluators.coherence_evaluator.Agent")
+def test_evaluate_with_contradictory_response(mock_agent_class, evaluation_data):
+    """Test evaluation of a response with contradictions."""
+    # Modify evaluation data to have a contradictory response
+    evaluation_data.actual_trajectory.traces[0].spans[
+        0
+    ].agent_response = "Exercise is good for health. However, exercise is bad for health."
+
+    mock_agent = Mock()
+    mock_result = Mock()
+    mock_result.structured_output = CoherenceRating(
+        reasoning="The response contains contradictions about exercise", score=CoherenceScore.NOT_AT_ALL
+    )
+    mock_agent.return_value = mock_result
+    mock_agent_class.return_value = mock_agent
+    evaluator = CoherenceEvaluator()
+
+    result = evaluator.evaluate(evaluation_data)
+
+    assert len(result) == 1
+    assert result[0].score == 0.0
+    assert result[0].test_pass is False
+    assert result[0].label == CoherenceScore.NOT_AT_ALL
+
+
+@patch("strands_evals.evaluators.coherence_evaluator.Agent")
+def test_evaluate_with_reasoning_gaps(mock_agent_class, evaluation_data):
+    """Test evaluation of a response with reasoning gaps."""
+    mock_agent = Mock()
+    mock_result = Mock()
+    mock_result.structured_output = CoherenceRating(
+        reasoning="The response has some logical gaps but the main point is clear", score=CoherenceScore.GENERALLY_YES
+    )
+    mock_agent.return_value = mock_result
+    mock_agent_class.return_value = mock_agent
+    evaluator = CoherenceEvaluator()
+
+    result = evaluator.evaluate(evaluation_data)
+
+    assert len(result) == 1
+    assert result[0].score == 0.75
+    assert result[0].test_pass is True
+    assert result[0].label == CoherenceScore.GENERALLY_YES
+
+
+def test_coherence_rating_model():
+    """Test the CoherenceRating Pydantic model."""
+    rating = CoherenceRating(
+        reasoning="This is a test reasoning with less than 250 words", score=CoherenceScore.COMPLETELY_YES
+    )
+
+    assert rating.reasoning == "This is a test reasoning with less than 250 words"
+    assert rating.score == CoherenceScore.COMPLETELY_YES
+
+
+def test_get_last_turn_with_empty_trajectory():
+    """Test that _get_last_turn raises ValueError with empty trajectory."""
+    evaluator = CoherenceEvaluator()
+    trace = Trace(spans=[], trace_id="trace1", session_id="test-session")
+    session = Session(traces=[trace], session_id="test-session")
+
+    evaluation_data = EvaluationData(input="Test", actual_output="Test", actual_trajectory=session, name="test")
+
+    with pytest.raises(ValueError, match="No turn-level inputs could be parsed"):
+        evaluator._get_last_turn(evaluation_data)
+
+
+@patch("strands_evals.evaluators.coherence_evaluator.Agent")
+def test_format_prompt_includes_conversation_history(mock_agent_class, evaluation_data):
+    """Test that the formatted prompt includes conversation history."""
+    mock_agent = Mock()
+    mock_result = Mock()
+    mock_result.structured_output = CoherenceRating(reasoning="Test", score=CoherenceScore.COMPLETELY_YES)
+    mock_agent.return_value = mock_result
+    mock_agent_class.return_value = mock_agent
+
+    evaluator = CoherenceEvaluator()
+    parsed_input = evaluator._get_last_turn(evaluation_data)
+    formatted_prompt = evaluator._format_prompt(parsed_input)
+
+    # Check that the prompt contains the expected sections
+    assert "Target turn to evaluate:" in formatted_prompt
+    assert "User:" in formatted_prompt
+    assert "Assistant:" in formatted_prompt
+    assert evaluation_data.input in formatted_prompt
+    assert evaluation_data.actual_output in formatted_prompt
+
+
+def test_extract_user_prompt_with_session_history():
+    """Test _extract_user_prompt extracts the user prompt from session history."""
+    evaluator = CoherenceEvaluator()
+    now = datetime.now()
+    span_info = SpanInfo(session_id="test-session", start_time=now, end_time=now)
+    agent_span = AgentInvocationSpan(
+        span_info=span_info,
+        user_prompt="Test prompt",
+        agent_response="Test response",
+        available_tools=[],
+    )
+    trace = Trace(spans=[agent_span], trace_id="trace1", session_id="test-session")
+    session = Session(traces=[trace], session_id="test-session")
+
+    evaluation_data = EvaluationData(
+        input="Test prompt", actual_output="Test response", actual_trajectory=session, name="test"
+    )
+
+    parsed_input = evaluator._get_last_turn(evaluation_data)
+    user_prompt = evaluator._extract_user_prompt(parsed_input)
+
+    # Should extract the user prompt from session history
+    assert user_prompt == "Test prompt"
+
+
+@pytest.mark.parametrize(
+    "model_input,expected_model",
+    [
+        (None, None),
+        ("gpt-4", "gpt-4"),
+        ("us.anthropic.claude-sonnet-4-20250514-v1:0", "us.anthropic.claude-sonnet-4-20250514-v1:0"),
+    ],
+)
+def test_init_with_different_models(model_input, expected_model):
+    """Test initialization with different model types."""
+    evaluator = CoherenceEvaluator(model=model_input)
+    assert evaluator.model == expected_model
+
+
+def test_system_prompt_contains_evaluation_criteria():
+    """Test that the system prompt contains key evaluation criteria."""
+    evaluator = CoherenceEvaluator()
+
+    # Check for key criteria in the system prompt
+    assert "Self-contradictions" in evaluator.system_prompt
+    assert "Logic gaps or errors" in evaluator.system_prompt
+    assert "Soundness of reasoning" in evaluator.system_prompt
+    assert "Logical cohesion vs correctness" in evaluator.system_prompt
+    assert "Relevance of logical reasoning" in evaluator.system_prompt
+
+    # Check for scoring scale
+    assert "Not At All" in evaluator.system_prompt
+    assert "Not Generally" in evaluator.system_prompt
+    assert "Neutral/Mixed" in evaluator.system_prompt
+    assert "Generally Yes" in evaluator.system_prompt
+    assert "Completely Yes" in evaluator.system_prompt
+
+    # Check for important note
+    assert "tool output ALWAYS takes priority" in evaluator.system_prompt


### PR DESCRIPTION
## Description
Added Coherence evaluator which evaluates the logical cohesion and reasoning quality of agent responses with five-level scoring:

- NOT_AT_ALL = "Not At All"
- NOT_GENERALLY = "Not Generally"
- NEUTRAL_MIXED = "Neutral/Mixed"
- GENERALLY_YES = "Generally Yes"
- COMPLETELY_YES = "Completely Yes"

The evaluator is trace_level, which only contains the last prompt and the response.

## Related Issues

https://github.com/strands-agents/evals/issues/101

## Documentation PR

TBD

## Type of Change
New feature

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.