### PR TITLE
feat: added Langchain mappers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,13 @@ dev = [
 
 langfuse = ["langfuse>=2.0.0,<3"]
 otel = ["opentelemetry-exporter-otlp-proto-http>=1.30.0,<2.0.0"]
+langchain = [
+    "langchain>=0.3.0",
+    "langchain-aws>=0.2.0",
+    "langgraph>=0.2.0",
+    "openinference-instrumentation-langchain>=0.1.0",
+    "opentelemetry-instrumentation-langchain>=0.40.0,<0.50.0",
+]
 
 [tool.ruff]
 line-length = 120
@@ -54,7 +61,7 @@ include = ["src/**/*.py", "tests/**/*.py", "tests_integ/**/*.py"]
 [tool.hatch.envs.hatch-test]
 installer = "uv"
 extra-args = ["-n", "auto", "-vv"]
-features = ["otel", "langfuse"]
+features = ["otel", "langfuse", "langchain"]
 dependencies = [
     "pytest>=8.0.0,<10.0.0",
     "pytest-cov>=7.0.0,<8.0.0",

--- a/src/strands_evals/mappers/__init__.py
+++ b/src/strands_evals/mappers/__init__.py
@@ -1,7 +1,23 @@
 """Converters for transforming telemetry data to Session format."""
 
+from .cloudwatch_parser import CloudWatchLogsParser, parse_cloudwatch_logs
 from .cloudwatch_session_mapper import CloudWatchSessionMapper
+from .langchain_otel_session_mapper import LangChainOtelSessionMapper
+from .openinference_session_mapper import OpenInferenceSessionMapper
 from .session_mapper import SessionMapper
 from .strands_in_memory_session_mapper import GenAIConventionVersion, StrandsInMemorySessionMapper
+from .utils import detect_otel_mapper, get_scope_name, readable_spans_to_dicts
 
-__all__ = ["CloudWatchSessionMapper", "GenAIConventionVersion", "SessionMapper", "StrandsInMemorySessionMapper"]
+__all__ = [
+    "CloudWatchLogsParser",
+    "CloudWatchSessionMapper",
+    "GenAIConventionVersion",
+    "LangChainOtelSessionMapper",
+    "OpenInferenceSessionMapper",
+    "SessionMapper",
+    "StrandsInMemorySessionMapper",
+    "detect_otel_mapper",
+    "get_scope_name",
+    "parse_cloudwatch_logs",
+    "readable_spans_to_dicts",
+]

--- a/src/strands_evals/mappers/cloudwatch_parser.py
+++ b/src/strands_evals/mappers/cloudwatch_parser.py
@@ -1,0 +1,226 @@
+"""Parser for normalizing CloudWatch/ADOT logs to standard span format.
+
+This parser converts raw CloudWatch logs (which may contain spans, events, or both)
+into the normalized format expected by mappers - matching the output of
+`readable_spans_to_dicts()`.
+
+CloudWatch logs can have:
+1. SPAN records (with startTimeUnixNano, endTimeUnixNano) + EVENT records
+2. Only EVENT records (common for Strands telemetry)
+
+The parser handles both cases, creating synthetic spans from events when needed.
+"""
+
+import logging
+from collections import defaultdict
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_SESSION_ID = "default_session"
+
+
+class CloudWatchLogsParser:
+    """Normalizes CloudWatch/ADOT logs to standard span dict format.
+
+    Converts raw CloudWatch logs to match the output format of `readable_spans_to_dicts()`:
+    - snake_case field names (trace_id, span_id, parent_span_id)
+    - Events attached to spans as span_events[]
+    - Consistent structure regardless of input format
+
+    Example:
+        >>> raw_logs = cloudwatch_provider.fetch_logs()
+        >>> parser = CloudWatchLogsParser(raw_logs)
+        >>> normalized = parser.parse()
+        >>> mapper = detect_otel_mapper(normalized)
+        >>> session = mapper.map_to_session(normalized, session_id)
+    """
+
+    def __init__(self, raw_logs: list[dict]):
+        """Initialize parser with raw CloudWatch logs.
+
+        Args:
+            raw_logs: List of raw JSON records from CloudWatch Logs Insights
+        """
+        self.raw_logs = raw_logs
+
+    def parse(self) -> list[dict]:
+        """Parse CloudWatch logs to normalized span format.
+
+        Returns:
+            List of normalized span dicts matching readable_spans_to_dicts() format
+        """
+        if not self.raw_logs:
+            return []
+
+        # Separate spans from events
+        spans_by_id: dict[str, dict] = {}
+        events_by_span_id: dict[str, list[dict]] = defaultdict(list)
+
+        for record in self.raw_logs:
+            if self._is_event(record):
+                event = self._normalize_event(record)
+                if event:
+                    span_id = event.get("span_id", "")
+                    events_by_span_id[span_id].append(event)
+            elif self._is_span(record):
+                span = self._normalize_span(record)
+                if span:
+                    spans_by_id[span["span_id"]] = span
+            # Skip other log records (application logs, etc.)
+
+        # If we have spans, associate events with them
+        if spans_by_id:
+            for span_id, span in spans_by_id.items():
+                span["span_events"] = events_by_span_id.get(span_id, [])
+            return list(spans_by_id.values())
+
+        # No spans - create synthetic spans from events
+        # Group events by span_id to create one span per event group
+        result = []
+        for span_id, events in events_by_span_id.items():
+            if not events:
+                continue
+            # Use first event to create synthetic span
+            first_event = events[0]
+            synthetic_span = self._create_synthetic_span(span_id, events, first_event)
+            result.append(synthetic_span)
+
+        return result
+
+    def _is_event(self, record: dict) -> bool:
+        """Check if record is an OTEL event (has event.name attribute)."""
+        if not isinstance(record, dict):
+            return False
+
+        # Check various event name locations
+        if "EventName" in record or "eventName" in record:
+            return True
+
+        attrs = record.get("attributes", {})
+        if isinstance(attrs, dict) and "event.name" in attrs:
+            return True
+
+        return False
+
+    def _is_span(self, record: dict) -> bool:
+        """Check if record is an OTEL span (has start/end time)."""
+        if not isinstance(record, dict):
+            return False
+
+        # Spans have startTimeUnixNano or start_time
+        has_start = "startTimeUnixNano" in record or "start_time" in record
+        has_end = "endTimeUnixNano" in record or "end_time" in record
+
+        return has_start and has_end
+
+    def _normalize_event(self, record: dict) -> dict | None:
+        """Normalize a CloudWatch event record."""
+        try:
+            # Extract event name from various locations
+            event_name = (
+                record.get("EventName") or record.get("eventName") or record.get("attributes", {}).get("event.name", "")
+            )
+
+            # Extract span_id (camelCase in CloudWatch)
+            span_id = record.get("spanId") or record.get("span_id", "")
+
+            # Extract timestamp
+            timestamp = (
+                record.get("timeUnixNano") or record.get("time_unix_nano") or record.get("observedTimeUnixNano") or 0
+            )
+
+            return {
+                "event_name": event_name,
+                "span_id": span_id,
+                "timestamp": timestamp,
+                "attributes": record.get("attributes", {}),
+                "body": record.get("body", {}),
+            }
+        except Exception as e:
+            logger.warning(f"Failed to normalize event: {e}")
+            return None
+
+    def _normalize_span(self, record: dict) -> dict | None:
+        """Normalize a CloudWatch span record to standard format."""
+        try:
+            # Normalize field names (camelCase → snake_case)
+            trace_id = record.get("traceId") or record.get("trace_id", "")
+            span_id = record.get("spanId") or record.get("span_id", "")
+            parent_span_id = record.get("parentSpanId") or record.get("parent_span_id")
+
+            # Normalize timestamps
+            start_time = record.get("startTimeUnixNano") or record.get("start_time", 0)
+            end_time = record.get("endTimeUnixNano") or record.get("end_time", 0)
+
+            # Extract scope
+            scope = record.get("scope", {})
+            if not isinstance(scope, dict):
+                scope = {"name": "", "version": ""}
+
+            # Extract status
+            status = record.get("status", {})
+            if not isinstance(status, dict):
+                status = {"code": "UNSET"}
+
+            return {
+                "trace_id": trace_id,
+                "span_id": span_id,
+                "parent_span_id": parent_span_id,
+                "name": record.get("name", ""),
+                "start_time": start_time,
+                "end_time": end_time,
+                "attributes": record.get("attributes", {}),
+                "scope": {
+                    "name": scope.get("name", ""),
+                    "version": scope.get("version", ""),
+                },
+                "status": {"code": status.get("code", "UNSET")},
+                "span_events": [],  # Will be populated later
+            }
+        except Exception as e:
+            logger.warning(f"Failed to normalize span: {e}")
+            return None
+
+    def _create_synthetic_span(self, span_id: str, events: list[dict], first_event: dict) -> dict:
+        """Create a synthetic span from events when no span records exist."""
+        # Get trace_id from the raw logs (need to find matching record)
+        trace_id = ""
+        for record in self.raw_logs:
+            if record.get("spanId") == span_id or record.get("span_id") == span_id:
+                trace_id = record.get("traceId") or record.get("trace_id", "")
+                break
+
+        # Get scope from event name
+        event_name = first_event.get("event_name", "")
+        scope_name = first_event.get("attributes", {}).get("event.name", event_name)
+
+        # Use event timestamp for span times
+        timestamp = first_event.get("timestamp", 0)
+
+        return {
+            "trace_id": trace_id,
+            "span_id": span_id,
+            "parent_span_id": None,
+            "name": event_name,
+            "start_time": timestamp,
+            "end_time": timestamp,
+            "attributes": first_event.get("attributes", {}),
+            "scope": {
+                "name": scope_name,
+                "version": "",
+            },
+            "status": {"code": "OK"},
+            "span_events": events,
+        }
+
+
+def parse_cloudwatch_logs(raw_logs: list[dict]) -> list[dict]:
+    """Convenience function to parse CloudWatch logs.
+
+    Args:
+        raw_logs: Raw CloudWatch log records
+
+    Returns:
+        Normalized span dicts matching readable_spans_to_dicts() format
+    """
+    return CloudWatchLogsParser(raw_logs).parse()

--- a/src/strands_evals/mappers/cloudwatch_session_mapper.py
+++ b/src/strands_evals/mappers/cloudwatch_session_mapper.py
@@ -1,4 +1,8 @@
-"""CloudWatch session mapper — converts CW Logs Insights records to Session format."""
+"""CloudWatch session mapper - converts normalized CloudWatch spans to Session format.
+
+This mapper handles Strands telemetry data that has been normalized by CloudWatchLogsParser.
+It expects spans in the normalized format with span_events[].body containing input/output messages.
+"""
 
 import json
 import logging
@@ -7,6 +11,7 @@ from datetime import datetime, timezone
 from typing import Any
 
 from ..mappers.session_mapper import SessionMapper
+from ..mappers.utils import get_body
 from ..types.trace import (
     AgentInvocationSpan,
     AssistantMessage,
@@ -28,109 +33,159 @@ logger = logging.getLogger(__name__)
 
 
 class CloudWatchSessionMapper(SessionMapper):
-    """Maps CloudWatch Logs Insights records to Session format.
+    """Maps normalized CloudWatch spans to Session format.
 
-    Parses body.input/output messages from OTEL log records emitted by
-    Strands agent runtimes and builds typed Session objects for evaluation.
+    This mapper handles Strands telemetry data. It expects spans in the normalized
+    format produced by CloudWatchLogsParser:
+    - snake_case field names (trace_id, span_id)
+    - Messages in span_events[].body.input/output.messages
+
+    For raw CloudWatch logs, use CloudWatchLogsParser first to normalize.
     """
 
-    def map_to_session(self, records: list[dict[str, Any]], session_id: str) -> Session:
-        """Group log records by traceId, convert each group to a Trace, return a Session."""
+    def map_to_session(self, spans: list[dict[str, Any]], session_id: str) -> Session:
+        """Map normalized spans to Session format.
+
+        Args:
+            spans: Normalized span dicts from CloudWatchLogsParser
+            session_id: Session identifier
+
+        Returns:
+            Session object ready for evaluation
+        """
+        # Group spans by trace_id
         traces_by_id: dict[str, list[dict[str, Any]]] = defaultdict(list)
-        for record in records:
-            trace_id = record.get("traceId", "")
-            if not trace_id:
-                continue
-            traces_by_id[trace_id].append(record)
+        for span in spans:
+            # Support both normalized (trace_id) and raw (traceId) formats
+            trace_id = span.get("trace_id") or span.get("traceId", "")
+            if trace_id:
+                traces_by_id[trace_id].append(span)
 
         traces: list[Trace] = []
-        for trace_id, trace_records in traces_by_id.items():
-            trace = self._convert_trace(trace_id, trace_records, session_id)
+        for trace_id, trace_spans in traces_by_id.items():
+            trace = self._convert_trace(trace_id, trace_spans, session_id)
             if trace.spans:
                 traces.append(trace)
 
         return Session(session_id=session_id, traces=traces)
 
-    def _convert_trace(self, trace_id: str, records: list[dict[str, Any]], session_id: str) -> Trace:
-        """Convert a group of log records (same traceId) into a Trace with typed spans."""
-        sorted_records = sorted(records, key=lambda r: r.get("timeUnixNano", 0))
+    def _convert_trace(self, trace_id: str, spans: list[dict[str, Any]], session_id: str) -> Trace:
+        """Convert spans with the same trace_id into a Trace with typed spans."""
+        # Sort by start_time or timestamp
+        sorted_spans = sorted(spans, key=lambda s: s.get("start_time") or s.get("timeUnixNano", 0))
 
-        spans: list[InferenceSpan | ToolExecutionSpan | AgentInvocationSpan] = []
+        result_spans: list[InferenceSpan | ToolExecutionSpan | AgentInvocationSpan] = []
 
-        # Collect all tool calls and results across records
+        # Collect all tool calls and results
         all_tool_calls: dict[str, ToolCall] = {}
         all_tool_results: dict[str, ToolResult] = {}
 
-        for record in sorted_records:
-            if not isinstance(record.get("body"), dict):
+        for span in sorted_spans:
+            body = get_body(span)
+            if not body:
                 continue
 
-            for tc in self._extract_tool_calls(record):
+            for tc in self._extract_tool_calls(body):
                 if tc.tool_call_id:
                     all_tool_calls[tc.tool_call_id] = tc
 
-            for tr in self._extract_tool_results(record):
+            for tr in self._extract_tool_results(body):
                 if tr.tool_call_id:
                     all_tool_results[tr.tool_call_id] = tr
 
-        # Create InferenceSpans (one per record with parseable body)
-        for record in sorted_records:
-            if not isinstance(record.get("body"), dict):
+        # Create InferenceSpans
+        for span in sorted_spans:
+            body = get_body(span)
+            if not body:
                 continue
 
             try:
-                messages = self._record_to_messages(record)
+                messages = self._body_to_messages(body)
                 if messages:
-                    span_info = self._create_span_info(record, session_id)
-                    spans.append(InferenceSpan(span_info=span_info, messages=messages, metadata={}))
+                    span_info = self._create_span_info(span, session_id)
+                    result_spans.append(InferenceSpan(span_info=span_info, messages=messages, metadata={}))
             except Exception as e:
-                logger.warning("Failed to create inference span from record %s: %s", record.get("spanId"), e)
+                span_id = span.get("span_id") or span.get("spanId", "unknown")
+                logger.warning("Failed to create inference span from %s: %s", span_id, e)
 
-        # Create ToolExecutionSpans by matching calls to results
+        # Create ToolExecutionSpans
         seen_tool_ids: set[str] = set()
-        for record in sorted_records:
-            for tc in self._extract_tool_calls(record):
+        for span in sorted_spans:
+            body = get_body(span)
+            if not body:
+                continue
+
+            for tc in self._extract_tool_calls(body):
                 if tc.tool_call_id and tc.tool_call_id not in seen_tool_ids:
                     seen_tool_ids.add(tc.tool_call_id)
                     tr = all_tool_results.get(tc.tool_call_id, ToolResult(content="", tool_call_id=tc.tool_call_id))
-                    span_info = self._create_span_info(record, session_id)
-                    spans.append(ToolExecutionSpan(span_info=span_info, tool_call=tc, tool_result=tr, metadata={}))
+                    span_info = self._create_span_info(span, session_id)
+                    result_spans.append(
+                        ToolExecutionSpan(span_info=span_info, tool_call=tc, tool_result=tr, metadata={})
+                    )
 
-        # Create AgentInvocationSpan from first user prompt + last agent response
-        agent_span = self._create_agent_invocation_span(sorted_records, all_tool_calls, session_id)
+        # Create AgentInvocationSpan
+        agent_span = self._create_agent_invocation_span(sorted_spans, all_tool_calls, session_id)
         if agent_span:
-            spans.append(agent_span)
+            result_spans.append(agent_span)
 
-        return Trace(spans=spans, trace_id=trace_id, session_id=session_id)
+        return Trace(spans=result_spans, trace_id=trace_id, session_id=session_id)
+
+    def _create_span_info(self, span: dict, session_id: str) -> SpanInfo:
+        """Create SpanInfo from span dict."""
+        # Handle both normalized and raw field names
+        trace_id = span.get("trace_id") or span.get("traceId", "")
+        span_id = span.get("span_id") or span.get("spanId", "")
+        parent_span_id = span.get("parent_span_id") or span.get("parentSpanId")
+
+        # Handle timestamps
+        time_value = span.get("start_time") or span.get("timeUnixNano", 0)
+        if isinstance(time_value, (int, float)) and time_value > 0:
+            ts = datetime.fromtimestamp(time_value / 1e9, tz=timezone.utc)
+        else:
+            ts = datetime.now(timezone.utc)
+
+        return SpanInfo(
+            trace_id=trace_id,
+            span_id=span_id,
+            session_id=session_id,
+            parent_span_id=parent_span_id,
+            start_time=ts,
+            end_time=ts,
+        )
 
     def _create_agent_invocation_span(
-        self, records: list[dict[str, Any]], tool_calls: dict[str, ToolCall], session_id: str
+        self, spans: list[dict], tool_calls: dict[str, ToolCall], session_id: str
     ) -> AgentInvocationSpan | None:
-        """Create an AgentInvocationSpan from the first user prompt and last agent response."""
+        """Create AgentInvocationSpan from first user prompt and last agent response."""
         user_prompt = None
-        for record in records:
-            prompt = self._extract_user_prompt(record)
-            if prompt:
-                user_prompt = prompt
-                break
+        for span in spans:
+            body = get_body(span)
+            if body:
+                prompt = self._extract_user_prompt(body)
+                if prompt:
+                    user_prompt = prompt
+                    break
 
         if not user_prompt:
             return None
 
         agent_response = None
-        best_record = None
-        for record in reversed(records):
-            response = self._extract_agent_response(record)
-            if response:
-                agent_response = response
-                best_record = record
-                break
+        best_span = None
+        for span in reversed(spans):
+            body = get_body(span)
+            if body:
+                response = self._extract_agent_response(body)
+                if response:
+                    agent_response = response
+                    best_span = span
+                    break
 
-        if not agent_response or not best_record:
+        if not agent_response or not best_span:
             return None
 
         available_tools = [ToolConfig(name=name) for name in sorted({tc.name for tc in tool_calls.values()})]
-        span_info = self._create_span_info(best_record, session_id)
+        span_info = self._create_span_info(best_span, session_id)
 
         return AgentInvocationSpan(
             span_info=span_info,
@@ -138,21 +193,6 @@ class CloudWatchSessionMapper(SessionMapper):
             agent_response=agent_response,
             available_tools=available_tools,
             metadata={},
-        )
-
-    # --- Span info ---
-
-    def _create_span_info(self, record: dict[str, Any], session_id: str) -> SpanInfo:
-        time_nano = record.get("timeUnixNano", 0)
-        ts = datetime.fromtimestamp(time_nano / 1e9, tz=timezone.utc)
-
-        return SpanInfo(
-            trace_id=record.get("traceId", ""),
-            span_id=record.get("spanId", ""),
-            session_id=session_id,
-            parent_span_id=record.get("parentSpanId") or None,
-            start_time=ts,
-            end_time=ts,
         )
 
     # --- Body-based content extraction ---
@@ -186,12 +226,8 @@ class CloudWatchSessionMapper(SessionMapper):
 
         return raw if isinstance(raw, str) else None
 
-    def _extract_message_text(self, record: dict[str, Any], message_type: str, role: str) -> str | None:
-        """Extract text from a specific message type and role in a log record."""
-        body = record.get("body", {})
-        if not isinstance(body, dict):
-            return None
-
+    def _extract_message_text(self, body: dict, message_type: str, role: str) -> str | None:
+        """Extract text from a specific message type and role."""
         messages = body.get(message_type, {}).get("messages", [])
         for msg in messages:
             if msg.get("role") == role:
@@ -200,20 +236,17 @@ class CloudWatchSessionMapper(SessionMapper):
                     return text
         return None
 
-    def _extract_user_prompt(self, record: dict[str, Any]) -> str | None:
-        """Extract user prompt text from a log record's body.input.messages."""
-        return self._extract_message_text(record, "input", "user")
+    def _extract_user_prompt(self, body: dict) -> str | None:
+        """Extract user prompt text from body.input.messages."""
+        return self._extract_message_text(body, "input", "user")
 
-    def _extract_agent_response(self, record: dict[str, Any]) -> str | None:
-        """Extract assistant text response from a log record's body.output.messages."""
-        return self._extract_message_text(record, "output", "assistant")
+    def _extract_agent_response(self, body: dict) -> str | None:
+        """Extract assistant text response from body.output.messages."""
+        return self._extract_message_text(body, "output", "assistant")
 
-    def _extract_tool_calls(self, record: dict[str, Any]) -> list[ToolCall]:
-        """Extract tool calls from a log record's body.output.messages."""
+    def _extract_tool_calls(self, body: dict) -> list[ToolCall]:
+        """Extract tool calls from body.output.messages."""
         tool_calls: list[ToolCall] = []
-        body = record.get("body", {})
-        if not isinstance(body, dict):
-            return tool_calls
 
         for msg in body.get("output", {}).get("messages", []):
             if msg.get("role") != "assistant":
@@ -237,12 +270,9 @@ class CloudWatchSessionMapper(SessionMapper):
 
         return tool_calls
 
-    def _extract_tool_results(self, record: dict[str, Any]) -> list[ToolResult]:
-        """Extract tool results from a log record's body.input.messages."""
+    def _extract_tool_results(self, body: dict) -> list[ToolResult]:
+        """Extract tool results from body.input.messages."""
         tool_results: list[ToolResult] = []
-        body = record.get("body", {})
-        if not isinstance(body, dict):
-            return tool_results
 
         for msg in body.get("input", {}).get("messages", []):
             raw = self._extract_content_field(msg.get("content", {}))
@@ -272,14 +302,11 @@ class CloudWatchSessionMapper(SessionMapper):
             return content[0].get("text", "")
         return str(content)
 
-    # --- Record-to-messages conversion ---
+    # --- Body-to-messages conversion ---
 
-    def _record_to_messages(self, record: dict[str, Any]) -> list[UserMessage | AssistantMessage]:
-        """Convert a log record's body into a list of typed messages for InferenceSpan."""
+    def _body_to_messages(self, body: dict) -> list[UserMessage | AssistantMessage]:
+        """Convert body into a list of typed messages for InferenceSpan."""
         messages: list[UserMessage | AssistantMessage] = []
-        body = record.get("body", {})
-        if not isinstance(body, dict):
-            return messages
 
         # Process input messages
         for msg in body.get("input", {}).get("messages", []):

--- a/src/strands_evals/mappers/langchain_otel_session_mapper.py
+++ b/src/strands_evals/mappers/langchain_otel_session_mapper.py
@@ -1,0 +1,602 @@
+"""
+LangChainOtelSessionMapper - Maps Traceloop/OpenLLMetry LangChain traces to Session format.
+
+Handles traces with scope: opentelemetry.instrumentation.langchain
+(produced by opentelemetry-instrumentation-langchain from Traceloop's OpenLLMetry project)
+
+Supports two trace formats:
+1. ADOT/CloudWatch: Messages in span_events[].body.input/output.messages
+2. Live instrumentation: Messages in gen_ai.*/traceloop.entity.* attributes
+"""
+
+import json
+import logging
+from collections import defaultdict
+from datetime import datetime, timezone
+from typing import Any
+
+from ..types.trace import (
+    AgentInvocationSpan,
+    AssistantMessage,
+    InferenceSpan,
+    Session,
+    SpanInfo,
+    TextContent,
+    ToolCall,
+    ToolCallContent,
+    ToolConfig,
+    ToolExecutionSpan,
+    ToolResult,
+    ToolResultContent,
+    Trace,
+    UserMessage,
+)
+from .session_mapper import SessionMapper
+
+logger = logging.getLogger(__name__)
+
+SCOPE_NAME = "opentelemetry.instrumentation.langchain"
+
+
+class LangChainOtelSessionMapper(SessionMapper):
+    """Maps Traceloop/OpenLLMetry LangChain traces to Session format.
+
+    This mapper handles traces with scope 'opentelemetry.instrumentation.langchain',
+    produced by Traceloop's OpenLLMetry project (opentelemetry-instrumentation-langchain).
+
+    Span type detection (using Traceloop attributes):
+    - Inference spans: llm.request.type == "chat"
+    - Tool execution spans: traceloop.span.kind == "tool"
+    - Agent invocation spans: traceloop.span.kind == "workflow"
+
+    Supported trace formats:
+    - ADOT/CloudWatch: Messages in span_events[].body.input/output.messages
+    - Live instrumentation: Messages in gen_ai.*/traceloop.entity.* attributes
+    """
+
+    def __init__(self):
+        super().__init__()
+        # Track tools per trace (LangGraph stores tools in inference spans, not agent spans)
+        self._trace_tools_map: dict[str, dict[str, ToolConfig]] = defaultdict(dict)
+        # Track system prompts per trace
+        self._trace_system_prompt_map: dict[str, str] = defaultdict(str)
+
+    def map_to_session(self, data: Any, session_id: str) -> Session:
+        """Map LangChain OTEL spans to Session format.
+
+        Args:
+            data: Trace data in various formats:
+                - Flat list of spans: [{"trace_id": "x", "span_id": "y", ...}, ...]
+                - Grouped by trace_id: {"trace_1": [spans], "trace_2": [spans]}
+                - List of trace objects: [{"trace_id": "x", "spans": [...]}, ...]
+            session_id: Session identifier
+
+        Returns:
+            Session object ready for evaluation
+        """
+        # Reset state for new mapping
+        self._trace_tools_map = defaultdict(dict)
+        self._trace_system_prompt_map = defaultdict(str)
+
+        # Normalize input to flat spans
+        spans = self._normalize_to_flat_spans(data)
+
+        # Filter to only spans from this scope
+        langchain_spans = [s for s in spans if self._get_scope_name(s) == SCOPE_NAME]
+
+        # Group spans by trace_id
+        grouped = defaultdict(list)
+        for span in langchain_spans:
+            trace_id = span.get("trace_id", "")
+            grouped[trace_id].append(span)
+
+        # Build traces
+        result_traces: list[Trace] = []
+        for trace_id, trace_spans in grouped.items():
+            trace = self._build_trace(trace_id, trace_spans, session_id)
+            if trace.spans:
+                result_traces.append(trace)
+
+        return Session(traces=result_traces, session_id=session_id)
+
+    def _build_trace(self, trace_id: str, spans: list[dict], session_id: str) -> Trace:
+        """Build a Trace from spans with the same trace_id."""
+        converted_spans: list[InferenceSpan | ToolExecutionSpan | AgentInvocationSpan] = []
+
+        for span in spans:
+            try:
+                if self._is_inference_span(span):
+                    inference_span = self._convert_inference_span(span, session_id)
+                    if inference_span and inference_span.messages:
+                        converted_spans.append(inference_span)
+                elif self._is_tool_execution_span(span):
+                    tool_span = self._convert_tool_execution_span(span, session_id)
+                    if tool_span:
+                        converted_spans.append(tool_span)
+                elif self._is_agent_invocation_span(span):
+                    agent_span = self._convert_agent_invocation_span(span, session_id)
+                    if agent_span:
+                        converted_spans.append(agent_span)
+            except Exception as e:
+                logger.warning(f"Failed to convert span {span.get('span_id', 'unknown')}: {e}")
+
+        return Trace(spans=converted_spans, trace_id=trace_id, session_id=session_id)
+
+    # =========================================================================
+    # Span Type Detection
+    # =========================================================================
+
+    def _is_inference_span(self, span: dict) -> bool:
+        """Check if span is an LLM inference span."""
+        attrs = span.get("attributes", {})
+        return attrs.get("llm.request.type") == "chat"
+
+    def _is_tool_execution_span(self, span: dict) -> bool:
+        """Check if span is a tool execution span."""
+        attrs = span.get("attributes", {})
+        return attrs.get("traceloop.span.kind") == "tool"
+
+    def _is_agent_invocation_span(self, span: dict) -> bool:
+        """Check if span is an agent invocation span."""
+        attrs = span.get("attributes", {})
+        return attrs.get("traceloop.span.kind") == "workflow"
+
+    # =========================================================================
+    # Span Conversion
+    # =========================================================================
+
+    def _convert_inference_span(self, span: dict, session_id: str) -> InferenceSpan | None:
+        """Convert OTEL span to InferenceSpan."""
+        span_info = self._create_span_info(span, session_id)
+        attrs = span.get("attributes", {})
+        trace_id = span.get("trace_id", "")
+
+        # Extract available tools from attributes
+        tools = self._extract_tools_from_attributes(attrs)
+        self._trace_tools_map[trace_id].update(tools)
+
+        # Extract messages from span events
+        input_messages, output_messages = self._get_messages_from_span_events(span)
+
+        messages: list[UserMessage | AssistantMessage] = []
+
+        # Process user message
+        if input_messages:
+            user_msg = self._extract_user_message(input_messages[-1], len(input_messages) - 1, attrs)
+            if user_msg:
+                messages.append(user_msg)
+
+        # Process assistant message
+        if output_messages:
+            assistant_msg = self._extract_assistant_message(output_messages[-1], len(output_messages) - 1, attrs)
+            if assistant_msg:
+                messages.append(assistant_msg)
+
+        # Extract system prompt
+        for idx, msg in enumerate(input_messages):
+            if attrs.get(f"gen_ai.prompt.{idx}.role") == "system":
+                content = msg.get("content", "")
+                if isinstance(content, str):
+                    self._trace_system_prompt_map[trace_id] = content
+                break
+
+        if not messages:
+            return None
+
+        return InferenceSpan(span_info=span_info, messages=messages, metadata={})
+
+    def _convert_tool_execution_span(self, span: dict, session_id: str) -> ToolExecutionSpan | None:
+        """Convert OTEL span to ToolExecutionSpan.
+
+        Handles two formats:
+        1. ADOT/CloudWatch: Data in span_events[].body.input/output.messages
+        2. Live instrumentation: Data in traceloop.entity.input/output attributes
+        """
+        span_info = self._create_span_info(span, session_id)
+        attrs = span.get("attributes", {})
+
+        tool_name = attrs.get("traceloop.entity.name")
+        tool_parameters: dict | None = None
+        tool_output_content: str | None = None
+        tool_call_id: str | None = None
+        tool_status: str | None = ""
+
+        # Try ADOT/CloudWatch format first (span_events)
+        input_messages, output_messages = self._get_messages_from_span_events(span)
+
+        if input_messages and output_messages:
+            # ADOT format - extract from messages
+            input_content = input_messages[-1].get("content", "")
+            if isinstance(input_content, str):
+                parsed = self._safe_json_parse(input_content)
+                if isinstance(parsed, dict):
+                    if "inputs" in parsed and isinstance(parsed.get("inputs"), dict):
+                        tool_parameters = parsed.get("inputs")
+                    elif "input_str" in parsed:
+                        params_parsed = self._safe_json_parse(parsed.get("input_str", ""))
+                        if isinstance(params_parsed, dict):
+                            tool_parameters = params_parsed
+
+            output_content = output_messages[-1].get("content", "")
+            if isinstance(output_content, str):
+                parsed = self._safe_json_parse(output_content)
+                if isinstance(parsed, dict) and "output" in parsed:
+                    output_obj = parsed["output"]
+                    if isinstance(output_obj, dict) and "kwargs" in output_obj:
+                        kwargs = output_obj["kwargs"]
+                        if isinstance(kwargs, dict):
+                            tool_output_content = kwargs.get("content")
+                            tool_call_id = kwargs.get("tool_call_id")
+                            tool_status = kwargs.get("status")
+        else:
+            # Live format - extract from traceloop.entity.* attributes
+            entity_input = attrs.get("traceloop.entity.input", "")
+            entity_output = attrs.get("traceloop.entity.output", "")
+
+            if entity_input:
+                parsed = self._safe_json_parse(entity_input)
+                if isinstance(parsed, dict):
+                    if "inputs" in parsed and isinstance(parsed.get("inputs"), dict):
+                        tool_parameters = parsed.get("inputs")
+                    elif "input_str" in parsed:
+                        params_parsed = self._safe_json_parse(parsed.get("input_str", ""))
+                        if isinstance(params_parsed, dict):
+                            tool_parameters = params_parsed
+
+            if entity_output:
+                parsed = self._safe_json_parse(entity_output)
+                if isinstance(parsed, dict) and "output" in parsed:
+                    output_obj = parsed["output"]
+                    if isinstance(output_obj, dict) and "kwargs" in output_obj:
+                        kwargs = output_obj["kwargs"]
+                        if isinstance(kwargs, dict):
+                            tool_output_content = kwargs.get("content")
+                            tool_call_id = kwargs.get("tool_call_id")
+                            tool_status = kwargs.get("status")
+
+        # Validate required fields
+        if not tool_name or tool_parameters is None or tool_output_content is None:
+            logger.warning(f"Missing required fields for tool span {span.get('span_id')}")
+            return None
+
+        tool_call = ToolCall(name=tool_name, arguments=tool_parameters or {}, tool_call_id=tool_call_id)
+        tool_result = ToolResult(
+            content=tool_output_content or "",
+            error=None if tool_status == "success" else tool_status,
+            tool_call_id=tool_call_id,
+        )
+
+        return ToolExecutionSpan(span_info=span_info, tool_call=tool_call, tool_result=tool_result, metadata={})
+
+    def _convert_agent_invocation_span(self, span: dict, session_id: str) -> AgentInvocationSpan | None:
+        """Convert OTEL span to AgentInvocationSpan.
+
+        Handles two formats:
+        1. ADOT/CloudWatch: Data in span_events[].body.input/output.messages
+        2. Live instrumentation: Data in traceloop.entity.input/output attributes
+        """
+        span_info = self._create_span_info(span, session_id)
+        trace_id = span.get("trace_id", "")
+        attrs = span.get("attributes", {})
+
+        user_query: str | None = None
+        agent_response: str | None = None
+
+        # Try ADOT/CloudWatch format first (span_events)
+        input_messages, output_messages = self._get_messages_from_span_events(span)
+
+        if input_messages and output_messages:
+            # ADOT format
+            user_query = self._extract_user_prompt_from_input(input_messages)
+            agent_response = self._extract_agent_response_from_output(output_messages)
+        else:
+            # Live format - extract from traceloop.entity.* attributes
+            entity_input = attrs.get("traceloop.entity.input", "")
+            entity_output = attrs.get("traceloop.entity.output", "")
+
+            if entity_input:
+                parsed = self._safe_json_parse(entity_input)
+                if isinstance(parsed, dict) and "inputs" in parsed:
+                    inputs = parsed["inputs"]
+                    if isinstance(inputs, dict) and "messages" in inputs:
+                        user_query = self._get_last_message_text(inputs["messages"])
+
+            if entity_output:
+                parsed = self._safe_json_parse(entity_output)
+                if isinstance(parsed, dict) and "outputs" in parsed:
+                    outputs = parsed["outputs"]
+                    if isinstance(outputs, dict) and "messages" in outputs:
+                        agent_response = self._get_last_message_text(outputs["messages"])
+
+        if not user_query or not agent_response:
+            logger.warning(f"Missing user_query or agent_response for span {span.get('span_id')}")
+            return None
+
+        available_tools = sorted(
+            self._trace_tools_map.get(trace_id, {}).values(),
+            key=lambda t: t.name,
+        )
+
+        return AgentInvocationSpan(
+            span_info=span_info,
+            user_prompt=user_query,
+            agent_response=agent_response,
+            available_tools=available_tools,
+            metadata={},
+        )
+
+    # =========================================================================
+    # Helper Methods
+    # =========================================================================
+
+    def _get_scope_name(self, span: dict) -> str:
+        """Extract scope name from span."""
+        scope = span.get("scope", {})
+        return scope.get("name", "") if isinstance(scope, dict) else ""
+
+    def _create_span_info(self, span: dict, session_id: str) -> SpanInfo:
+        """Create SpanInfo from span dict."""
+        start_time = self._parse_timestamp(span.get("start_time"))
+        end_time = self._parse_timestamp(span.get("end_time"))
+
+        return SpanInfo(
+            trace_id=span.get("trace_id"),
+            span_id=span.get("span_id"),
+            session_id=session_id,
+            parent_span_id=span.get("parent_span_id"),
+            start_time=start_time,
+            end_time=end_time,
+        )
+
+    def _parse_timestamp(self, value: Any) -> datetime:
+        """Parse timestamp from various formats."""
+        if value is None:
+            return datetime.now(timezone.utc)
+        if isinstance(value, datetime):
+            return value
+        if isinstance(value, str):
+            try:
+                if value.endswith("Z"):
+                    value = value[:-1] + "+00:00"
+                return datetime.fromisoformat(value)
+            except ValueError:
+                return datetime.now(timezone.utc)
+        if isinstance(value, (int, float)):
+            # Handle nanoseconds
+            if value > 1e12:
+                value = value / 1e9
+            return datetime.fromtimestamp(value, tz=timezone.utc)
+        return datetime.now(timezone.utc)
+
+    def _safe_json_parse(self, content: Any) -> Any:
+        """Safely parse JSON content."""
+        if isinstance(content, dict):
+            return content
+        if isinstance(content, str):
+            try:
+                return json.loads(content)
+            except json.JSONDecodeError:
+                return content
+        return content
+
+    def _get_messages_from_span_events(self, span: dict) -> tuple[list[dict], list[dict]]:
+        """Extract input and output messages from span events or attributes.
+
+        Handles two formats:
+        1. ADOT/CloudWatch: Messages in span_events[].body.input/output.messages
+        2. Live instrumentation: Messages in gen_ai.prompt.*/gen_ai.completion.* attributes
+        """
+        # Try ADOT/CloudWatch format first (span_events)
+        span_events = span.get("span_events", [])
+        for event in span_events:
+            event_name = event.get("event_name", "")
+            if event_name == SCOPE_NAME:
+                body = event.get("body", {})
+                input_group = body.get("input", {})
+                output_group = body.get("output", {})
+                input_msgs = input_group.get("messages", [])
+                output_msgs = output_group.get("messages", [])
+                if input_msgs or output_msgs:
+                    return input_msgs, output_msgs
+
+        # Fallback to live instrumentation format (gen_ai.* attributes)
+        attrs = span.get("attributes", {})
+        input_messages = self._extract_messages_from_gen_ai_attrs(attrs, "prompt")
+        output_messages = self._extract_messages_from_gen_ai_attrs(attrs, "completion")
+
+        return input_messages, output_messages
+
+    def _extract_messages_from_gen_ai_attrs(self, attrs: dict, msg_type: str) -> list[dict]:
+        """Extract messages from gen_ai.prompt.* or gen_ai.completion.* attributes.
+
+        Args:
+            attrs: Span attributes dict
+            msg_type: Either "prompt" (for input) or "completion" (for output)
+
+        Returns:
+            List of message dicts with 'role' and 'content' keys
+        """
+        messages: list[dict] = []
+        idx = 0
+
+        while True:
+            role_key = f"gen_ai.{msg_type}.{idx}.role"
+            content_key = f"gen_ai.{msg_type}.{idx}.content"
+
+            role = attrs.get(role_key)
+            content = attrs.get(content_key)
+
+            if content is None:
+                break
+
+            messages.append(
+                {
+                    "role": role or ("user" if msg_type == "prompt" else "assistant"),
+                    "content": content,
+                }
+            )
+            idx += 1
+
+        return messages
+
+    def _extract_tools_from_attributes(self, attrs: dict) -> dict[str, ToolConfig]:
+        """Extract tool definitions from llm.request.functions.* attributes."""
+        tools: dict[str, ToolConfig] = {}
+
+        # Find all function indices
+        indices = set()
+        for key in attrs.keys():
+            if key.startswith("llm.request.functions.") and key.endswith(".name"):
+                try:
+                    idx = key.split(".")[3]
+                    if idx.isdigit():
+                        indices.add(idx)
+                except (IndexError, ValueError):
+                    continue
+
+        for idx in indices:
+            name = attrs.get(f"llm.request.functions.{idx}.name")
+            if name:
+                description = attrs.get(f"llm.request.functions.{idx}.description")
+                params_str = attrs.get(f"llm.request.functions.{idx}.parameters")
+                parameters = None
+                if params_str:
+                    try:
+                        parameters = json.loads(params_str)
+                    except json.JSONDecodeError:
+                        pass
+                tools[name] = ToolConfig(name=name, description=description, parameters=parameters)
+
+        return tools
+
+    def _extract_user_message(self, message: dict, index: int, attrs: dict) -> UserMessage | None:
+        """Extract user message from span event message."""
+        content: list[TextContent | ToolResultContent] = []
+
+        # Check if this is a tool result message
+        is_tool_msg, tool_call_id = self._check_tool_result_message(index, attrs)
+
+        msg_content = message.get("content", "")
+        if isinstance(msg_content, str):
+            if is_tool_msg:
+                content.append(ToolResultContent(content=msg_content, error=None, tool_call_id=tool_call_id))
+            else:
+                content.append(TextContent(text=msg_content))
+            return UserMessage(content=content)
+
+        return None
+
+    def _extract_assistant_message(self, message: dict, index: int, attrs: dict) -> AssistantMessage | None:
+        """Extract assistant message from span event message."""
+        content: list[TextContent | ToolCallContent] = []
+
+        msg_content = message.get("content", "")
+        if isinstance(msg_content, str):
+            content.append(TextContent(text=msg_content))
+
+            # Check for tool calls
+            tool_calls = self._get_assistant_tool_calls(index, attrs)
+            content.extend(tool_calls)
+
+            return AssistantMessage(content=content)
+
+        return None
+
+    def _check_tool_result_message(self, index: int, attrs: dict) -> tuple[bool, str]:
+        """Check if message at index is a tool result."""
+        role_key = f"gen_ai.prompt.{index}.role"
+        if attrs.get(role_key) == "tool":
+            tool_call_id_key = f"gen_ai.prompt.{index}.tool_call_id"
+            return True, attrs.get(tool_call_id_key, "")
+        return False, ""
+
+    def _get_assistant_tool_calls(self, index: int, attrs: dict) -> list[ToolCallContent]:
+        """Extract tool calls from assistant message attributes."""
+        tool_calls: list[ToolCallContent] = []
+        tool_idx = 0
+
+        while True:
+            name_key = f"gen_ai.completion.{index}.tool_calls.{tool_idx}.name"
+            args_key = f"gen_ai.completion.{index}.tool_calls.{tool_idx}.arguments"
+            id_key = f"gen_ai.completion.{index}.tool_calls.{tool_idx}.id"
+
+            tool_name = attrs.get(name_key)
+            if not tool_name:
+                break
+
+            args_str = attrs.get(args_key, "{}")
+            tool_call_id = attrs.get(id_key, "")
+
+            try:
+                arguments = json.loads(args_str) if args_str else {}
+            except json.JSONDecodeError:
+                arguments = {}
+
+            tool_calls.append(ToolCallContent(name=tool_name, arguments=arguments, tool_call_id=tool_call_id))
+            tool_idx += 1
+
+        return tool_calls
+
+    def _extract_user_prompt_from_input(self, input_messages: list[dict]) -> str | None:
+        """Extract user prompt from agent invocation input messages."""
+        if not input_messages:
+            return None
+
+        msg = input_messages[-1]
+        content = msg.get("content", "")
+        if isinstance(content, str):
+            parsed = self._safe_json_parse(content)
+            if isinstance(parsed, dict) and "inputs" in parsed:
+                inputs = parsed["inputs"]
+                if isinstance(inputs, dict) and "messages" in inputs:
+                    messages = inputs["messages"]
+                    return self._get_last_message_text(messages)
+        return None
+
+    def _extract_agent_response_from_output(self, output_messages: list[dict]) -> str | None:
+        """Extract agent response from agent invocation output messages."""
+        if not output_messages:
+            return None
+
+        msg = output_messages[-1]
+        content = msg.get("content", "")
+        if isinstance(content, str):
+            parsed = self._safe_json_parse(content)
+            if isinstance(parsed, dict) and "outputs" in parsed:
+                outputs = parsed["outputs"]
+                if isinstance(outputs, dict) and "messages" in outputs:
+                    messages = outputs["messages"]
+                    return self._get_last_message_text(messages)
+        return None
+
+    def _get_last_message_text(self, messages: list) -> str | None:
+        """Extract text from the last message in a LangGraph state messages list."""
+        if not messages:
+            return None
+
+        msg = messages[-1]
+
+        # LangGraph-native format: {"kwargs": {"content": "..."}}
+        if isinstance(msg, dict):
+            if "kwargs" in msg:
+                kwargs = msg["kwargs"]
+                if isinstance(kwargs, dict) and "content" in kwargs:
+                    content = kwargs["content"]
+                    # Handle list content (multi-part messages)
+                    if isinstance(content, list):
+                        for item in content:
+                            if isinstance(item, dict) and "text" in item:
+                                return item["text"]
+                    return content
+            # OpenAI format: {"content": "..."}
+            if "content" in msg:
+                return msg["content"]
+
+        # Tuple format: ["role", "content"]
+        elif isinstance(msg, list):
+            return msg[-1] if msg else None
+
+        elif isinstance(msg, str):
+            return msg
+
+        return None

--- a/src/strands_evals/mappers/openinference_session_mapper.py
+++ b/src/strands_evals/mappers/openinference_session_mapper.py
@@ -1,0 +1,661 @@
+"""
+OpenInferenceSessionMapper - Maps OpenInference LangChain traces to Session format.
+
+Handles traces with scope: openinference.instrumentation.langchain
+"""
+
+import json
+import logging
+from collections import defaultdict
+from datetime import datetime, timezone
+from typing import Any
+
+from ..types.trace import (
+    AgentInvocationSpan,
+    AssistantMessage,
+    InferenceSpan,
+    Session,
+    SpanInfo,
+    TextContent,
+    ToolCall,
+    ToolCallContent,
+    ToolConfig,
+    ToolExecutionSpan,
+    ToolResult,
+    ToolResultContent,
+    Trace,
+    UserMessage,
+)
+from .session_mapper import SessionMapper
+
+logger = logging.getLogger(__name__)
+
+SCOPE_NAME = "openinference.instrumentation.langchain"
+
+
+class OpenInferenceSessionMapper(SessionMapper):
+    """Maps OpenInference LangChain traces to Session format.
+
+    This mapper handles traces produced by the openinference-instrumentation-langchain library.
+    It identifies span types using:
+    - Inference spans: openinference.span.kind == "LLM"
+    - Tool execution spans: openinference.span.kind == "TOOL"
+    - Agent invocation spans: openinference.span.kind == "CHAIN" (name=LangGraph) or "AGENT"
+    """
+
+    def __init__(self):
+        super().__init__()
+        # Track tools per trace (tools appear in LLM spans, not agent spans)
+        self._trace_tools_map: dict[str, dict[str, ToolConfig]] = defaultdict(dict)
+        # Track if agent invocation span already found for trace
+        self._trace_has_agent_invocation: dict[str, bool] = defaultdict(bool)
+        # Track system prompts per trace
+        self._trace_system_prompt_map: dict[str, str] = defaultdict(str)
+
+    def map_to_session(self, data: Any, session_id: str) -> Session:
+        """Map OpenInference LangChain spans to Session format.
+
+        Args:
+            data: Trace data in various formats:
+                - Flat list of spans: [{"trace_id": "x", "span_id": "y", ...}, ...]
+                - Grouped by trace_id: {"trace_1": [spans], "trace_2": [spans]}
+                - List of trace objects: [{"trace_id": "x", "spans": [...]}, ...]
+            session_id: Session identifier
+
+        Returns:
+            Session object ready for evaluation
+        """
+        # Reset state for new mapping
+        self._trace_tools_map = defaultdict(dict)
+        self._trace_has_agent_invocation = defaultdict(bool)
+        self._trace_system_prompt_map = defaultdict(str)
+
+        # Normalize input to flat spans
+        spans = self._normalize_to_flat_spans(data)
+
+        # Filter to only spans from this scope
+        openinference_spans = [s for s in spans if self._get_scope_name(s) == SCOPE_NAME]
+
+        # Group spans by trace_id
+        grouped = defaultdict(list)
+        for span in openinference_spans:
+            trace_id = span.get("trace_id", "")
+            grouped[trace_id].append(span)
+
+        # Build traces
+        result_traces: list[Trace] = []
+        for trace_id, trace_spans in grouped.items():
+            trace = self._build_trace(trace_id, trace_spans, session_id)
+            if trace.spans:
+                result_traces.append(trace)
+
+        return Session(traces=result_traces, session_id=session_id)
+
+    def _build_trace(self, trace_id: str, spans: list[dict], session_id: str) -> Trace:
+        """Build a Trace from spans with the same trace_id."""
+        converted_spans: list[InferenceSpan | ToolExecutionSpan | AgentInvocationSpan] = []
+
+        for span in spans:
+            try:
+                if self._is_inference_span(span):
+                    inference_span = self._convert_inference_span(span, session_id)
+                    if inference_span and inference_span.messages:
+                        converted_spans.append(inference_span)
+                elif self._is_tool_execution_span(span):
+                    tool_span = self._convert_tool_execution_span(span, session_id)
+                    if tool_span:
+                        converted_spans.append(tool_span)
+                elif self._is_agent_invocation_span(span):
+                    agent_span = self._convert_agent_invocation_span(span, session_id)
+                    if agent_span:
+                        converted_spans.append(agent_span)
+            except Exception as e:
+                logger.warning(f"Failed to convert span {span.get('span_id', 'unknown')}: {e}")
+
+        return Trace(spans=converted_spans, trace_id=trace_id, session_id=session_id)
+
+    # =========================================================================
+    # Span Type Detection
+    # =========================================================================
+
+    def _is_inference_span(self, span: dict) -> bool:
+        """Check if span is an LLM inference span."""
+        attrs = span.get("attributes", {})
+        return attrs.get("openinference.span.kind") == "LLM"
+
+    def _is_tool_execution_span(self, span: dict) -> bool:
+        """Check if span is a tool execution span."""
+        attrs = span.get("attributes", {})
+        return attrs.get("openinference.span.kind") == "TOOL"
+
+    def _is_agent_invocation_span(self, span: dict) -> bool:
+        """Check if span is an agent invocation span.
+
+        Returns True for:
+        1. Default agent: CHAIN + name=LangGraph (takes priority)
+        2. Custom-named agent: AGENT + langgraph_step >= 2
+        3. Model chain: CHAIN + name=model + langgraph_step >= 2
+
+        Enforces: Only ONE agent invocation span per trace.
+        """
+        attrs = span.get("attributes", {})
+        span_kind = attrs.get("openinference.span.kind", "")
+        span_name = span.get("name", "")
+        trace_id = span.get("trace_id", "")
+
+        # If we've already found an agent invocation for this trace, skip
+        if self._trace_has_agent_invocation.get(trace_id, False):
+            return False
+
+        # Case 1: Default unnamed agent (standard LangGraph pattern)
+        if span_kind == "CHAIN" and span_name == "LangGraph":
+            self._trace_has_agent_invocation[trace_id] = True
+            return True
+
+        # Case 2: Custom-named agent
+        if span_kind == "AGENT":
+            metadata_str = attrs.get("metadata", "{}")
+            try:
+                metadata = json.loads(metadata_str) if isinstance(metadata_str, str) else metadata_str
+                step = metadata.get("langgraph_step", 0)
+                if step >= 2:
+                    self._trace_has_agent_invocation[trace_id] = True
+                    return True
+            except (json.JSONDecodeError, AttributeError):
+                pass
+
+        # Case 3: Model chain
+        if span_kind == "CHAIN" and span_name == "model":
+            metadata_str = attrs.get("metadata", "{}")
+            try:
+                metadata = json.loads(metadata_str) if isinstance(metadata_str, str) else metadata_str
+                step = metadata.get("langgraph_step", 0)
+                if step >= 2:
+                    self._trace_has_agent_invocation[trace_id] = True
+                    return True
+            except (json.JSONDecodeError, AttributeError):
+                pass
+
+        return False
+
+    # =========================================================================
+    # Span Conversion
+    # =========================================================================
+
+    def _convert_inference_span(self, span: dict, session_id: str) -> InferenceSpan | None:
+        """Convert OTEL span to InferenceSpan."""
+        span_info = self._create_span_info(span, session_id)
+        attrs = span.get("attributes", {})
+        trace_id = span.get("trace_id", "")
+
+        input_messages, output_messages = self._get_messages_from_span_events(span)
+
+        # Extract user message
+        user_contents, system_prompt = self._extract_user_contents(input_messages, span)
+        if not user_contents:
+            logger.warning(f"No user contents for span {span.get('span_id')}")
+            return None
+
+        user_message = UserMessage(content=user_contents)
+
+        # Track system prompt
+        if system_prompt:
+            self._trace_system_prompt_map[trace_id] = system_prompt
+
+        # Extract assistant message
+        assistant_contents = self._extract_assistant_contents(output_messages, span)
+        if not assistant_contents:
+            logger.warning(f"No assistant contents for span {span.get('span_id')}")
+            return None
+
+        assistant_message = AssistantMessage(content=assistant_contents)
+
+        # Extract tool schemas
+        tools = self._extract_tools_from_attributes(attrs)
+        self._trace_tools_map[trace_id].update({t.name: t for t in tools})
+
+        return InferenceSpan(span_info=span_info, messages=[user_message, assistant_message], metadata={})
+
+    def _convert_tool_execution_span(self, span: dict, session_id: str) -> ToolExecutionSpan | None:
+        """Convert OTEL span to ToolExecutionSpan."""
+        span_info = self._create_span_info(span, session_id)
+        attrs = span.get("attributes", {})
+
+        tool_name: str | None = None
+        tool_parameters: dict | None = None
+        tool_output_content: str | None = None
+        tool_call_id: str | None = None
+        tool_status: str | None = None
+
+        # Try live format first (attributes)
+        tool_name = attrs.get("tool.name") or span.get("name")
+
+        # Get input from attributes
+        input_value = attrs.get("input.value")
+        if input_value:
+            try:
+                if isinstance(input_value, str):
+                    tool_parameters = json.loads(input_value.replace("'", '"'))
+                elif isinstance(input_value, dict):
+                    tool_parameters = input_value
+            except json.JSONDecodeError:
+                tool_parameters = {}
+
+        # Get output from attributes
+        output_value = attrs.get("output.value")
+        if output_value:
+            try:
+                if isinstance(output_value, str):
+                    parsed = json.loads(output_value)
+                    tool_output_content = parsed.get("content", str(parsed))
+                    tool_call_id = parsed.get("tool_call_id")
+                    tool_status = parsed.get("status", "success")
+                elif isinstance(output_value, dict):
+                    tool_output_content = output_value.get("content", str(output_value))
+            except json.JSONDecodeError:
+                tool_output_content = str(output_value)
+
+        # Fallback to span_events format (CloudWatch/ADOT)
+        if not tool_name or tool_parameters is None or tool_output_content is None:
+            input_messages, output_messages = self._get_messages_from_span_events(span)
+
+            # Extract tool parameters from input
+            if input_messages and tool_parameters is None:
+                input_msg = input_messages[-1]
+                if input_msg.get("role") == "user":
+                    content_str = input_msg.get("content", "")
+                    if isinstance(content_str, str):
+                        try:
+                            parsed = json.loads(content_str.replace("'", '"'))
+                            if isinstance(parsed, dict):
+                                tool_parameters = parsed
+                        except json.JSONDecodeError:
+                            pass
+
+            # Extract tool result from output
+            if output_messages and tool_output_content is None:
+                output_msg = output_messages[-1]
+                if output_msg.get("role") == "assistant":
+                    content_str = output_msg.get("content", "")
+                    if isinstance(content_str, str):
+                        try:
+                            tool_data = json.loads(content_str)
+                            tool_output_content = tool_data.get("content")
+                            tool_call_id = tool_data.get("tool_call_id")
+                            tool_status = tool_data.get("status")
+                            if not tool_name:
+                                tool_name = tool_data.get("name")
+                        except json.JSONDecodeError:
+                            pass
+
+        # Validate required fields
+        if not tool_name or tool_parameters is None or tool_output_content is None:
+            logger.warning(f"Missing required fields for tool span {span.get('span_id')}")
+            return None
+
+        tool_call = ToolCall(name=tool_name, arguments=tool_parameters or {}, tool_call_id=tool_call_id)
+        tool_result = ToolResult(
+            content=tool_output_content or "",
+            error=None if tool_status == "success" else tool_status,
+            tool_call_id=tool_call_id,
+        )
+
+        return ToolExecutionSpan(span_info=span_info, tool_call=tool_call, tool_result=tool_result, metadata={})
+
+    def _convert_agent_invocation_span(self, span: dict, session_id: str) -> AgentInvocationSpan | None:
+        """Convert OTEL span to AgentInvocationSpan."""
+        span_info = self._create_span_info(span, session_id)
+        trace_id = span.get("trace_id", "")
+
+        input_messages, output_messages = self._get_messages_from_span_events(span)
+
+        user_prompt = self._extract_user_prompt(input_messages, span)
+        agent_response = self._extract_agent_response(output_messages, span)
+
+        if not user_prompt:
+            logger.warning(f"No user_prompt for agent span {span.get('span_id')}")
+            return None
+
+        if not agent_response:
+            logger.warning(f"No agent_response for agent span {span.get('span_id')}")
+            return None
+
+        available_tools = sorted(
+            self._trace_tools_map.get(trace_id, {}).values(),
+            key=lambda t: t.name,
+        )
+
+        return AgentInvocationSpan(
+            span_info=span_info,
+            user_prompt=user_prompt,
+            agent_response=agent_response,
+            available_tools=available_tools,
+            metadata={},
+        )
+
+    # =========================================================================
+    # Helper Methods
+    # =========================================================================
+
+    def _get_scope_name(self, span: dict) -> str:
+        """Extract scope name from span."""
+        scope = span.get("scope", {})
+        return scope.get("name", "") if isinstance(scope, dict) else ""
+
+    def _create_span_info(self, span: dict, session_id: str) -> SpanInfo:
+        """Create SpanInfo from span dict."""
+        start_time = self._parse_timestamp(span.get("start_time"))
+        end_time = self._parse_timestamp(span.get("end_time"))
+
+        return SpanInfo(
+            trace_id=span.get("trace_id"),
+            span_id=span.get("span_id"),
+            session_id=session_id,
+            parent_span_id=span.get("parent_span_id"),
+            start_time=start_time,
+            end_time=end_time,
+        )
+
+    def _parse_timestamp(self, value: Any) -> datetime:
+        """Parse timestamp from various formats."""
+        if value is None:
+            return datetime.now(timezone.utc)
+        if isinstance(value, datetime):
+            return value
+        if isinstance(value, str):
+            try:
+                if value.endswith("Z"):
+                    value = value[:-1] + "+00:00"
+                return datetime.fromisoformat(value)
+            except ValueError:
+                return datetime.now(timezone.utc)
+        if isinstance(value, (int, float)):
+            if value > 1e12:
+                value = value / 1e9
+            return datetime.fromtimestamp(value, tz=timezone.utc)
+        return datetime.now(timezone.utc)
+
+    def _get_messages_from_span_events(self, span: dict) -> tuple[list[dict], list[dict]]:
+        """Extract input and output messages from span events or attributes.
+
+        Handles two formats:
+        1. CloudWatch/ADOT: span_events[].body.input/output.messages
+        2. Live instrumentation: attributes.input.value / output.value
+        """
+        # Try span_events first (CloudWatch/ADOT format)
+        span_events = span.get("span_events", [])
+        for event in span_events:
+            event_name = event.get("event_name", "")
+            if event_name == SCOPE_NAME:
+                body = event.get("body", {})
+                input_group = body.get("input", {})
+                output_group = body.get("output", {})
+                input_msgs = input_group.get("messages", [])
+                output_msgs = output_group.get("messages", [])
+                if input_msgs or output_msgs:
+                    return input_msgs, output_msgs
+
+        # Fallback: try attributes (live instrumentation format)
+        attrs = span.get("attributes", {})
+        input_messages = []
+        output_messages = []
+
+        # Parse input.value
+        input_value = attrs.get("input.value")
+        if input_value:
+            try:
+                parsed = json.loads(input_value) if isinstance(input_value, str) else input_value
+                if isinstance(parsed, dict):
+                    # Format: {"messages": [...]}
+                    if "messages" in parsed:
+                        input_messages = [{"content": json.dumps(parsed), "role": "user"}]
+                    else:
+                        input_messages = [{"content": json.dumps(parsed), "role": "user"}]
+            except (json.JSONDecodeError, TypeError):
+                pass
+
+        # Parse output.value
+        output_value = attrs.get("output.value")
+        if output_value:
+            try:
+                parsed = json.loads(output_value) if isinstance(output_value, str) else output_value
+                output_messages = [
+                    {
+                        "content": json.dumps(parsed) if isinstance(parsed, (dict, list)) else str(parsed),
+                        "role": "assistant",
+                    }
+                ]
+            except (json.JSONDecodeError, TypeError):
+                pass
+
+        return input_messages, output_messages
+
+    def _extract_tools_from_attributes(self, attrs: dict) -> list[ToolConfig]:
+        """Extract tool definitions from llm.tools.*.tool.json_schema attributes."""
+        tools: list[ToolConfig] = []
+
+        for key, value in attrs.items():
+            if key.startswith("llm.tools.") and key.endswith(".tool.json_schema"):
+                try:
+                    tool_info = json.loads(value) if isinstance(value, str) else value
+                    tools.append(
+                        ToolConfig(
+                            name=tool_info.get("name"),
+                            description=tool_info.get("description"),
+                            parameters=tool_info.get("input_schema"),
+                        )
+                    )
+                except (json.JSONDecodeError, AttributeError):
+                    pass
+
+        return sorted(tools, key=lambda t: t.name or "")
+
+    def _extract_user_contents(
+        self, input_messages: list[dict], span: dict
+    ) -> tuple[list[TextContent | ToolResultContent], str | None]:
+        """Extract user contents from input messages or attributes."""
+        results: list[TextContent | ToolResultContent] = []
+        system_prompt: str | None = None
+        attrs = span.get("attributes", {})
+
+        # First, try to get from llm.input_messages attributes (live format)
+        user_content = attrs.get("llm.input_messages.0.message.content")
+        if user_content:
+            results.append(TextContent(text=user_content))
+            return results, system_prompt
+
+        # Try to find structured message list from input_messages
+        structured_messages = None
+        for msg in input_messages:
+            if msg.get("role") != "user":
+                continue
+            try:
+                content_json = json.loads(msg.get("content", ""))
+                if "messages" in content_json:
+                    structured_messages = content_json["messages"]
+                    break
+            except (json.JSONDecodeError, TypeError):
+                pass
+
+        if structured_messages:
+            # Handle nested list
+            if (
+                isinstance(structured_messages, list)
+                and structured_messages
+                and isinstance(structured_messages[0], list)
+            ):
+                structured_messages = structured_messages[0]
+
+            for item in structured_messages:
+                if not isinstance(item, dict):
+                    continue
+                kwargs = item.get("kwargs", {})
+                data_type = kwargs.get("type")
+
+                if data_type == "human":
+                    results.append(TextContent(text=kwargs.get("content", "")))
+                elif data_type == "tool":
+                    status = kwargs.get("status")
+                    results.append(
+                        ToolResultContent(
+                            content=kwargs.get("content", ""),
+                            tool_call_id=kwargs.get("tool_call_id"),
+                            error=None if status == "success" else status,
+                        )
+                    )
+                elif data_type == "system":
+                    system_prompt = kwargs.get("content")
+        else:
+            # Fallback: use raw content
+            for msg in input_messages:
+                if msg.get("role") == "user":
+                    content = msg.get("content", "")
+                    # Try to parse if it's a JSON string
+                    try:
+                        parsed = json.loads(content)
+                        if isinstance(parsed, dict) and "messages" in parsed:
+                            # Extract first human message
+                            for m in parsed.get("messages", []):
+                                if isinstance(m, dict):
+                                    c = m.get("content", "")
+                                    if c:
+                                        results.append(TextContent(text=c))
+                                        break
+                        else:
+                            results.append(TextContent(text=content))
+                    except (json.JSONDecodeError, TypeError):
+                        results.append(TextContent(text=content))
+                    break
+
+        return results, system_prompt
+
+    def _extract_assistant_contents(
+        self, output_messages: list[dict], span: dict
+    ) -> list[TextContent | ToolCallContent]:
+        """Extract assistant contents from output messages or attributes."""
+        results: list[TextContent | ToolCallContent] = []
+        attrs = span.get("attributes", {})
+
+        # First, try to get from llm.output_messages attributes (live format)
+        assistant_content = attrs.get("llm.output_messages.0.message.content")
+        if assistant_content:
+            results.append(TextContent(text=assistant_content))
+
+            # Check for tool calls in attributes
+            tool_idx = 0
+            while True:
+                tool_name = attrs.get(f"llm.output_messages.0.message.tool_calls.{tool_idx}.tool_call.function.name")
+                if not tool_name:
+                    break
+                tool_args_str = attrs.get(
+                    f"llm.output_messages.0.message.tool_calls.{tool_idx}.tool_call.function.arguments", "{}"
+                )
+                tool_id = attrs.get(f"llm.output_messages.0.message.tool_calls.{tool_idx}.tool_call.id")
+                try:
+                    tool_args = json.loads(tool_args_str) if isinstance(tool_args_str, str) else tool_args_str
+                except json.JSONDecodeError:
+                    tool_args = {}
+                results.append(ToolCallContent(name=tool_name, arguments=tool_args, tool_call_id=tool_id))
+                tool_idx += 1
+
+            if results:
+                return results
+
+        # Try parsing from output_messages
+        for msg in output_messages:
+            if msg.get("role") != "assistant":
+                continue
+
+            content_str = msg.get("content", "")
+            if not isinstance(content_str, str):
+                content_str = json.dumps(content_str)
+
+            try:
+                gen = json.loads(content_str)
+                if "generations" in gen:
+                    gen_item = gen["generations"][0][0]
+                    results.append(TextContent(text=gen_item.get("text", "")))
+
+                    # Extract tool calls
+                    kwargs = gen_item.get("message", {}).get("kwargs", {})
+                    for call in kwargs.get("tool_calls", []):
+                        results.append(
+                            ToolCallContent(
+                                name=call.get("name", ""),
+                                arguments=call.get("args", {}),
+                                tool_call_id=call.get("id"),
+                            )
+                        )
+                    return results
+            except (json.JSONDecodeError, KeyError, IndexError, TypeError):
+                pass
+
+        # Fallback: use raw content
+        for msg in output_messages:
+            if msg.get("role") == "assistant":
+                content_str = msg.get("content", "")
+                if isinstance(content_str, str):
+                    results.append(TextContent(text=content_str))
+
+        return results
+
+    def _extract_user_prompt(self, input_messages: list[dict], span: dict) -> str | None:
+        """Extract user prompt from agent invocation input."""
+        for msg in input_messages:
+            if msg.get("role") != "user":
+                continue
+
+            content_str = msg.get("content", "")
+            if not isinstance(content_str, str):
+                continue
+
+            try:
+                j = json.loads(content_str)
+                if "messages" in j:
+                    messages = j["messages"]
+                    for item in messages:
+                        if isinstance(item, dict):
+                            kwargs = item.get("kwargs", {})
+                            if kwargs.get("type") == "human":
+                                return kwargs.get("content", "")
+                            if item.get("type") == "human":
+                                return item.get("content", "")
+                            if item.get("role") == "user":
+                                return item.get("content", "")
+            except json.JSONDecodeError:
+                return content_str
+
+        return None
+
+    def _extract_agent_response(self, output_messages: list[dict], span: dict) -> str | None:
+        """Extract agent response from agent invocation output."""
+        for msg in output_messages:
+            if msg.get("role") != "assistant":
+                continue
+
+            content_str = msg.get("content", "")
+            if not isinstance(content_str, str):
+                content_str = json.dumps(content_str)
+
+            try:
+                j = json.loads(content_str)
+
+                # Check for messages structure
+                if "messages" in j:
+                    messages = j["messages"]
+                    if isinstance(messages, list):
+                        # Iterate backwards to find last AI message
+                        for item in reversed(messages):
+                            if isinstance(item, dict):
+                                kwargs = item.get("kwargs", {}) if "kwargs" in item else item
+                                if item.get("type") == "ai" or kwargs.get("type") == "ai":
+                                    return kwargs.get("content", "")
+
+                # Check for generations structure
+                if "generations" in j:
+                    return j["generations"][0][0].get("text", "")
+
+            except (json.JSONDecodeError, KeyError, IndexError, TypeError):
+                pass
+
+        return None

--- a/src/strands_evals/mappers/session_mapper.py
+++ b/src/strands_evals/mappers/session_mapper.py
@@ -13,15 +13,62 @@ class SessionMapper(ABC):
     """Base class for mapping telemetry data to Session format for evaluation."""
 
     @abstractmethod
-    def map_to_session(self, spans: list[Any], session_id: str) -> Session:
+    def map_to_session(self, data: Any, session_id: str) -> Session:
         """
-        Map spans to Session format.
+        Map trace data to Session format.
 
         Args:
-            spans: List of span objects
+            data: Trace data in various formats:
+                - Flat list of spans: [{"trace_id": "x", "span_id": "y", ...}, ...]
+                - Grouped by trace_id: {"trace_1": [spans], "trace_2": [spans]}
+                - List of trace objects: [{"trace_id": "x", "spans": [...]}, ...]
             session_id: Session identifier
 
         Returns:
             Session object ready for evaluation
         """
         pass
+
+    def _normalize_to_flat_spans(self, data: Any) -> list[dict]:
+        """Normalize various input formats to a flat list of spans.
+
+        Accepts:
+        - Flat list of spans: [{"trace_id": "x", "span_id": "y", ...}, ...]
+        - Grouped by trace_id: {"trace_1": [spans], "trace_2": [spans]}
+        - List of trace objects: [{"trace_id": "x", "spans": [...]}, ...]
+
+        Returns:
+            Flat list of span dictionaries
+        """
+        if not data:
+            return []
+
+        # Case 1: Grouped by trace_id: {"trace_1": [spans], "trace_2": [spans]}
+        if isinstance(data, dict):
+            result: list[dict] = []
+            for value in data.values():
+                if isinstance(value, list):
+                    result.extend(span for span in value if isinstance(span, dict))
+            return result
+
+        # Case 2: List input
+        if isinstance(data, list):
+            # Check if it's a list of trace objects with "spans" key
+            # by looking for any element with "spans"
+            has_spans_key = any(isinstance(item, dict) and "spans" in item for item in data)
+
+            if has_spans_key:
+                # List of trace objects: [{"trace_id": "x", "spans": [...]}, ...]
+                result = []
+                for trace in data:
+                    if isinstance(trace, dict):
+                        spans = trace.get("spans", [])
+                        if isinstance(spans, list):
+                            result.extend(span for span in spans if isinstance(span, dict))
+                return result
+            else:
+                # Flat list of spans: [{"trace_id": "x", "span_id": "y", ...}, ...]
+                return [item for item in data if isinstance(item, dict)]
+
+        # Fallback for unexpected types
+        return []

--- a/src/strands_evals/mappers/strands_in_memory_session_mapper.py
+++ b/src/strands_evals/mappers/strands_in_memory_session_mapper.py
@@ -62,21 +62,21 @@ class StrandsInMemorySessionMapper(SessionMapper):
 
     def map_to_session(
         self,
-        otel_spans: list[ReadableSpan],
+        data: list[ReadableSpan],
         session_id: str,
     ) -> Session:
-        if otel_spans:
-            self._convention_version = self._detect_convention_version(otel_spans[0])
+        if data:
+            self._convention_version = self._detect_convention_version(data[0])
 
         # Check if any spans have session.id or gen_ai.conversation.id attribute
         any_span_has_session_id = any(
             span.attributes and ("session.id" in span.attributes or "gen_ai.conversation.id" in span.attributes)
-            for span in otel_spans
+            for span in data
         )
 
         # Build traces: if no spans have session IDs, include all; otherwise filter by matching session_id
         traces_by_id = defaultdict(list)
-        for span in otel_spans:
+        for span in data:
             should_include = False
 
             if not any_span_has_session_id:

--- a/src/strands_evals/mappers/utils.py
+++ b/src/strands_evals/mappers/utils.py
@@ -1,0 +1,174 @@
+"""
+Utility functions for mapper selection and detection.
+"""
+
+from typing import Any
+
+from .session_mapper import SessionMapper
+
+
+def detect_otel_mapper(spans: list[Any]) -> SessionMapper:
+    """Detect the appropriate mapper based on span scope and data format.
+
+    Examines spans to determine:
+    1. Which framework produced the traces (via scope.name)
+    2. What data format is used (CloudWatch body vs gen_ai.* attributes)
+
+    For Strands telemetry, auto-detects format:
+    - CloudWatch format: span_events[].body.input/output OR body directly
+    - InMemory format: gen_ai.* attributes
+
+    Args:
+        spans: List of span dictionaries (normalized or raw)
+
+    Returns:
+        Appropriate SessionMapper instance
+
+    Example:
+        >>> # After CloudWatchLogsParser normalization
+        >>> normalized = CloudWatchLogsParser(raw_logs).parse()
+        >>> mapper = detect_otel_mapper(normalized)
+        >>> session = mapper.map_to_session(normalized, "session-123")
+
+        >>> # After readable_spans_to_dicts
+        >>> spans = readable_spans_to_dicts(exporter.get_finished_spans())
+        >>> mapper = detect_otel_mapper(spans)
+        >>> session = mapper.map_to_session(spans, "session-123")
+    """
+    # Import here to avoid circular imports
+    from .cloudwatch_session_mapper import CloudWatchSessionMapper
+    from .langchain_otel_session_mapper import LangChainOtelSessionMapper
+    from .openinference_session_mapper import OpenInferenceSessionMapper
+    from .strands_in_memory_session_mapper import StrandsInMemorySessionMapper
+
+    if not spans:
+        return StrandsInMemorySessionMapper()
+
+    # Detect scope and format from first relevant span
+    for span in spans:
+        scope_name = get_scope_name(span)
+
+        if scope_name == "opentelemetry.instrumentation.langchain":
+            return LangChainOtelSessionMapper()
+
+        if scope_name == "openinference.instrumentation.langchain":
+            return OpenInferenceSessionMapper()
+
+        if scope_name == "strands.telemetry.tracer":
+            # Auto-detect format for Strands
+            if get_body(span) is not None:
+                return CloudWatchSessionMapper()
+            else:
+                return StrandsInMemorySessionMapper()
+
+    # Default to StrandsInMemorySessionMapper
+    return StrandsInMemorySessionMapper()
+
+
+def get_body(span: dict) -> dict | None:
+    """Extract body from span, handling both normalized and raw formats.
+
+    Normalized format: span_events[].body
+    Raw format: span.body directly
+    """
+    # Try normalized format first (span_events[].body)
+    span_events = span.get("span_events", [])
+    for event in span_events:
+        body = event.get("body")
+        if isinstance(body, dict) and ("input" in body or "output" in body):
+            return body
+
+    # Fall back to raw format (body directly on span/record)
+    body = span.get("body")
+    if isinstance(body, dict):
+        return body
+
+    return None
+
+
+def get_scope_name(span: Any) -> str:
+    """Extract the instrumentation scope name from a span or event.
+
+    Handles:
+    - Dict-based spans with scope.name
+    - Dict-based events with attributes.event.name (CloudWatch format)
+    - ReadableSpan objects with instrumentation_scope
+
+    Args:
+        span: A span/event dictionary or ReadableSpan object
+
+    Returns:
+        The scope name, or empty string if not found
+    """
+    if isinstance(span, dict):
+        # Try scope.name first (standard OTEL span format)
+        scope = span.get("scope", {})
+        if isinstance(scope, dict):
+            scope_name = scope.get("name", "")
+            if scope_name:
+                return scope_name
+
+        # Try attributes.event.name (CloudWatch event format)
+        attrs = span.get("attributes", {})
+        if isinstance(attrs, dict):
+            event_name = attrs.get("event.name", "")
+            if event_name:
+                return event_name
+    else:
+        # Handle ReadableSpan objects
+        if hasattr(span, "instrumentation_scope"):
+            return getattr(span.instrumentation_scope, "name", "")
+
+    return ""
+
+
+def readable_spans_to_dicts(spans: Any) -> list[dict]:
+    """Convert OpenTelemetry ReadableSpan objects to dict format.
+
+    This utility converts spans from the OpenTelemetry SDK's InMemorySpanExporter
+    (which returns ReadableSpan objects) to the dict format expected by mappers.
+
+    Args:
+        spans: Iterable of ReadableSpan objects from InMemorySpanExporter
+
+    Returns:
+        List of span dictionaries ready for use with mappers
+
+    Example:
+        >>> from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+        >>> exporter = InMemorySpanExporter()
+        >>> # ... run instrumented code ...
+        >>> spans = readable_spans_to_dicts(exporter.get_finished_spans())
+        >>> mapper = detect_otel_mapper(spans)
+        >>> session = mapper.map_to_session(spans, "session-123")
+    """
+    result = []
+    for span in spans:
+        span_dict = {
+            "trace_id": format(span.context.trace_id, "032x"),
+            "span_id": format(span.context.span_id, "016x"),
+            "parent_span_id": format(span.parent.span_id, "016x") if span.parent else None,
+            "name": span.name,
+            "start_time": span.start_time,
+            "end_time": span.end_time,
+            "attributes": dict(span.attributes) if span.attributes else {},
+            "scope": {
+                "name": span.instrumentation_scope.name if span.instrumentation_scope else "",
+                "version": span.instrumentation_scope.version if span.instrumentation_scope else "",
+            },
+            "status": {"code": span.status.status_code.name if span.status else "UNSET"},
+            "span_events": [],
+        }
+
+        # Convert events
+        if span.events:
+            for event in span.events:
+                event_dict = {
+                    "event_name": event.name,
+                    "timestamp": event.timestamp,
+                    "attributes": dict(event.attributes) if event.attributes else {},
+                }
+                span_dict["span_events"].append(event_dict)
+
+        result.append(span_dict)
+    return result

--- a/tests/strands_evals/mappers/test_cloudwatch_parser.py
+++ b/tests/strands_evals/mappers/test_cloudwatch_parser.py
@@ -1,0 +1,221 @@
+"""Tests for CloudWatchLogsParser - raw CloudWatch logs → normalized span format."""
+
+from strands_evals.mappers import CloudWatchLogsParser, parse_cloudwatch_logs
+
+
+def make_span_record(
+    trace_id="trace-1",
+    span_id="span-1",
+    parent_span_id=None,
+    name="test-span",
+    start_time=1700000000000000000,
+    end_time=1700000001000000000,
+    attributes=None,
+    scope_name="strands.telemetry.tracer",
+):
+    """Build a raw CloudWatch SPAN record (camelCase format)."""
+    record = {
+        "traceId": trace_id,
+        "spanId": span_id,
+        "name": name,
+        "startTimeUnixNano": start_time,
+        "endTimeUnixNano": end_time,
+        "attributes": attributes or {},
+        "scope": {"name": scope_name, "version": "0.1.0"},
+        "status": {"code": "OK"},
+    }
+    if parent_span_id:
+        record["parentSpanId"] = parent_span_id
+    return record
+
+
+def make_event_record(
+    span_id="span-1",
+    event_name="strands.telemetry.tracer",
+    time_nano=1700000000500000000,
+    attributes=None,
+    body=None,
+):
+    """Build a raw CloudWatch EVENT record."""
+    return {
+        "spanId": span_id,
+        "EventName": event_name,
+        "timeUnixNano": time_nano,
+        "attributes": attributes or {},
+        "body": body or {},
+    }
+
+
+class TestRecordTypeDetection:
+    def setup_method(self):
+        self.parser = CloudWatchLogsParser([])
+
+    def test_span_record_detected(self):
+        """Record with start/end time is detected as span."""
+        record = make_span_record()
+        assert self.parser._is_span(record) is True
+        assert self.parser._is_event(record) is False
+
+    def test_event_record_detected_by_event_name(self):
+        """Record with EventName is detected as event."""
+        record = make_event_record()
+        assert self.parser._is_event(record) is True
+        assert self.parser._is_span(record) is False
+
+    def test_event_record_detected_by_attributes_event_name(self):
+        """Record with attributes.event.name is detected as event."""
+        record = {
+            "spanId": "span-1",
+            "attributes": {"event.name": "test.event"},
+        }
+        assert self.parser._is_event(record) is True
+
+    def test_invalid_record_not_detected(self):
+        """Invalid records are not detected as span or event."""
+        record = {"foo": "bar"}
+        assert self.parser._is_span(record) is False
+        assert self.parser._is_event(record) is False
+
+
+class TestSpanNormalization:
+    def setup_method(self):
+        self.parser = CloudWatchLogsParser([])
+
+    def test_camel_case_to_snake_case(self):
+        """camelCase field names are normalized to snake_case."""
+        record = make_span_record(
+            trace_id="t1",
+            span_id="s1",
+            parent_span_id="p1",
+        )
+        normalized = self.parser._normalize_span(record)
+
+        assert normalized["trace_id"] == "t1"
+        assert normalized["span_id"] == "s1"
+        assert normalized["parent_span_id"] == "p1"
+
+    def test_timestamps_preserved(self):
+        """Timestamps are preserved in normalized output."""
+        record = make_span_record(
+            start_time=1700000000000000000,
+            end_time=1700000001000000000,
+        )
+        normalized = self.parser._normalize_span(record)
+
+        assert normalized["start_time"] == 1700000000000000000
+        assert normalized["end_time"] == 1700000001000000000
+
+    def test_scope_normalized(self):
+        """Scope is normalized to dict format."""
+        record = make_span_record(scope_name="test.scope")
+        normalized = self.parser._normalize_span(record)
+
+        assert normalized["scope"]["name"] == "test.scope"
+
+    def test_span_events_initialized_empty(self):
+        """Normalized span has empty span_events list."""
+        record = make_span_record()
+        normalized = self.parser._normalize_span(record)
+
+        assert normalized["span_events"] == []
+
+
+class TestEventNormalization:
+    def setup_method(self):
+        self.parser = CloudWatchLogsParser([])
+
+    def test_event_name_extracted(self):
+        """Event name is extracted from EventName field."""
+        record = make_event_record(event_name="test.event")
+        normalized = self.parser._normalize_event(record)
+
+        assert normalized["event_name"] == "test.event"
+
+    def test_span_id_extracted(self):
+        """Span ID is extracted from spanId field."""
+        record = make_event_record(span_id="s1")
+        normalized = self.parser._normalize_event(record)
+
+        assert normalized["span_id"] == "s1"
+
+    def test_body_preserved(self):
+        """Body is preserved in normalized event."""
+        body = {"input": {"messages": []}, "output": {"messages": []}}
+        record = make_event_record(body=body)
+        normalized = self.parser._normalize_event(record)
+
+        assert normalized["body"] == body
+
+
+class TestParserIntegration:
+    def test_spans_with_events_associated(self):
+        """Events are associated with their parent spans."""
+        span = make_span_record(trace_id="t1", span_id="s1")
+        event = make_event_record(span_id="s1", body={"data": "test"})
+
+        parser = CloudWatchLogsParser([span, event])
+        result = parser.parse()
+
+        assert len(result) == 1
+        assert result[0]["span_id"] == "s1"
+        assert len(result[0]["span_events"]) == 1
+        assert result[0]["span_events"][0]["body"] == {"data": "test"}
+
+    def test_multiple_events_per_span(self):
+        """Multiple events are associated with same span."""
+        span = make_span_record(trace_id="t1", span_id="s1")
+        event1 = make_event_record(span_id="s1", time_nano=1000)
+        event2 = make_event_record(span_id="s1", time_nano=2000)
+
+        parser = CloudWatchLogsParser([span, event1, event2])
+        result = parser.parse()
+
+        assert len(result) == 1
+        assert len(result[0]["span_events"]) == 2
+
+    def test_synthetic_span_from_orphan_events(self):
+        """Synthetic span is created when only events exist (no span records)."""
+        event = make_event_record(
+            span_id="s1",
+            event_name="test.event",
+            body={"input": {"messages": []}, "output": {"messages": []}},
+        )
+
+        parser = CloudWatchLogsParser([event])
+        result = parser.parse()
+
+        assert len(result) == 1
+        assert result[0]["span_id"] == "s1"
+        assert len(result[0]["span_events"]) == 1
+
+    def test_empty_logs(self):
+        """Empty logs return empty result."""
+        parser = CloudWatchLogsParser([])
+        result = parser.parse()
+
+        assert result == []
+
+    def test_multiple_spans_multiple_traces(self):
+        """Multiple spans from different traces are all included."""
+        span1 = make_span_record(trace_id="t1", span_id="s1")
+        span2 = make_span_record(trace_id="t2", span_id="s2")
+
+        parser = CloudWatchLogsParser([span1, span2])
+        result = parser.parse()
+
+        assert len(result) == 2
+        span_ids = {s["span_id"] for s in result}
+        assert span_ids == {"s1", "s2"}
+
+
+class TestConvenienceFunction:
+    def test_parse_cloudwatch_logs_function(self):
+        """Convenience function works same as class."""
+        span = make_span_record(trace_id="t1", span_id="s1")
+        event = make_event_record(span_id="s1")
+
+        result = parse_cloudwatch_logs([span, event])
+
+        assert len(result) == 1
+        assert result[0]["span_id"] == "s1"
+        assert len(result[0]["span_events"]) == 1

--- a/tests/strands_evals/mappers/test_langchain_mapper_integration.py
+++ b/tests/strands_evals/mappers/test_langchain_mapper_integration.py
@@ -1,0 +1,538 @@
+"""Integration tests for LangChain mappers with the evaluation pipeline.
+
+These tests verify that the LangChain mappers (both Traceloop/OpenLLMetry and OpenInference)
+correctly integrate with the strands-evals evaluation framework.
+"""
+
+import json
+
+import pytest
+
+from strands_evals import Case, Experiment
+from strands_evals.evaluators import Evaluator
+from strands_evals.mappers import (
+    LangChainOtelSessionMapper,
+    OpenInferenceSessionMapper,
+    detect_otel_mapper,
+)
+from strands_evals.types import EvaluationData, EvaluationOutput
+from strands_evals.types.trace import AgentInvocationSpan, ToolExecutionSpan
+
+TRACELOOP_SCOPE = "opentelemetry.instrumentation.langchain"
+OPENINFERENCE_SCOPE = "openinference.instrumentation.langchain"
+
+
+def make_traceloop_span(
+    trace_id="trace-1",
+    span_id="span-1",
+    parent_span_id=None,
+    name="test-span",
+    attributes=None,
+    start_time=1700000000000000000,
+    end_time=1700000001000000000,
+):
+    """Build a span dict for Traceloop/OpenLLMetry LangChain traces."""
+    return {
+        "trace_id": trace_id,
+        "span_id": span_id,
+        "parent_span_id": parent_span_id,
+        "name": name,
+        "start_time": start_time,
+        "end_time": end_time,
+        "attributes": attributes or {},
+        "scope": {"name": TRACELOOP_SCOPE, "version": "0.1.0"},
+        "status": {"code": "OK"},
+        "span_events": [],
+    }
+
+
+def make_openinference_span(
+    trace_id="trace-1",
+    span_id="span-1",
+    parent_span_id=None,
+    name="test-span",
+    attributes=None,
+    start_time=1700000000000000000,
+    end_time=1700000001000000000,
+):
+    """Build a span dict for OpenInference LangChain traces."""
+    return {
+        "trace_id": trace_id,
+        "span_id": span_id,
+        "parent_span_id": parent_span_id,
+        "name": name,
+        "start_time": start_time,
+        "end_time": end_time,
+        "attributes": attributes or {},
+        "scope": {"name": OPENINFERENCE_SCOPE, "version": "0.1.0"},
+        "status": {"code": "OK"},
+        "span_events": [],
+    }
+
+
+def create_traceloop_agent_trace(user_query: str, agent_response: str, tool_name: str, tool_result: str):
+    """Create a complete Traceloop agent trace with inference, tool use, and agent invocation spans."""
+    trace_id = "trace-weather-1"
+
+    # LLM inference span with tool call
+    inference_span = make_traceloop_span(
+        trace_id=trace_id,
+        span_id="span-llm-1",
+        attributes={
+            "llm.request.type": "chat",
+            "gen_ai.prompt.0.role": "user",
+            "gen_ai.prompt.0.content": user_query,
+            "gen_ai.completion.0.role": "assistant",
+            "gen_ai.completion.0.content": "Let me check that for you.",
+            "gen_ai.completion.0.tool_calls.0.name": tool_name,
+            "gen_ai.completion.0.tool_calls.0.arguments": json.dumps({"city": "Seattle"}),
+            "gen_ai.completion.0.tool_calls.0.id": "tc-1",
+            "llm.request.functions.0.name": tool_name,
+            "llm.request.functions.0.description": "Get current weather for a city",
+        },
+    )
+
+    # Tool execution span
+    tool_span = make_traceloop_span(
+        trace_id=trace_id,
+        span_id="span-tool-1",
+        attributes={
+            "traceloop.span.kind": "tool",
+            "traceloop.entity.name": tool_name,
+            "traceloop.entity.input": json.dumps({"inputs": {"city": "Seattle"}}),
+            "traceloop.entity.output": json.dumps(
+                {"output": {"kwargs": {"content": tool_result, "tool_call_id": "tc-1", "status": "success"}}}
+            ),
+        },
+    )
+
+    # Final LLM inference span after tool result
+    inference_span_2 = make_traceloop_span(
+        trace_id=trace_id,
+        span_id="span-llm-2",
+        attributes={
+            "llm.request.type": "chat",
+            "gen_ai.prompt.0.role": "user",
+            "gen_ai.prompt.0.content": f"Tool result: {tool_result}",
+            "gen_ai.completion.0.role": "assistant",
+            "gen_ai.completion.0.content": agent_response,
+        },
+    )
+
+    # Workflow/agent invocation span
+    workflow_span = make_traceloop_span(
+        trace_id=trace_id,
+        span_id="span-workflow-1",
+        attributes={
+            "traceloop.span.kind": "workflow",
+            "traceloop.entity.input": json.dumps(
+                {"inputs": {"messages": [{"kwargs": {"content": user_query, "type": "human"}}]}}
+            ),
+            "traceloop.entity.output": json.dumps(
+                {"outputs": {"messages": [{"kwargs": {"content": agent_response, "type": "ai"}}]}}
+            ),
+        },
+    )
+
+    return [inference_span, tool_span, inference_span_2, workflow_span]
+
+
+def create_openinference_agent_trace(user_query: str, agent_response: str, tool_name: str, tool_result: str):
+    """Create a complete OpenInference agent trace with LLM, tool, and chain spans."""
+    trace_id = "trace-weather-2"
+
+    # LLM span with tool call
+    llm_span = make_openinference_span(
+        trace_id=trace_id,
+        span_id="span-llm-1",
+        attributes={
+            "openinference.span.kind": "LLM",
+            "llm.input_messages.0.message.role": "user",
+            "llm.input_messages.0.message.content": user_query,
+            "llm.output_messages.0.message.role": "assistant",
+            "llm.output_messages.0.message.content": "Let me check that for you.",
+            "llm.output_messages.0.message.tool_calls.0.tool_call.function.name": tool_name,
+            "llm.output_messages.0.message.tool_calls.0.tool_call.function.arguments": json.dumps({"city": "Seattle"}),
+            "llm.output_messages.0.message.tool_calls.0.tool_call.id": "tc-1",
+            "llm.tools.0.tool.json_schema": json.dumps(
+                {
+                    "name": tool_name,
+                    "description": "Get current weather for a city",
+                    "input_schema": {"type": "object"},
+                }
+            ),
+        },
+    )
+
+    # Tool span
+    tool_span = make_openinference_span(
+        trace_id=trace_id,
+        span_id="span-tool-1",
+        name=tool_name,
+        attributes={
+            "openinference.span.kind": "TOOL",
+            "tool.name": tool_name,
+            "input.value": json.dumps({"city": "Seattle"}),
+            "output.value": json.dumps({"content": tool_result, "tool_call_id": "tc-1", "status": "success"}),
+        },
+    )
+
+    # Final LLM span
+    llm_span_2 = make_openinference_span(
+        trace_id=trace_id,
+        span_id="span-llm-2",
+        attributes={
+            "openinference.span.kind": "LLM",
+            "llm.input_messages.0.message.role": "user",
+            "llm.input_messages.0.message.content": f"Tool result: {tool_result}",
+            "llm.output_messages.0.message.role": "assistant",
+            "llm.output_messages.0.message.content": agent_response,
+        },
+    )
+
+    # Chain/LangGraph span (agent invocation)
+    chain_span = make_openinference_span(
+        trace_id=trace_id,
+        span_id="span-chain-1",
+        name="LangGraph",
+        attributes={
+            "openinference.span.kind": "CHAIN",
+            "input.value": json.dumps({"messages": [{"kwargs": {"content": user_query, "type": "human"}}]}),
+            "output.value": json.dumps({"messages": [{"kwargs": {"content": agent_response, "type": "ai"}}]}),
+        },
+    )
+
+    return [llm_span, tool_span, llm_span_2, chain_span]
+
+
+class TrajectoryCheckEvaluator(Evaluator[str, str]):
+    """Evaluator that checks trajectory has expected tool usage."""
+
+    def _check_trajectory(self, evaluation_case: EvaluationData[str, str]) -> list[EvaluationOutput]:
+        """Common logic for checking trajectory."""
+        trajectory = evaluation_case.actual_trajectory
+        expected_tool = evaluation_case.metadata.get("expected_tool")
+
+        if not trajectory or not hasattr(trajectory, "traces"):
+            return [EvaluationOutput(score=0.0, test_pass=False, reason="No trajectory found")]
+
+        # Find tool execution spans
+        tool_found = False
+        for trace in trajectory.traces:
+            for span in trace.spans:
+                if isinstance(span, ToolExecutionSpan):
+                    if span.tool_call.name == expected_tool:
+                        tool_found = True
+                        break
+
+        if tool_found:
+            return [EvaluationOutput(score=1.0, test_pass=True, reason=f"Found expected tool: {expected_tool}")]
+        return [
+            EvaluationOutput(
+                score=0.0,
+                test_pass=False,
+                reason=f"Expected tool '{expected_tool}' not found in trajectory",
+            )
+        ]
+
+    def evaluate(self, evaluation_case: EvaluationData[str, str]) -> list[EvaluationOutput]:
+        return self._check_trajectory(evaluation_case)
+
+    async def evaluate_async(self, evaluation_case: EvaluationData[str, str]) -> list[EvaluationOutput]:
+        return self._check_trajectory(evaluation_case)
+
+
+class TestMapperAutoDetection:
+    """Test that detect_otel_mapper correctly identifies LangChain mappers."""
+
+    def test_detect_traceloop_mapper(self):
+        """Traceloop spans should be detected and mapped to LangChainOtelSessionMapper."""
+        spans = create_traceloop_agent_trace(
+            user_query="What's the weather?",
+            agent_response="It's sunny.",
+            tool_name="get_weather",
+            tool_result="Sunny, 72F",
+        )
+        mapper = detect_otel_mapper(spans)
+        assert isinstance(mapper, LangChainOtelSessionMapper)
+
+    def test_detect_openinference_mapper(self):
+        """OpenInference spans should be detected and mapped to OpenInferenceSessionMapper."""
+        spans = create_openinference_agent_trace(
+            user_query="What's the weather?",
+            agent_response="It's sunny.",
+            tool_name="get_weather",
+            tool_result="Sunny, 72F",
+        )
+        mapper = detect_otel_mapper(spans)
+        assert isinstance(mapper, OpenInferenceSessionMapper)
+
+
+class TestTraceloopMapperIntegration:
+    """Integration tests for Traceloop/OpenLLMetry mapper with evaluation pipeline."""
+
+    def test_mapper_produces_valid_session(self):
+        """Verify mapper produces a session with all expected span types."""
+        spans = create_traceloop_agent_trace(
+            user_query="What's the weather in Seattle?",
+            agent_response="The weather in Seattle is rainy, 55F.",
+            tool_name="get_weather",
+            tool_result="Rainy, 55F",
+        )
+
+        mapper = LangChainOtelSessionMapper()
+        session = mapper.map_to_session(spans, "test-session")
+
+        assert session.session_id == "test-session"
+        assert len(session.traces) == 1
+
+        span_types = [type(s).__name__ for s in session.traces[0].spans]
+        assert "InferenceSpan" in span_types
+        assert "ToolExecutionSpan" in span_types
+        assert "AgentInvocationSpan" in span_types
+
+    def test_evaluation_with_traceloop_mapper(self):
+        """Test full evaluation pipeline with Traceloop mapper."""
+        test_cases = [
+            Case[str, str](
+                name="weather-seattle",
+                input="What's the weather in Seattle?",
+                metadata={"expected_tool": "get_weather"},
+            ),
+        ]
+
+        def task_function(case: Case) -> dict:
+            spans = create_traceloop_agent_trace(
+                user_query=case.input,
+                agent_response="The weather in Seattle is rainy, 55F.",
+                tool_name="get_weather",
+                tool_result="Rainy, 55F",
+            )
+            mapper = detect_otel_mapper(spans)
+            session = mapper.map_to_session(spans, session_id=case.session_id)
+            return {
+                "output": "The weather in Seattle is rainy, 55F.",
+                "trajectory": session,
+            }
+
+        experiment = Experiment(cases=test_cases, evaluators=[TrajectoryCheckEvaluator()])
+        reports = experiment.run_evaluations(task_function)
+
+        assert len(reports) == 1
+        assert reports[0].scores[0] == 1.0
+        assert reports[0].test_passes[0] is True
+
+    def test_traceloop_mapper_extracts_tools(self):
+        """Verify that available tools are extracted from inference spans."""
+        spans = create_traceloop_agent_trace(
+            user_query="What's the weather?",
+            agent_response="Sunny!",
+            tool_name="get_weather",
+            tool_result="Sunny",
+        )
+
+        mapper = LangChainOtelSessionMapper()
+        session = mapper.map_to_session(spans, "test-session")
+
+        agent_spans = [s for s in session.traces[0].spans if isinstance(s, AgentInvocationSpan)]
+        assert len(agent_spans) == 1
+        assert len(agent_spans[0].available_tools) == 1
+        assert agent_spans[0].available_tools[0].name == "get_weather"
+
+
+class TestOpenInferenceMapperIntegration:
+    """Integration tests for OpenInference mapper with evaluation pipeline."""
+
+    def test_mapper_produces_valid_session(self):
+        """Verify mapper produces a session with all expected span types."""
+        spans = create_openinference_agent_trace(
+            user_query="What's the weather in Tokyo?",
+            agent_response="The weather in Tokyo is clear, 68F.",
+            tool_name="get_weather",
+            tool_result="Clear, 68F",
+        )
+
+        mapper = OpenInferenceSessionMapper()
+        session = mapper.map_to_session(spans, "test-session")
+
+        assert session.session_id == "test-session"
+        assert len(session.traces) == 1
+
+        span_types = [type(s).__name__ for s in session.traces[0].spans]
+        assert "InferenceSpan" in span_types
+        assert "ToolExecutionSpan" in span_types
+        assert "AgentInvocationSpan" in span_types
+
+    def test_evaluation_with_openinference_mapper(self):
+        """Test full evaluation pipeline with OpenInference mapper."""
+        test_cases = [
+            Case[str, str](
+                name="weather-tokyo",
+                input="What's the weather in Tokyo?",
+                metadata={"expected_tool": "get_weather"},
+            ),
+        ]
+
+        def task_function(case: Case) -> dict:
+            spans = create_openinference_agent_trace(
+                user_query=case.input,
+                agent_response="The weather in Tokyo is clear, 68F.",
+                tool_name="get_weather",
+                tool_result="Clear, 68F",
+            )
+            mapper = detect_otel_mapper(spans)
+            session = mapper.map_to_session(spans, session_id=case.session_id)
+            return {
+                "output": "The weather in Tokyo is clear, 68F.",
+                "trajectory": session,
+            }
+
+        experiment = Experiment(cases=test_cases, evaluators=[TrajectoryCheckEvaluator()])
+        reports = experiment.run_evaluations(task_function)
+
+        assert len(reports) == 1
+        assert reports[0].scores[0] == 1.0
+        assert reports[0].test_passes[0] is True
+
+    def test_openinference_mapper_extracts_tools(self):
+        """Verify that available tools are extracted from LLM spans."""
+        spans = create_openinference_agent_trace(
+            user_query="What's the weather?",
+            agent_response="Sunny!",
+            tool_name="get_weather",
+            tool_result="Sunny",
+        )
+
+        mapper = OpenInferenceSessionMapper()
+        session = mapper.map_to_session(spans, "test-session")
+
+        agent_spans = [s for s in session.traces[0].spans if isinstance(s, AgentInvocationSpan)]
+        assert len(agent_spans) == 1
+        assert len(agent_spans[0].available_tools) == 1
+        assert agent_spans[0].available_tools[0].name == "get_weather"
+
+
+class TestMultipleCasesEvaluation:
+    """Test evaluation pipeline with multiple test cases."""
+
+    def test_multiple_traceloop_cases(self):
+        """Evaluate multiple cases using Traceloop mapper."""
+        test_cases = [
+            Case[str, str](
+                name="weather-seattle",
+                input="What's the weather in Seattle?",
+                metadata={"expected_tool": "get_weather"},
+            ),
+            Case[str, str](
+                name="weather-tokyo",
+                input="Tell me the weather in Tokyo",
+                metadata={"expected_tool": "get_weather"},
+            ),
+        ]
+
+        weather_data = {
+            "Seattle": "Rainy, 55F",
+            "Tokyo": "Clear, 68F",
+        }
+
+        def task_function(case: Case) -> dict:
+            city = "Seattle" if "Seattle" in case.input else "Tokyo"
+            weather = weather_data[city]
+            spans = create_traceloop_agent_trace(
+                user_query=case.input,
+                agent_response=f"The weather in {city} is {weather}.",
+                tool_name="get_weather",
+                tool_result=weather,
+            )
+            mapper = detect_otel_mapper(spans)
+            session = mapper.map_to_session(spans, session_id=case.session_id)
+            return {
+                "output": f"The weather in {city} is {weather}.",
+                "trajectory": session,
+            }
+
+        experiment = Experiment(cases=test_cases, evaluators=[TrajectoryCheckEvaluator()])
+        reports = experiment.run_evaluations(task_function)
+
+        assert len(reports) == 1
+        assert len(reports[0].scores) == 2
+        assert all(score == 1.0 for score in reports[0].scores)
+        assert all(reports[0].test_passes)
+        assert reports[0].overall_score == 1.0
+
+    def test_multiple_openinference_cases(self):
+        """Evaluate multiple cases using OpenInference mapper."""
+        test_cases = [
+            Case[str, str](
+                name="weather-london",
+                input="What's the weather in London?",
+                metadata={"expected_tool": "get_weather"},
+            ),
+            Case[str, str](
+                name="weather-paris",
+                input="Tell me the weather in Paris",
+                metadata={"expected_tool": "get_weather"},
+            ),
+        ]
+
+        weather_data = {
+            "London": "Cloudy, 60F",
+            "Paris": "Partly cloudy, 65F",
+        }
+
+        def task_function(case: Case) -> dict:
+            city = "London" if "London" in case.input else "Paris"
+            weather = weather_data[city]
+            spans = create_openinference_agent_trace(
+                user_query=case.input,
+                agent_response=f"The weather in {city} is {weather}.",
+                tool_name="get_weather",
+                tool_result=weather,
+            )
+            mapper = detect_otel_mapper(spans)
+            session = mapper.map_to_session(spans, session_id=case.session_id)
+            return {
+                "output": f"The weather in {city} is {weather}.",
+                "trajectory": session,
+            }
+
+        experiment = Experiment(cases=test_cases, evaluators=[TrajectoryCheckEvaluator()])
+        reports = experiment.run_evaluations(task_function)
+
+        assert len(reports) == 1
+        assert len(reports[0].scores) == 2
+        assert all(score == 1.0 for score in reports[0].scores)
+        assert all(reports[0].test_passes)
+
+
+@pytest.mark.asyncio
+async def test_async_evaluation_with_langchain_mappers():
+    """Test async evaluation workflow with LangChain mappers."""
+    test_cases = [
+        Case[str, str](
+            name="weather-async",
+            input="What's the weather in New York?",
+            metadata={"expected_tool": "get_weather"},
+        ),
+    ]
+
+    async def async_task(case: Case) -> dict:
+        spans = create_traceloop_agent_trace(
+            user_query=case.input,
+            agent_response="The weather in New York is sunny, 72F.",
+            tool_name="get_weather",
+            tool_result="Sunny, 72F",
+        )
+        mapper = detect_otel_mapper(spans)
+        session = mapper.map_to_session(spans, session_id=case.session_id)
+        return {
+            "output": "The weather in New York is sunny, 72F.",
+            "trajectory": session,
+        }
+
+    experiment = Experiment(cases=test_cases, evaluators=[TrajectoryCheckEvaluator()])
+    reports = await experiment.run_evaluations_async(async_task)
+
+    assert len(reports) == 1
+    assert reports[0].scores[0] == 1.0
+    assert reports[0].test_passes[0] is True

--- a/tests/strands_evals/mappers/test_langchain_otel_session_mapper.py
+++ b/tests/strands_evals/mappers/test_langchain_otel_session_mapper.py
@@ -1,0 +1,322 @@
+"""Tests for LangChainOtelSessionMapper - Traceloop/OpenLLMetry trace → Session conversion."""
+
+import json
+
+from strands_evals.mappers import LangChainOtelSessionMapper
+from strands_evals.types.trace import (
+    AgentInvocationSpan,
+    InferenceSpan,
+    ToolExecutionSpan,
+)
+
+SCOPE_NAME = "opentelemetry.instrumentation.langchain"
+
+
+def make_span(
+    trace_id="trace-1",
+    span_id="span-1",
+    parent_span_id=None,
+    name="test-span",
+    attributes=None,
+    span_events=None,
+    start_time=1700000000000000000,
+    end_time=1700000001000000000,
+):
+    """Build a normalized span dict for LangChain OTEL traces."""
+    return {
+        "trace_id": trace_id,
+        "span_id": span_id,
+        "parent_span_id": parent_span_id,
+        "name": name,
+        "start_time": start_time,
+        "end_time": end_time,
+        "attributes": attributes or {},
+        "scope": {"name": SCOPE_NAME, "version": "0.1.0"},
+        "status": {"code": "OK"},
+        "span_events": span_events or [],
+    }
+
+
+def make_inference_span(
+    trace_id="trace-1",
+    span_id="span-1",
+    user_content="Hello",
+    assistant_content="Hi there",
+    tool_calls=None,
+):
+    """Build an LLM inference span with gen_ai.* attributes."""
+    attrs = {
+        "llm.request.type": "chat",
+        "gen_ai.prompt.0.role": "user",
+        "gen_ai.prompt.0.content": user_content,
+        "gen_ai.completion.0.role": "assistant",
+        "gen_ai.completion.0.content": assistant_content,
+    }
+
+    if tool_calls:
+        for i, tc in enumerate(tool_calls):
+            attrs[f"gen_ai.completion.0.tool_calls.{i}.name"] = tc["name"]
+            attrs[f"gen_ai.completion.0.tool_calls.{i}.arguments"] = json.dumps(tc.get("arguments", {}))
+            attrs[f"gen_ai.completion.0.tool_calls.{i}.id"] = tc.get("id", f"tool-{i}")
+
+    return make_span(trace_id=trace_id, span_id=span_id, attributes=attrs)
+
+
+def make_tool_span(
+    trace_id="trace-1",
+    span_id="span-1",
+    tool_name="calculator",
+    tool_input=None,
+    tool_output=None,
+    tool_call_id="tool-1",
+):
+    """Build a tool execution span with traceloop.* attributes."""
+    tool_input = tool_input or {"expr": "2+2"}
+    tool_output = tool_output or "4"
+
+    entity_input = json.dumps({"inputs": tool_input})
+    entity_output = json.dumps(
+        {
+            "output": {
+                "kwargs": {
+                    "content": tool_output,
+                    "tool_call_id": tool_call_id,
+                    "status": "success",
+                }
+            }
+        }
+    )
+
+    attrs = {
+        "traceloop.span.kind": "tool",
+        "traceloop.entity.name": tool_name,
+        "traceloop.entity.input": entity_input,
+        "traceloop.entity.output": entity_output,
+    }
+
+    return make_span(trace_id=trace_id, span_id=span_id, attributes=attrs)
+
+
+def make_workflow_span(
+    trace_id="trace-1",
+    span_id="span-1",
+    user_query="What is 2+2?",
+    agent_response="The answer is 4",
+):
+    """Build a workflow/agent invocation span."""
+    entity_input = json.dumps({"inputs": {"messages": [{"kwargs": {"content": user_query, "type": "human"}}]}})
+    entity_output = json.dumps({"outputs": {"messages": [{"kwargs": {"content": agent_response, "type": "ai"}}]}})
+
+    attrs = {
+        "traceloop.span.kind": "workflow",
+        "traceloop.entity.input": entity_input,
+        "traceloop.entity.output": entity_output,
+    }
+
+    return make_span(trace_id=trace_id, span_id=span_id, attributes=attrs)
+
+
+class TestSpanTypeDetection:
+    def setup_method(self):
+        self.mapper = LangChainOtelSessionMapper()
+
+    def test_inference_span_detected(self):
+        """Span with llm.request.type=chat is detected as inference span."""
+        span = make_span(attributes={"llm.request.type": "chat"})
+        assert self.mapper._is_inference_span(span) is True
+        assert self.mapper._is_tool_execution_span(span) is False
+        assert self.mapper._is_agent_invocation_span(span) is False
+
+    def test_tool_span_detected(self):
+        """Span with traceloop.span.kind=tool is detected as tool span."""
+        span = make_span(attributes={"traceloop.span.kind": "tool"})
+        assert self.mapper._is_inference_span(span) is False
+        assert self.mapper._is_tool_execution_span(span) is True
+        assert self.mapper._is_agent_invocation_span(span) is False
+
+    def test_workflow_span_detected(self):
+        """Span with traceloop.span.kind=workflow is detected as agent span."""
+        span = make_span(attributes={"traceloop.span.kind": "workflow"})
+        assert self.mapper._is_inference_span(span) is False
+        assert self.mapper._is_tool_execution_span(span) is False
+        assert self.mapper._is_agent_invocation_span(span) is True
+
+
+class TestInferenceSpanConversion:
+    def setup_method(self):
+        self.mapper = LangChainOtelSessionMapper()
+
+    def test_basic_inference_span(self):
+        """Basic inference span with user and assistant messages."""
+        span = make_inference_span(
+            user_content="What is the weather?",
+            assistant_content="It's sunny today.",
+        )
+        session = self.mapper.map_to_session([span], "sess-1")
+
+        assert len(session.traces) == 1
+        assert len(session.traces[0].spans) == 1
+
+        inference = session.traces[0].spans[0]
+        assert isinstance(inference, InferenceSpan)
+        assert inference.messages[0].content[0].text == "What is the weather?"
+        assert inference.messages[1].content[0].text == "It's sunny today."
+
+    def test_inference_span_with_tool_calls(self):
+        """Inference span with tool calls in assistant response."""
+        span = make_inference_span(
+            user_content="Calculate 2+2",
+            assistant_content="Let me calculate that.",
+            tool_calls=[{"name": "calculator", "arguments": {"expr": "2+2"}, "id": "tc-1"}],
+        )
+        session = self.mapper.map_to_session([span], "sess-1")
+
+        inference = session.traces[0].spans[0]
+        assert isinstance(inference, InferenceSpan)
+        assert len(inference.messages[1].content) == 2
+        assert inference.messages[1].content[0].text == "Let me calculate that."
+        assert inference.messages[1].content[1].name == "calculator"
+        assert inference.messages[1].content[1].tool_call_id == "tc-1"
+
+
+class TestToolExecutionSpanConversion:
+    def setup_method(self):
+        self.mapper = LangChainOtelSessionMapper()
+
+    def test_basic_tool_span(self):
+        """Tool execution span with input and output."""
+        span = make_tool_span(
+            tool_name="calculator",
+            tool_input={"expr": "6*7"},
+            tool_output="42",
+            tool_call_id="tc-1",
+        )
+        session = self.mapper.map_to_session([span], "sess-1")
+
+        assert len(session.traces[0].spans) == 1
+        tool = session.traces[0].spans[0]
+        assert isinstance(tool, ToolExecutionSpan)
+        assert tool.tool_call.name == "calculator"
+        assert tool.tool_call.arguments == {"expr": "6*7"}
+        assert tool.tool_result.content == "42"
+        assert tool.tool_result.tool_call_id == "tc-1"
+
+
+class TestAgentInvocationSpanConversion:
+    def setup_method(self):
+        self.mapper = LangChainOtelSessionMapper()
+
+    def test_basic_agent_span(self):
+        """Agent invocation span with user query and response."""
+        span = make_workflow_span(
+            user_query="What is the capital of France?",
+            agent_response="The capital of France is Paris.",
+        )
+        session = self.mapper.map_to_session([span], "sess-1")
+
+        assert len(session.traces[0].spans) == 1
+        agent = session.traces[0].spans[0]
+        assert isinstance(agent, AgentInvocationSpan)
+        assert agent.user_prompt == "What is the capital of France?"
+        assert agent.agent_response == "The capital of France is Paris."
+
+    def test_agent_span_collects_tools(self):
+        """Agent invocation span collects tools from inference spans."""
+        inference = make_inference_span(
+            trace_id="t1",
+            span_id="s1",
+            user_content="Calculate",
+            assistant_content="OK",
+        )
+        inference["attributes"]["llm.request.functions.0.name"] = "calculator"
+        inference["attributes"]["llm.request.functions.0.description"] = "A calculator"
+
+        workflow = make_workflow_span(
+            trace_id="t1",
+            span_id="s2",
+            user_query="Calculate 2+2",
+            agent_response="4",
+        )
+
+        session = self.mapper.map_to_session([inference, workflow], "sess-1")
+
+        agent_spans = [s for s in session.traces[0].spans if isinstance(s, AgentInvocationSpan)]
+        assert len(agent_spans) == 1
+        assert len(agent_spans[0].available_tools) == 1
+        assert agent_spans[0].available_tools[0].name == "calculator"
+
+
+class TestSessionBuilding:
+    def setup_method(self):
+        self.mapper = LangChainOtelSessionMapper()
+
+    def test_empty_spans_list(self):
+        """Empty spans list produces empty session."""
+        session = self.mapper.map_to_session([], "sess-1")
+        assert session.session_id == "sess-1"
+        assert session.traces == []
+
+    def test_multiple_traces(self):
+        """Spans with different trace_ids grouped into separate traces."""
+        span1 = make_inference_span(trace_id="t1", span_id="s1", user_content="Q1", assistant_content="A1")
+        span2 = make_inference_span(trace_id="t2", span_id="s2", user_content="Q2", assistant_content="A2")
+
+        session = self.mapper.map_to_session([span1, span2], "sess-1")
+
+        assert len(session.traces) == 2
+        trace_ids = {t.trace_id for t in session.traces}
+        assert trace_ids == {"t1", "t2"}
+
+    def test_filters_by_scope(self):
+        """Only spans with matching scope are processed."""
+        langchain_span = make_inference_span(user_content="Q1", assistant_content="A1")
+        other_span = make_span(
+            span_id="other",
+            attributes={"llm.request.type": "chat"},
+        )
+        other_span["scope"]["name"] = "other.scope"
+
+        session = self.mapper.map_to_session([langchain_span, other_span], "sess-1")
+
+        assert len(session.traces) == 1
+        assert len(session.traces[0].spans) == 1
+
+    def test_full_agent_loop(self):
+        """Full agent loop: inference → tool → inference → agent produces all span types."""
+        spans = [
+            make_inference_span(
+                trace_id="t1",
+                span_id="s1",
+                user_content="Calculate 6*7",
+                assistant_content="Let me calculate",
+                tool_calls=[{"name": "calculator", "arguments": {"expr": "6*7"}, "id": "tc-1"}],
+            ),
+            make_tool_span(
+                trace_id="t1",
+                span_id="s2",
+                tool_name="calculator",
+                tool_input={"expr": "6*7"},
+                tool_output="42",
+                tool_call_id="tc-1",
+            ),
+            make_inference_span(
+                trace_id="t1",
+                span_id="s3",
+                user_content="Tool result: 42",
+                assistant_content="The answer is 42.",
+            ),
+            make_workflow_span(
+                trace_id="t1",
+                span_id="s4",
+                user_query="Calculate 6*7",
+                agent_response="The answer is 42.",
+            ),
+        ]
+
+        session = self.mapper.map_to_session(spans, "sess-1")
+
+        assert len(session.traces) == 1
+        span_types = [type(s).__name__ for s in session.traces[0].spans]
+        assert "InferenceSpan" in span_types
+        assert "ToolExecutionSpan" in span_types
+        assert "AgentInvocationSpan" in span_types

--- a/tests/strands_evals/mappers/test_openinference_session_mapper.py
+++ b/tests/strands_evals/mappers/test_openinference_session_mapper.py
@@ -1,0 +1,364 @@
+"""Tests for OpenInferenceSessionMapper - OpenInference LangChain trace → Session conversion."""
+
+import json
+
+from strands_evals.mappers import OpenInferenceSessionMapper
+from strands_evals.types.trace import (
+    AgentInvocationSpan,
+    InferenceSpan,
+    ToolExecutionSpan,
+)
+
+SCOPE_NAME = "openinference.instrumentation.langchain"
+
+
+def make_span(
+    trace_id="trace-1",
+    span_id="span-1",
+    parent_span_id=None,
+    name="test-span",
+    attributes=None,
+    span_events=None,
+    start_time=1700000000000000000,
+    end_time=1700000001000000000,
+):
+    """Build a normalized span dict for OpenInference LangChain traces."""
+    return {
+        "trace_id": trace_id,
+        "span_id": span_id,
+        "parent_span_id": parent_span_id,
+        "name": name,
+        "start_time": start_time,
+        "end_time": end_time,
+        "attributes": attributes or {},
+        "scope": {"name": SCOPE_NAME, "version": "0.1.0"},
+        "status": {"code": "OK"},
+        "span_events": span_events or [],
+    }
+
+
+def make_llm_span(
+    trace_id="trace-1",
+    span_id="span-1",
+    user_content="Hello",
+    assistant_content="Hi there",
+    tool_calls=None,
+):
+    """Build an LLM inference span with openinference attributes."""
+    attrs = {
+        "openinference.span.kind": "LLM",
+        "llm.input_messages.0.message.role": "user",
+        "llm.input_messages.0.message.content": user_content,
+        "llm.output_messages.0.message.role": "assistant",
+        "llm.output_messages.0.message.content": assistant_content,
+    }
+
+    if tool_calls:
+        for i, tc in enumerate(tool_calls):
+            attrs[f"llm.output_messages.0.message.tool_calls.{i}.tool_call.function.name"] = tc["name"]
+            attrs[f"llm.output_messages.0.message.tool_calls.{i}.tool_call.function.arguments"] = json.dumps(
+                tc.get("arguments", {})
+            )
+            attrs[f"llm.output_messages.0.message.tool_calls.{i}.tool_call.id"] = tc.get("id", f"tool-{i}")
+
+    return make_span(trace_id=trace_id, span_id=span_id, attributes=attrs)
+
+
+def make_tool_span(
+    trace_id="trace-1",
+    span_id="span-1",
+    tool_name="calculator",
+    tool_input=None,
+    tool_output=None,
+    tool_call_id="tool-1",
+):
+    """Build a tool execution span with openinference attributes."""
+    tool_input = tool_input or {"expr": "2+2"}
+    tool_output = tool_output or "4"
+
+    output_value = json.dumps(
+        {
+            "content": tool_output,
+            "tool_call_id": tool_call_id,
+            "status": "success",
+        }
+    )
+
+    attrs = {
+        "openinference.span.kind": "TOOL",
+        "tool.name": tool_name,
+        "input.value": json.dumps(tool_input),
+        "output.value": output_value,
+    }
+
+    return make_span(trace_id=trace_id, span_id=span_id, name=tool_name, attributes=attrs)
+
+
+def make_chain_span(
+    trace_id="trace-1",
+    span_id="span-1",
+    name="LangGraph",
+    user_query="What is 2+2?",
+    agent_response="The answer is 4",
+):
+    """Build a CHAIN span (agent invocation) with openinference attributes."""
+    input_value = json.dumps({"messages": [{"kwargs": {"content": user_query, "type": "human"}}]})
+    output_value = json.dumps({"messages": [{"kwargs": {"content": agent_response, "type": "ai"}}]})
+
+    attrs = {
+        "openinference.span.kind": "CHAIN",
+        "input.value": input_value,
+        "output.value": output_value,
+    }
+
+    return make_span(trace_id=trace_id, span_id=span_id, name=name, attributes=attrs)
+
+
+class TestSpanTypeDetection:
+    def setup_method(self):
+        self.mapper = OpenInferenceSessionMapper()
+
+    def test_llm_span_detected(self):
+        """Span with openinference.span.kind=LLM is detected as inference span."""
+        span = make_span(attributes={"openinference.span.kind": "LLM"})
+        assert self.mapper._is_inference_span(span) is True
+        assert self.mapper._is_tool_execution_span(span) is False
+
+    def test_tool_span_detected(self):
+        """Span with openinference.span.kind=TOOL is detected as tool span."""
+        span = make_span(attributes={"openinference.span.kind": "TOOL"})
+        assert self.mapper._is_inference_span(span) is False
+        assert self.mapper._is_tool_execution_span(span) is True
+
+    def test_chain_langgraph_span_detected_as_agent(self):
+        """CHAIN span with name=LangGraph is detected as agent invocation."""
+        span = make_span(name="LangGraph", attributes={"openinference.span.kind": "CHAIN"})
+        assert self.mapper._is_agent_invocation_span(span) is True
+
+
+class TestInferenceSpanConversion:
+    def setup_method(self):
+        self.mapper = OpenInferenceSessionMapper()
+
+    def test_basic_llm_span(self):
+        """Basic LLM span with user and assistant messages."""
+        span = make_llm_span(
+            user_content="What is the weather?",
+            assistant_content="It's sunny today.",
+        )
+        session = self.mapper.map_to_session([span], "sess-1")
+
+        assert len(session.traces) == 1
+        assert len(session.traces[0].spans) == 1
+
+        inference = session.traces[0].spans[0]
+        assert isinstance(inference, InferenceSpan)
+        assert inference.messages[0].content[0].text == "What is the weather?"
+        assert inference.messages[1].content[0].text == "It's sunny today."
+
+    def test_llm_span_with_tool_calls(self):
+        """LLM span with tool calls in assistant response."""
+        span = make_llm_span(
+            user_content="Calculate 2+2",
+            assistant_content="Let me calculate that.",
+            tool_calls=[{"name": "calculator", "arguments": {"expr": "2+2"}, "id": "tc-1"}],
+        )
+        session = self.mapper.map_to_session([span], "sess-1")
+
+        inference = session.traces[0].spans[0]
+        assert isinstance(inference, InferenceSpan)
+        assert len(inference.messages[1].content) == 2
+        assert inference.messages[1].content[0].text == "Let me calculate that."
+        assert inference.messages[1].content[1].name == "calculator"
+        assert inference.messages[1].content[1].tool_call_id == "tc-1"
+
+
+class TestToolExecutionSpanConversion:
+    def setup_method(self):
+        self.mapper = OpenInferenceSessionMapper()
+
+    def test_basic_tool_span(self):
+        """Tool execution span with input and output."""
+        span = make_tool_span(
+            tool_name="calculator",
+            tool_input={"expr": "6*7"},
+            tool_output="42",
+            tool_call_id="tc-1",
+        )
+        session = self.mapper.map_to_session([span], "sess-1")
+
+        assert len(session.traces[0].spans) == 1
+        tool = session.traces[0].spans[0]
+        assert isinstance(tool, ToolExecutionSpan)
+        assert tool.tool_call.name == "calculator"
+        assert tool.tool_result.content == "42"
+        assert tool.tool_result.tool_call_id == "tc-1"
+
+
+class TestAgentInvocationSpanConversion:
+    def setup_method(self):
+        self.mapper = OpenInferenceSessionMapper()
+
+    def test_langgraph_chain_as_agent_span(self):
+        """CHAIN span named LangGraph becomes agent invocation span."""
+        span = make_chain_span(
+            name="LangGraph",
+            user_query="What is the capital of France?",
+            agent_response="The capital of France is Paris.",
+        )
+        session = self.mapper.map_to_session([span], "sess-1")
+
+        assert len(session.traces[0].spans) == 1
+        agent = session.traces[0].spans[0]
+        assert isinstance(agent, AgentInvocationSpan)
+        assert agent.user_prompt == "What is the capital of France?"
+        assert agent.agent_response == "The capital of France is Paris."
+
+    def test_only_one_agent_span_per_trace(self):
+        """Only one agent invocation span is created per trace."""
+        span1 = make_chain_span(trace_id="t1", span_id="s1", name="LangGraph")
+        span2 = make_chain_span(trace_id="t1", span_id="s2", name="LangGraph")
+
+        session = self.mapper.map_to_session([span1, span2], "sess-1")
+
+        agent_spans = [s for s in session.traces[0].spans if isinstance(s, AgentInvocationSpan)]
+        assert len(agent_spans) == 1
+
+    def test_agent_span_collects_tools_from_llm_spans(self):
+        """Agent invocation span collects tools from LLM spans in same trace."""
+        llm_span = make_llm_span(
+            trace_id="t1",
+            span_id="s1",
+            user_content="Calculate",
+            assistant_content="OK",
+        )
+        llm_span["attributes"]["llm.tools.0.tool.json_schema"] = json.dumps(
+            {
+                "name": "calculator",
+                "description": "A calculator tool",
+                "input_schema": {"type": "object"},
+            }
+        )
+
+        agent_span = make_chain_span(
+            trace_id="t1",
+            span_id="s2",
+            name="LangGraph",
+            user_query="Calculate 2+2",
+            agent_response="4",
+        )
+
+        session = self.mapper.map_to_session([llm_span, agent_span], "sess-1")
+
+        agent_spans = [s for s in session.traces[0].spans if isinstance(s, AgentInvocationSpan)]
+        assert len(agent_spans) == 1
+        assert len(agent_spans[0].available_tools) == 1
+        assert agent_spans[0].available_tools[0].name == "calculator"
+
+
+class TestSessionBuilding:
+    def setup_method(self):
+        self.mapper = OpenInferenceSessionMapper()
+
+    def test_empty_spans_list(self):
+        """Empty spans list produces empty session."""
+        session = self.mapper.map_to_session([], "sess-1")
+        assert session.session_id == "sess-1"
+        assert session.traces == []
+
+    def test_multiple_traces(self):
+        """Spans with different trace_ids grouped into separate traces."""
+        span1 = make_llm_span(trace_id="t1", span_id="s1", user_content="Q1", assistant_content="A1")
+        span2 = make_llm_span(trace_id="t2", span_id="s2", user_content="Q2", assistant_content="A2")
+
+        session = self.mapper.map_to_session([span1, span2], "sess-1")
+
+        assert len(session.traces) == 2
+        trace_ids = {t.trace_id for t in session.traces}
+        assert trace_ids == {"t1", "t2"}
+
+    def test_filters_by_scope(self):
+        """Only spans with matching scope are processed."""
+        openinference_span = make_llm_span(user_content="Q1", assistant_content="A1")
+        other_span = make_span(
+            span_id="other",
+            attributes={"openinference.span.kind": "LLM"},
+        )
+        other_span["scope"]["name"] = "other.scope"
+
+        session = self.mapper.map_to_session([openinference_span, other_span], "sess-1")
+
+        assert len(session.traces) == 1
+        assert len(session.traces[0].spans) == 1
+
+    def test_full_agent_loop(self):
+        """Full agent loop produces all span types."""
+        spans = [
+            make_llm_span(
+                trace_id="t1",
+                span_id="s1",
+                user_content="Calculate 6*7",
+                assistant_content="Let me calculate",
+                tool_calls=[{"name": "calculator", "arguments": {"expr": "6*7"}, "id": "tc-1"}],
+            ),
+            make_tool_span(
+                trace_id="t1",
+                span_id="s2",
+                tool_name="calculator",
+                tool_input={"expr": "6*7"},
+                tool_output="42",
+                tool_call_id="tc-1",
+            ),
+            make_llm_span(
+                trace_id="t1",
+                span_id="s3",
+                user_content="Tool result: 42",
+                assistant_content="The answer is 42.",
+            ),
+            make_chain_span(
+                trace_id="t1",
+                span_id="s4",
+                name="LangGraph",
+                user_query="Calculate 6*7",
+                agent_response="The answer is 42.",
+            ),
+        ]
+
+        session = self.mapper.map_to_session(spans, "sess-1")
+
+        assert len(session.traces) == 1
+        span_types = [type(s).__name__ for s in session.traces[0].spans]
+        assert "InferenceSpan" in span_types
+        assert "ToolExecutionSpan" in span_types
+        assert "AgentInvocationSpan" in span_types
+
+
+class TestInputNormalization:
+    def setup_method(self):
+        self.mapper = OpenInferenceSessionMapper()
+
+    def test_grouped_by_trace_id_input(self):
+        """Handles input grouped by trace_id dict format."""
+        span1 = make_llm_span(trace_id="t1", span_id="s1", user_content="Q1", assistant_content="A1")
+        span2 = make_llm_span(trace_id="t2", span_id="s2", user_content="Q2", assistant_content="A2")
+
+        grouped_data = {
+            "t1": [span1],
+            "t2": [span2],
+        }
+
+        session = self.mapper.map_to_session(grouped_data, "sess-1")
+
+        assert len(session.traces) == 2
+
+    def test_trace_objects_input(self):
+        """Handles input as list of trace objects with spans key."""
+        span1 = make_llm_span(trace_id="t1", span_id="s1", user_content="Q1", assistant_content="A1")
+
+        trace_objects = [
+            {"trace_id": "t1", "spans": [span1]},
+        ]
+
+        session = self.mapper.map_to_session(trace_objects, "sess-1")
+
+        assert len(session.traces) == 1

--- a/tests/strands_evals/mappers/test_utils.py
+++ b/tests/strands_evals/mappers/test_utils.py
@@ -1,0 +1,199 @@
+"""Tests for mapper utility functions."""
+
+from strands_evals.mappers import (
+    CloudWatchSessionMapper,
+    LangChainOtelSessionMapper,
+    OpenInferenceSessionMapper,
+    StrandsInMemorySessionMapper,
+    detect_otel_mapper,
+    get_scope_name,
+    readable_spans_to_dicts,
+)
+
+
+def make_span_dict(scope_name="test.scope", attributes=None, span_events=None):
+    """Build a minimal span dict for testing."""
+    return {
+        "trace_id": "trace-1",
+        "span_id": "span-1",
+        "scope": {"name": scope_name, "version": "0.1.0"},
+        "attributes": attributes or {},
+        "span_events": span_events or [],
+    }
+
+
+class TestGetScopeName:
+    def test_extracts_from_scope_dict(self):
+        """Extracts scope name from scope.name field."""
+        span = make_span_dict(scope_name="test.scope")
+        assert get_scope_name(span) == "test.scope"
+
+    def test_extracts_from_attributes_event_name(self):
+        """Falls back to attributes.event.name if scope.name is empty."""
+        span = {
+            "scope": {"name": ""},
+            "attributes": {"event.name": "fallback.scope"},
+        }
+        assert get_scope_name(span) == "fallback.scope"
+
+    def test_returns_empty_for_missing_scope(self):
+        """Returns empty string if no scope found."""
+        span = {"attributes": {}}
+        assert get_scope_name(span) == ""
+
+    def test_handles_non_dict_input(self):
+        """Returns empty string for non-dict input without scope."""
+
+        class FakeSpan:
+            pass
+
+        span = FakeSpan()
+        assert get_scope_name(span) == ""
+
+
+class TestDetectOtelMapper:
+    def test_empty_spans_returns_strands_mapper(self):
+        """Empty spans list returns StrandsInMemorySessionMapper."""
+        mapper = detect_otel_mapper([])
+        assert isinstance(mapper, StrandsInMemorySessionMapper)
+
+    def test_detects_langchain_traceloop_scope(self):
+        """Detects LangChainOtelSessionMapper for traceloop scope."""
+        spans = [make_span_dict(scope_name="opentelemetry.instrumentation.langchain")]
+        mapper = detect_otel_mapper(spans)
+        assert isinstance(mapper, LangChainOtelSessionMapper)
+
+    def test_detects_openinference_scope(self):
+        """Detects OpenInferenceSessionMapper for openinference scope."""
+        spans = [make_span_dict(scope_name="openinference.instrumentation.langchain")]
+        mapper = detect_otel_mapper(spans)
+        assert isinstance(mapper, OpenInferenceSessionMapper)
+
+    def test_detects_strands_cloudwatch_format(self):
+        """Detects CloudWatchSessionMapper for strands scope with body format."""
+        spans = [
+            make_span_dict(
+                scope_name="strands.telemetry.tracer",
+                span_events=[
+                    {
+                        "body": {
+                            "input": {"messages": []},
+                            "output": {"messages": []},
+                        }
+                    }
+                ],
+            )
+        ]
+        mapper = detect_otel_mapper(spans)
+        assert isinstance(mapper, CloudWatchSessionMapper)
+
+    def test_detects_strands_in_memory_format(self):
+        """Detects StrandsInMemorySessionMapper for strands scope without body format."""
+        spans = [
+            make_span_dict(
+                scope_name="strands.telemetry.tracer",
+                attributes={"gen_ai.operation.name": "chat"},
+            )
+        ]
+        mapper = detect_otel_mapper(spans)
+        assert isinstance(mapper, StrandsInMemorySessionMapper)
+
+    def test_defaults_to_strands_mapper_for_unknown_scope(self):
+        """Defaults to StrandsInMemorySessionMapper for unknown scope."""
+        spans = [make_span_dict(scope_name="unknown.scope")]
+        mapper = detect_otel_mapper(spans)
+        assert isinstance(mapper, StrandsInMemorySessionMapper)
+
+    def test_skips_spans_without_scope(self):
+        """Skips spans without scope and continues detection."""
+        spans = [
+            {"trace_id": "t1", "span_id": "s1"},  # No scope
+            make_span_dict(scope_name="openinference.instrumentation.langchain"),
+        ]
+        mapper = detect_otel_mapper(spans)
+        assert isinstance(mapper, OpenInferenceSessionMapper)
+
+
+class TestReadableSpansToDicts:
+    def test_converts_readable_spans(self):
+        """Converts ReadableSpan objects to dict format."""
+        from unittest.mock import MagicMock
+
+        # Create mock ReadableSpan
+        mock_span = MagicMock()
+        mock_span.context.trace_id = 0xABCD1234
+        mock_span.context.span_id = 0x5678
+        mock_span.parent = None
+        mock_span.name = "test-span"
+        mock_span.start_time = 1700000000000000000
+        mock_span.end_time = 1700000001000000000
+        mock_span.attributes = {"key": "value"}
+        mock_span.instrumentation_scope.name = "test.scope"
+        mock_span.instrumentation_scope.version = "1.0"
+        mock_span.status.status_code.name = "OK"
+        mock_span.events = []
+
+        result = readable_spans_to_dicts([mock_span])
+
+        assert len(result) == 1
+        assert result[0]["trace_id"] == "000000000000000000000000abcd1234"
+        assert result[0]["span_id"] == "0000000000005678"
+        assert result[0]["parent_span_id"] is None
+        assert result[0]["name"] == "test-span"
+        assert result[0]["attributes"] == {"key": "value"}
+        assert result[0]["scope"]["name"] == "test.scope"
+        assert result[0]["span_events"] == []
+
+    def test_converts_span_with_parent(self):
+        """Converts span with parent reference."""
+        from unittest.mock import MagicMock
+
+        mock_span = MagicMock()
+        mock_span.context.trace_id = 0xABCD
+        mock_span.context.span_id = 0x1234
+        mock_span.parent.span_id = 0x5678
+        mock_span.name = "child-span"
+        mock_span.start_time = 0
+        mock_span.end_time = 0
+        mock_span.attributes = {}
+        mock_span.instrumentation_scope.name = "test"
+        mock_span.instrumentation_scope.version = "1.0"
+        mock_span.status.status_code.name = "OK"
+        mock_span.events = []
+
+        result = readable_spans_to_dicts([mock_span])
+
+        assert result[0]["parent_span_id"] == "0000000000005678"
+
+    def test_converts_span_events(self):
+        """Converts span events to dict format."""
+        from unittest.mock import MagicMock
+
+        mock_event = MagicMock()
+        mock_event.name = "test.event"
+        mock_event.timestamp = 1700000000500000000
+        mock_event.attributes = {"event_key": "event_value"}
+
+        mock_span = MagicMock()
+        mock_span.context.trace_id = 0xABCD
+        mock_span.context.span_id = 0x1234
+        mock_span.parent = None
+        mock_span.name = "span"
+        mock_span.start_time = 0
+        mock_span.end_time = 0
+        mock_span.attributes = {}
+        mock_span.instrumentation_scope.name = "test"
+        mock_span.instrumentation_scope.version = "1.0"
+        mock_span.status.status_code.name = "OK"
+        mock_span.events = [mock_event]
+
+        result = readable_spans_to_dicts([mock_span])
+
+        assert len(result[0]["span_events"]) == 1
+        assert result[0]["span_events"][0]["event_name"] == "test.event"
+        assert result[0]["span_events"][0]["attributes"] == {"event_key": "event_value"}
+
+    def test_handles_empty_list(self):
+        """Handles empty span list."""
+        result = readable_spans_to_dicts([])
+        assert result == []

--- a/tests_integ/test_langchain_openinference_eval.py
+++ b/tests_integ/test_langchain_openinference_eval.py
@@ -1,0 +1,221 @@
+"""
+Integration tests for LangChain agent evaluation with OpenInference instrumentation.
+
+These tests create real LangChain agents, run them with Bedrock, capture OTEL traces
+using OpenInference instrumentation, and evaluate using strands-evals.
+
+Requirements:
+    pip install strands-agents-evals[langchain]
+"""
+
+import os
+
+import pytest
+from langchain_aws import ChatBedrock
+from langchain_core.messages import HumanMessage
+from langchain_core.tools import tool
+from langgraph.prebuilt import create_react_agent
+from openinference.instrumentation.langchain import LangChainInstrumentor
+
+from strands_evals import Case, Experiment
+from strands_evals.evaluators import Evaluator
+from strands_evals.mappers import detect_otel_mapper, readable_spans_to_dicts
+from strands_evals.telemetry import StrandsEvalsTelemetry
+from strands_evals.types import EvaluationData, EvaluationOutput
+from strands_evals.types.trace import ToolExecutionSpan
+
+# Use the same model that works in CI (same as evaluators use)
+DEFAULT_MODEL_ID = "us.anthropic.claude-sonnet-4-20250514-v1:0"
+
+
+class ToolUsageEvaluator(Evaluator[str, str]):
+    """Evaluator that checks if the expected tool was used."""
+
+    def _check_tool_usage(self, evaluation_case: EvaluationData[str, str]) -> list[EvaluationOutput]:
+        """Common logic for checking tool usage."""
+        trajectory = evaluation_case.actual_trajectory
+        expected_tool = evaluation_case.metadata.get("expected_tool")
+
+        if not trajectory or not hasattr(trajectory, "traces"):
+            return [EvaluationOutput(score=0.0, test_pass=False, reason="No trajectory found")]
+
+        for trace_obj in trajectory.traces:
+            for span in trace_obj.spans:
+                if isinstance(span, ToolExecutionSpan):
+                    if span.tool_call.name == expected_tool:
+                        return [
+                            EvaluationOutput(
+                                score=1.0,
+                                test_pass=True,
+                                reason=f"Found expected tool: {expected_tool}",
+                            )
+                        ]
+
+        return [
+            EvaluationOutput(
+                score=0.0,
+                test_pass=False,
+                reason=f"Expected tool '{expected_tool}' not found",
+            )
+        ]
+
+    def evaluate(self, evaluation_case: EvaluationData[str, str]) -> list[EvaluationOutput]:
+        return self._check_tool_usage(evaluation_case)
+
+    async def evaluate_async(self, evaluation_case: EvaluationData[str, str]) -> list[EvaluationOutput]:
+        return self._check_tool_usage(evaluation_case)
+
+
+@pytest.fixture(scope="module")
+def telemetry():
+    """Setup OTEL tracing with StrandsEvalsTelemetry for OpenInference."""
+    telemetry = StrandsEvalsTelemetry().setup_in_memory_exporter()
+    LangChainInstrumentor().instrument()
+    return telemetry
+
+
+@pytest.fixture
+def weather_tool():
+    """Create a weather tool for testing."""
+
+    @tool
+    def get_weather(city: str) -> str:
+        """Get the current weather for a city.
+
+        Args:
+            city: The city name to get weather for
+
+        Returns:
+            Weather information string
+        """
+        weather_data = {
+            "seattle": "Rainy, 55F",
+            "new york": "Sunny, 72F",
+            "london": "Cloudy, 60F",
+            "tokyo": "Clear, 68F",
+        }
+        city_lower = city.lower()
+        for c, w in weather_data.items():
+            if c in city_lower:
+                return f"Weather in {city}: {w}"
+        return f"Weather in {city}: Partly cloudy, 65F"
+
+    return get_weather
+
+
+@pytest.fixture
+def create_agent_func(weather_tool):
+    """Factory to create LangChain ReAct agents."""
+
+    def _create_agent():
+        region = os.environ.get("AWS_REGION", "us-west-2")
+        llm = ChatBedrock(
+            model_id=DEFAULT_MODEL_ID,
+            region_name=region,
+            model_kwargs={"temperature": 0},
+        )
+        return create_react_agent(llm, [weather_tool])
+
+    return _create_agent
+
+
+def test_openinference_single_query(telemetry, create_agent_func):
+    """Test single query evaluation with OpenInference instrumentation."""
+    telemetry.in_memory_exporter.clear()
+
+    agent = create_agent_func()
+    query = "What's the weather in Seattle?"
+
+    result = agent.invoke({"messages": [HumanMessage(content=query)]})
+    messages = result.get("messages", [])
+    response = messages[-1].content if messages else ""
+
+    spans = readable_spans_to_dicts(telemetry.in_memory_exporter.get_finished_spans())
+    assert len(spans) > 0, "Should have captured OTEL spans"
+
+    mapper = detect_otel_mapper(spans)
+    session = mapper.map_to_session(spans, session_id="test-single")
+
+    assert session.session_id == "test-single"
+    assert len(session.traces) > 0, "Should have at least one trace"
+    assert "seattle" in response.lower() or "weather" in response.lower()
+
+
+def test_openinference_evaluation_pipeline(telemetry, create_agent_func):
+    """Test full evaluation pipeline with OpenInference instrumentation."""
+    test_cases = [
+        Case[str, str](
+            name="weather-seattle",
+            input="What's the weather in Seattle?",
+            metadata={"expected_tool": "get_weather"},
+        ),
+    ]
+
+    def task_function(case: Case) -> dict:
+        telemetry.in_memory_exporter.clear()
+
+        agent = create_agent_func()
+        result = agent.invoke({"messages": [HumanMessage(content=case.input)]})
+
+        messages = result.get("messages", [])
+        response = messages[-1].content if messages else ""
+
+        spans = readable_spans_to_dicts(telemetry.in_memory_exporter.get_finished_spans())
+        mapper = detect_otel_mapper(spans)
+        session = mapper.map_to_session(spans, session_id=case.session_id)
+
+        return {
+            "output": response,
+            "trajectory": session,
+        }
+
+    experiment = Experiment(cases=test_cases, evaluators=[ToolUsageEvaluator()])
+    reports = experiment.run_evaluations(task_function)
+
+    assert len(reports) == 1
+    assert len(reports[0].scores) == 1
+    # The tool should have been used
+    assert reports[0].scores[0] == 1.0
+    assert reports[0].test_passes[0] is True
+
+
+def test_openinference_multiple_cases(telemetry, create_agent_func):
+    """Test evaluation with multiple test cases."""
+    test_cases = [
+        Case[str, str](
+            name="weather-seattle",
+            input="What's the weather in Seattle?",
+            metadata={"expected_tool": "get_weather"},
+        ),
+        Case[str, str](
+            name="weather-tokyo",
+            input="Tell me the weather in Tokyo",
+            metadata={"expected_tool": "get_weather"},
+        ),
+    ]
+
+    def task_function(case: Case) -> dict:
+        telemetry.in_memory_exporter.clear()
+
+        agent = create_agent_func()
+        result = agent.invoke({"messages": [HumanMessage(content=case.input)]})
+
+        messages = result.get("messages", [])
+        response = messages[-1].content if messages else ""
+
+        spans = readable_spans_to_dicts(telemetry.in_memory_exporter.get_finished_spans())
+        mapper = detect_otel_mapper(spans)
+        session = mapper.map_to_session(spans, session_id=case.session_id)
+
+        return {
+            "output": response,
+            "trajectory": session,
+        }
+
+    experiment = Experiment(cases=test_cases, evaluators=[ToolUsageEvaluator()])
+    reports = experiment.run_evaluations(task_function)
+
+    assert len(reports) == 1
+    assert len(reports[0].scores) == 2
+    assert reports[0].overall_score == 1.0
+    assert all(reports[0].test_passes)

--- a/tests_integ/test_langchain_traceloop_eval.py
+++ b/tests_integ/test_langchain_traceloop_eval.py
@@ -1,0 +1,239 @@
+"""
+Integration tests for LangChain agent evaluation with Traceloop/OpenLLMetry instrumentation.
+
+These tests create real LangChain agents, run them with Bedrock, capture OTEL traces
+using Traceloop's opentelemetry-instrumentation-langchain, and evaluate using strands-evals.
+
+This tests the LangChainOtelSessionMapper which handles traces with scope:
+    opentelemetry.instrumentation.langchain
+
+Requirements:
+    pip install strands-agents-evals[langchain]
+"""
+
+import os
+
+import pytest
+from langchain_aws import ChatBedrock
+from langchain_core.messages import HumanMessage
+from langchain_core.tools import tool
+from langgraph.prebuilt import create_react_agent
+from opentelemetry.instrumentation.langchain import LangchainInstrumentor
+
+from strands_evals import Case, Experiment
+from strands_evals.evaluators import Evaluator
+from strands_evals.mappers import LangChainOtelSessionMapper, detect_otel_mapper, readable_spans_to_dicts
+from strands_evals.telemetry import StrandsEvalsTelemetry
+from strands_evals.types import EvaluationData, EvaluationOutput
+from strands_evals.types.trace import ToolExecutionSpan
+
+# Use the same model that works in CI (same as evaluators use)
+DEFAULT_MODEL_ID = "us.anthropic.claude-sonnet-4-20250514-v1:0"
+
+
+class ToolUsageEvaluator(Evaluator[str, str]):
+    """Evaluator that checks if the expected tool was used."""
+
+    def _check_tool_usage(self, evaluation_case: EvaluationData[str, str]) -> list[EvaluationOutput]:
+        """Common logic for checking tool usage."""
+        trajectory = evaluation_case.actual_trajectory
+        expected_tool = evaluation_case.metadata.get("expected_tool")
+
+        if not trajectory or not hasattr(trajectory, "traces"):
+            return [EvaluationOutput(score=0.0, test_pass=False, reason="No trajectory found")]
+
+        for trace_obj in trajectory.traces:
+            for span in trace_obj.spans:
+                if isinstance(span, ToolExecutionSpan):
+                    if span.tool_call.name == expected_tool:
+                        return [
+                            EvaluationOutput(
+                                score=1.0,
+                                test_pass=True,
+                                reason=f"Found expected tool: {expected_tool}",
+                            )
+                        ]
+
+        return [
+            EvaluationOutput(
+                score=0.0,
+                test_pass=False,
+                reason=f"Expected tool '{expected_tool}' not found",
+            )
+        ]
+
+    def evaluate(self, evaluation_case: EvaluationData[str, str]) -> list[EvaluationOutput]:
+        return self._check_tool_usage(evaluation_case)
+
+    async def evaluate_async(self, evaluation_case: EvaluationData[str, str]) -> list[EvaluationOutput]:
+        return self._check_tool_usage(evaluation_case)
+
+
+@pytest.fixture(scope="module")
+def telemetry():
+    """Setup OTEL tracing with StrandsEvalsTelemetry for Traceloop."""
+    telemetry = StrandsEvalsTelemetry().setup_in_memory_exporter()
+    LangchainInstrumentor().instrument()
+    return telemetry
+
+
+@pytest.fixture
+def weather_tool():
+    """Create a weather tool for testing."""
+
+    @tool
+    def get_weather(city: str) -> str:
+        """Get the current weather for a city.
+
+        Args:
+            city: The city name to get weather for
+
+        Returns:
+            Weather information string
+        """
+        weather_data = {
+            "seattle": "Rainy, 55F",
+            "new york": "Sunny, 72F",
+            "london": "Cloudy, 60F",
+            "tokyo": "Clear, 68F",
+        }
+        city_lower = city.lower()
+        for c, w in weather_data.items():
+            if c in city_lower:
+                return f"Weather in {city}: {w}"
+        return f"Weather in {city}: Partly cloudy, 65F"
+
+    return get_weather
+
+
+@pytest.fixture
+def create_agent_func(weather_tool):
+    """Factory to create LangChain ReAct agents."""
+
+    def _create_agent():
+        region = os.environ.get("AWS_REGION", "us-west-2")
+        llm = ChatBedrock(
+            model_id=DEFAULT_MODEL_ID,
+            region_name=region,
+            model_kwargs={"temperature": 0},
+        )
+        return create_react_agent(llm, [weather_tool])
+
+    return _create_agent
+
+
+def test_traceloop_single_query(telemetry, create_agent_func):
+    """Test single query evaluation with Traceloop instrumentation."""
+    telemetry.in_memory_exporter.clear()
+
+    agent = create_agent_func()
+    query = "What's the weather in Seattle?"
+
+    result = agent.invoke({"messages": [HumanMessage(content=query)]})
+    messages = result.get("messages", [])
+    response = messages[-1].content if messages else ""
+
+    spans = readable_spans_to_dicts(telemetry.in_memory_exporter.get_finished_spans())
+    assert len(spans) > 0, "Should have captured OTEL spans"
+
+    mapper = detect_otel_mapper(spans)
+    session = mapper.map_to_session(spans, session_id="test-single")
+
+    assert session.session_id == "test-single"
+    assert len(session.traces) > 0, "Should have at least one trace"
+    assert "seattle" in response.lower() or "weather" in response.lower()
+
+
+def test_traceloop_evaluation_pipeline(telemetry, create_agent_func):
+    """Test full evaluation pipeline with Traceloop instrumentation."""
+    test_cases = [
+        Case[str, str](
+            name="weather-seattle",
+            input="What's the weather in Seattle?",
+            metadata={"expected_tool": "get_weather"},
+        ),
+    ]
+
+    def task_function(case: Case) -> dict:
+        telemetry.in_memory_exporter.clear()
+
+        agent = create_agent_func()
+        result = agent.invoke({"messages": [HumanMessage(content=case.input)]})
+
+        messages = result.get("messages", [])
+        response = messages[-1].content if messages else ""
+
+        spans = readable_spans_to_dicts(telemetry.in_memory_exporter.get_finished_spans())
+        mapper = detect_otel_mapper(spans)
+        session = mapper.map_to_session(spans, session_id=case.session_id)
+
+        return {
+            "output": response,
+            "trajectory": session,
+        }
+
+    experiment = Experiment(cases=test_cases, evaluators=[ToolUsageEvaluator()])
+    reports = experiment.run_evaluations(task_function)
+
+    assert len(reports) == 1
+    assert len(reports[0].scores) == 1
+    # The tool should have been used
+    assert reports[0].scores[0] == 1.0
+    assert reports[0].test_passes[0] is True
+
+
+def test_traceloop_multiple_cases(telemetry, create_agent_func):
+    """Test evaluation with multiple test cases."""
+    test_cases = [
+        Case[str, str](
+            name="weather-seattle",
+            input="What's the weather in Seattle?",
+            metadata={"expected_tool": "get_weather"},
+        ),
+        Case[str, str](
+            name="weather-tokyo",
+            input="Tell me the weather in Tokyo",
+            metadata={"expected_tool": "get_weather"},
+        ),
+    ]
+
+    def task_function(case: Case) -> dict:
+        telemetry.in_memory_exporter.clear()
+
+        agent = create_agent_func()
+        result = agent.invoke({"messages": [HumanMessage(content=case.input)]})
+
+        messages = result.get("messages", [])
+        response = messages[-1].content if messages else ""
+
+        spans = readable_spans_to_dicts(telemetry.in_memory_exporter.get_finished_spans())
+        mapper = detect_otel_mapper(spans)
+        session = mapper.map_to_session(spans, session_id=case.session_id)
+
+        return {
+            "output": response,
+            "trajectory": session,
+        }
+
+    experiment = Experiment(cases=test_cases, evaluators=[ToolUsageEvaluator()])
+    reports = experiment.run_evaluations(task_function)
+
+    assert len(reports) == 1
+    assert len(reports[0].scores) == 2
+    assert reports[0].overall_score == 1.0
+    assert all(reports[0].test_passes)
+
+
+def test_traceloop_mapper_detection(telemetry, create_agent_func):
+    """Verify that the correct mapper is auto-detected for Traceloop spans."""
+    telemetry.in_memory_exporter.clear()
+
+    agent = create_agent_func()
+    agent.invoke({"messages": [HumanMessage(content="What's the weather in London?")]})
+
+    spans = readable_spans_to_dicts(telemetry.in_memory_exporter.get_finished_spans())
+    mapper = detect_otel_mapper(spans)
+
+    assert isinstance(mapper, LangChainOtelSessionMapper), (
+        f"Expected LangChainOtelSessionMapper but got {type(mapper).__name__}"
+    )


### PR DESCRIPTION
## Description
This PR adds a mapper framework for converting OpenTelemetry traces from different LangChain (with traceloop / openllmetry) into a unified Session format for evaluation


### Architecture

#### Base Class:
  - SessionMapper (abstract base class) - defines the map_to_session(data, session_id) interface and provides _normalize_to_flat_spans() helper for handling various input formats

#### Famework-Specific Mappers:
1. **LangChainOtelSessionMapper**: Maps Traceloop/OpenLLMetry LangChain traces (scope: opentelemetry.instrumentation.langchain)

1. **OpenInferenceSessionMapper**: Maps OpenInference LangChain traces (scope: openinference.instrumentation.langchain)
1. **CloudWatchSessionMapper**: Maps Strands telemetry from CloudWatch/ADOT format
1. **StrandsInMemorySessionMapper**: Maps Strands in-memory OTEL spans (existing, now inherits from base)

### Utilities:
- **detect_otel_mapper(spans)** - Auto-detects appropriate mapper based on scope name
- **readable_spans_to_dicts(spans)** - Converts ReadableSpan objects to dict format
- **get_scope_name(span)** - Extracts scope from various span formats
- **CloudWatchLogsParser** - Normalizes raw CloudWatch logs to standard span format

---
 ## Cleanup Opportunities for Follow-up

### 1. Extract Common Helper Methods to Base Class

  The following methods are duplicated across all mappers:
  - _get_scope_name() - identical in LangChain & OpenInference mappers
  - _create_span_info() - nearly identical across all mappers
  - _parse_timestamp() - identical in LangChain & OpenInference mappers
  - _safe_json_parse() - identical logic (only in LangChain, but useful for others)

### 2. DRY Up Build Trace Logic

`_build_trace()` method has identical structure in LangChainOtelSessionMapper and OpenInferenceSessionMapper. This pattern could be moved to base class with abstract _is_*_span() methods.

### 3. Consolidate Message Extraction Pattern

  `_get_messages_from_span_events()` has similar logic in both LangChain and OpenInference mappers for extracting messages from ADOT/CloudWatch format.

### 4. Unify Tool Extraction
  `_extract_tools_from_attributes()` could be generalized - both mappers extract tool schemas but from different attribute keys.

## Related Issues

https://github.com/strands-agents/evals/issues/91

## Documentation PR

N/A

## Type of Change
New feature

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.