### PR TITLE
fix: retrieve multiple text contentBlock in messageConent

### DIFF
--- a/src/strands_evals/evaluators/conciseness_evaluator.py
+++ b/src/strands_evals/evaluators/conciseness_evaluator.py
@@ -7,7 +7,7 @@ from strands.models.model import Model
 from typing_extensions import Union
 
 from ..types.evaluation import EvaluationData, EvaluationOutput, InputT, OutputT
-from ..types.trace import EvaluationLevel, TextContent, ToolExecution, TraceLevelInput
+from ..types.trace import EvaluationLevel, ToolExecution, TraceLevelInput
 from .evaluator import Evaluator
 from .prompt_templates.conciseness import get_template
 
@@ -101,9 +101,7 @@ class ConcisenessEvaluator(Evaluator[InputT, OutputT]):
 
         last_msg = parsed_input.session_history[-1]
         if not isinstance(last_msg, list) and self._has_text_content(last_msg):
-            first_content = last_msg.content[0]
-            if isinstance(first_content, TextContent):
-                return first_content.text
+            return self._extract_text_content(last_msg)
 
         return ""
 
@@ -124,9 +122,8 @@ class ConcisenessEvaluator(Evaluator[InputT, OutputT]):
                 if isinstance(msg, list) and msg and isinstance(msg[0], ToolExecution):
                     continue  # Skip tool execution lists
                 if not isinstance(msg, list) and self._has_text_content(msg):
-                    first_content = msg.content[0]
-                    if isinstance(first_content, TextContent):
-                        history_lines.append(f"{msg.role.value.capitalize()}: {first_content.text}")
+                    text = self._extract_text_content(msg)
+                    history_lines.append(f"{msg.role.value.capitalize()}: {text}")
             history_str = "\n".join(history_lines)
             parts.append(f"# Previous turns:\n{history_str}")
 

--- a/src/strands_evals/evaluators/evaluator.py
+++ b/src/strands_evals/evaluators/evaluator.py
@@ -131,14 +131,37 @@ class Evaluator(Generic[InputT, OutputT]):
             msg: Message object to check (UserMessage or AssistantMessage)
 
         Returns:
-            True if msg has content attribute with at least one item that is TextContent
+            True if msg has content attribute with at least one TextContent block.
+            Note: TextContent may not be at index 0 due to tool calls or other content types.
         """
-        return (
-            hasattr(msg, "content")
-            and bool(msg.content)
-            and len(msg.content) > 0
-            and isinstance(msg.content[0], TextContent)
-        )
+        if not hasattr(msg, "content") or not msg.content:
+            return False
+
+        # Check if ANY content block is TextContent, not just the first
+        return any(isinstance(content_block, TextContent) for content_block in msg.content)
+
+    def _extract_text_content(self, msg: UserMessage | AssistantMessage) -> str:
+        """Extract and concatenate text from all TextContent blocks in a message.
+
+        Args:
+            msg: Message object containing content blocks
+
+        Returns:
+            Concatenated text from all TextContent blocks, or empty string if none found.
+            Multiple text blocks are joined with a space.
+            Note: Iterates through all content blocks since TextContent may not be first.
+        """
+        if not hasattr(msg, "content") or not msg.content:
+            return ""
+
+        # Collect all TextContent blocks - there could be multiple
+        text_blocks = []
+        for content_block in msg.content:
+            if isinstance(content_block, TextContent):
+                text_blocks.append(content_block.text)
+
+        # Join multiple text blocks with space
+        return " ".join(text_blocks) if text_blocks else ""
 
     @classmethod
     def get_type_name(cls) -> str:

--- a/src/strands_evals/evaluators/faithfulness_evaluator.py
+++ b/src/strands_evals/evaluators/faithfulness_evaluator.py
@@ -108,7 +108,7 @@ class FaithfulnessEvaluator(Evaluator[InputT, OutputT]):
                         history_lines.append(f"Action: {tool_exec.tool_call.name}({tool_exec.tool_call.arguments})")
                         history_lines.append(f"Tool: {tool_exec.tool_result.content}")
                 else:
-                    text = msg.content[0].text if msg.content and hasattr(msg.content[0], "text") else ""
+                    text = self._extract_text_content(msg) if self._has_text_content(msg) else ""
                     history_lines.append(f"{msg.role.value.capitalize()}: {text}")
             history_str = "\n".join(history_lines)
             parts.append(f"# Conversation History:\n{history_str}")

--- a/src/strands_evals/evaluators/helpfulness_evaluator.py
+++ b/src/strands_evals/evaluators/helpfulness_evaluator.py
@@ -7,7 +7,7 @@ from strands.models.model import Model
 from typing_extensions import Union
 
 from ..types.evaluation import EvaluationData, EvaluationOutput, InputT, OutputT
-from ..types.trace import EvaluationLevel, TextContent, ToolExecution, TraceLevelInput
+from ..types.trace import EvaluationLevel, ToolExecution, TraceLevelInput
 from .evaluator import Evaluator
 from .prompt_templates.helpfulness import get_template
 
@@ -115,9 +115,7 @@ class HelpfulnessEvaluator(Evaluator[InputT, OutputT]):
 
         last_msg = parsed_input.session_history[-1]
         if not isinstance(last_msg, list) and self._has_text_content(last_msg):
-            first_content = last_msg.content[0]
-            if isinstance(first_content, TextContent):
-                return first_content.text
+            return self._extract_text_content(last_msg)
 
         return ""
 
@@ -138,9 +136,8 @@ class HelpfulnessEvaluator(Evaluator[InputT, OutputT]):
                 if isinstance(msg, list) and msg and isinstance(msg[0], ToolExecution):
                     continue  # Skip tool execution lists
                 if not isinstance(msg, list) and self._has_text_content(msg):
-                    first_content = msg.content[0]
-                    if isinstance(first_content, TextContent):
-                        history_lines.append(f"{msg.role.value.capitalize()}: {first_content.text}")
+                    text = self._extract_text_content(msg)
+                    history_lines.append(f"{msg.role.value.capitalize()}: {text}")
             history_str = "\n".join(history_lines)
             parts.append(f"# Previous turns:\n{history_str}")
 

--- a/src/strands_evals/evaluators/response_relevance_evaluator.py
+++ b/src/strands_evals/evaluators/response_relevance_evaluator.py
@@ -8,7 +8,7 @@ from strands.models.model import Model
 from typing_extensions import Union
 
 from ..types.evaluation import EvaluationData, EvaluationOutput, InputT, OutputT
-from ..types.trace import EvaluationLevel, TextContent, ToolExecution, TraceLevelInput
+from ..types.trace import EvaluationLevel, ToolExecution, TraceLevelInput
 from .evaluator import Evaluator
 from .prompt_templates.response_relevance import get_template
 
@@ -106,9 +106,7 @@ class ResponseRelevanceEvaluator(Evaluator[InputT, OutputT]):
 
         last_msg = parsed_input.session_history[-1]
         if not isinstance(last_msg, list) and self._has_text_content(last_msg):
-            first_content = last_msg.content[0]
-            if isinstance(first_content, TextContent):
-                return first_content.text
+            return self._extract_text_content(last_msg)
 
         return ""
 
@@ -129,9 +127,8 @@ class ResponseRelevanceEvaluator(Evaluator[InputT, OutputT]):
                 if isinstance(msg, list) and msg and isinstance(msg[0], ToolExecution):
                     continue  # Skip tool execution lists
                 if not isinstance(msg, list) and self._has_text_content(msg):
-                    first_content = msg.content[0]
-                    if isinstance(first_content, TextContent):
-                        history_lines.append(f"{msg.role.value.capitalize()}: {first_content.text}")
+                    text = self._extract_text_content(msg)
+                    history_lines.append(f"{msg.role.value.capitalize()}: {text}")
             history_str = "\n".join(history_lines)
             parts.append(f"# Previous turns:\n{history_str}")
 

--- a/src/strands_evals/evaluators/tool_parameter_accuracy_evaluator.py
+++ b/src/strands_evals/evaluators/tool_parameter_accuracy_evaluator.py
@@ -107,7 +107,7 @@ class ToolParameterAccuracyEvaluator(Evaluator[InputT, OutputT]):
                         history_lines.append(f"Action: {tool_exec.tool_call.name}({tool_exec.tool_call.arguments})")
                         history_lines.append(f"Tool: {tool_exec.tool_result.content}")
                 else:
-                    text = msg.content[0].text if msg.content and hasattr(msg.content[0], "text") else ""
+                    text = self._extract_text_content(msg) if self._has_text_content(msg) else ""
                     history_lines.append(f"{msg.role.value.capitalize()}: {text}")
             history_str = "\n".join(history_lines)
             parts.append(f"## Previous conversation history\n{history_str}")

--- a/src/strands_evals/evaluators/tool_selection_accuracy_evaluator.py
+++ b/src/strands_evals/evaluators/tool_selection_accuracy_evaluator.py
@@ -107,7 +107,7 @@ class ToolSelectionAccuracyEvaluator(Evaluator[InputT, OutputT]):
                         history_lines.append(f"Action: {tool_exec.tool_call.name}({tool_exec.tool_call.arguments})")
                         history_lines.append(f"Tool: {tool_exec.tool_result.content}")
                 else:
-                    text = msg.content[0].text if msg.content and hasattr(msg.content[0], "text") else ""
+                    text = self._extract_text_content(msg) if self._has_text_content(msg) else ""
                     history_lines.append(f"{msg.role.value.capitalize()}: {text}")
             history_str = "\n".join(history_lines)
             parts.append(f"## Previous conversation history\n{history_str}")

--- a/src/strands_evals/extractors/tools_use_extractor.py
+++ b/src/strands_evals/extractors/tools_use_extractor.py
@@ -43,13 +43,24 @@ def extract_agent_tools_used_from_messages(agent_messages):
                             if next_message.get("role") == "user":
                                 content = next_message.get("content")
                                 if content:
-                                    tool_result_dict = content[0].get("toolResult")
+                                    # Find toolResult in content blocks - may not be at index 0
+                                    tool_result_dict = None
+                                    for content_block in content:
+                                        if "toolResult" in content_block:
+                                            tool_result_dict = content_block.get("toolResult")
+                                            break
+
                                     if tool_result_dict and tool_result_dict.get("toolUseId") == tool_id:
                                         tool_result_content = tool_result_dict.get("content", [])
-                                        if len(tool_result_content) > 0:
-                                            tool_result = tool_result_content[0].get("text")
-                                            is_error = tool_result_dict.get("status") == "error"
-                                            break
+                                        # Find first text in tool result content - may not be at index 0
+                                        tool_result = None
+                                        if tool_result_content:
+                                            for result_item in tool_result_content:
+                                                if isinstance(result_item, dict) and "text" in result_item:
+                                                    tool_result = result_item.get("text")
+                                                    break
+                                        is_error = tool_result_dict.get("status") == "error"
+                                        break
 
                         tools_used.append(
                             {"name": tool_name, "input": tool_input, "tool_result": tool_result, "is_error": is_error}


### PR DESCRIPTION
## Description
Our sessionMapper only reads and parse the first text contentBlock, but there are cases where multiple multiple text contentBlocks exists. Therefore adjust the parsing logic to detect multiple text contentBlocks.

`Note`:
multi-modal contentBlcoks parsing is out of scope as multi-modal support will be visited in the future.

## Related Issues

https://github.com/strands-agents/evals/issues/130

## Documentation PR

N/A

## Type of Change

Bug fix

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.