### PR TITLE
fix: handle parallel tool calls during tool extraction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ dataset_files
 report_files
 .venv
 *.DS_Store*
+uv.lock

--- a/src/strands_evals/evaluators/coherence_evaluator.py
+++ b/src/strands_evals/evaluators/coherence_evaluator.py
@@ -31,11 +31,11 @@ class CoherenceRating(BaseModel):
 
 class CoherenceEvaluator(Evaluator[InputT, OutputT]):
     """Evaluates the logical cohesion of the assistant's response.
-    
+
     This evaluator assesses whether the assistant's response maintains logical consistency,
     flows naturally, and presents ideas in a well-organized manner. It uses an LLM-as-judge
     approach to provide categorical ratings that are then normalized to numeric scores.
-    
+
     Scores:
     - NOT_AT_ALL (0.0): Response is completely incoherent or contradictory
     - NOT_GENERALLY (0.25): Response has significant logical gaps or inconsistencies


### PR DESCRIPTION
## Description
The previous tool use extraction logic assumed a single tool use / result per turn, and silently dropped any parallel tool calls.

## Type of Change

Bug fix

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.