### PR TITLE
fix: update finalize condition for workflow execution

### DIFF
--- a/.github/workflows/strands-command.yml
+++ b/.github/workflows/strands-command.yml
@@ -79,7 +79,7 @@ jobs:
           write_permission: 'false'
 
   finalize:
-    if: always()
+    if: always() && (startsWith(github.event.comment.body, '/strands') || github.event_name == 'workflow_dispatch')
     needs: [setup-and-process, execute-readonly-agent]
     permissions:
       contents: write


### PR DESCRIPTION
Run Strands command only for valid invocations since we are getting failed workflows for no reason

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.