### PR TITLE
feat(report): allow flattened report

### DIFF
--- a/src/strands_evals/display/display_console.py
+++ b/src/strands_evals/display/display_console.py
@@ -79,21 +79,20 @@ class CollapsibleTableReportDisplay:
             symbol = "▼" if item["expanded"] else "▶"
             case = item["details"]
             pass_status = "✅" if case["test_pass"] else "❌"
-            other_fields = list(case.values())[3:]
-            if item["expanded"]:  # We always to render at least the index, name, score, test_pass, and reason
-                renderables = [
-                    f"{symbol} {key}",
-                    case.get("name", f"Test {key}"),
-                    case.get("score"),
-                    pass_status,
-                ] + other_fields
-            else:
-                renderables = [
-                    f"{symbol} {key}",
-                    case.get("name", f"Test {key}"),
-                    case.get("score"),
-                    pass_status,
-                ] + len(other_fields) * ["..."]
+
+            # Build renderables dynamically based on headers order
+            renderables = [f"{symbol} {key}"]  # index column
+            for header in list(case.keys()):
+                if header == "test_pass":
+                    renderables.append(pass_status)
+                elif item["expanded"]:
+                    renderables.append(case.get(header, ""))
+                else:
+                    # Show actual values for core fields, "..." for rest when collapsed
+                    if header in ("name", "evaluator", "score"):
+                        renderables.append(case.get(header, ""))
+                    else:
+                        renderables.append("...")
             table.add_row(*renderables)
 
         console.print(table)

--- a/src/strands_evals/experiment.py
+++ b/src/strands_evals/experiment.py
@@ -654,6 +654,7 @@ class Experiment(Generic[InputT, OutputT]):
             eval_name = evaluator.get_type_name()
             data = evaluator_data[eval_name]
             report = EvaluationReport(
+                evaluator_name=eval_name,
                 overall_score=sum(data["scores"]) / len(data["scores"]) if len(data["scores"]) else 0,
                 scores=data["scores"],
                 test_passes=data["test_passes"],
@@ -721,6 +722,7 @@ class Experiment(Generic[InputT, OutputT]):
             data = evaluator_data[eval_name]
             scores = data["scores"]
             report = EvaluationReport(
+                evaluator_name=eval_name,
                 overall_score=sum(scores) / len(scores) if scores else 0,
                 scores=scores,
                 test_passes=data["test_passes"],

--- a/src/strands_evals/types/evaluation_report.py
+++ b/src/strands_evals/types/evaluation_report.py
@@ -12,6 +12,7 @@ class EvaluationReport(BaseModel):
     A report of the evaluation of a task.
 
     Attributes:
+        evaluator_name: The name of the evaluator that produced this report.
         overall_score: The overall score of the task.
         scores: A list of the score for each test case in order.
         cases: A list of records for each test case.
@@ -19,12 +20,40 @@ class EvaluationReport(BaseModel):
         reasons: A list of reason for each test case.
     """
 
+    evaluator_name: str = ""
     overall_score: float
     scores: list[float]
     cases: list[dict]
     test_passes: list[bool]
     reasons: list[str] = []
     detailed_results: list[list[EvaluationOutput]] = []
+
+    @classmethod
+    def flatten(cls, reports: list["EvaluationReport"]) -> "EvaluationReport":
+        """Flatten multiple evaluation reports into a single report."""
+        if not reports:
+            return cls(overall_score=0.0, scores=[], cases=[], test_passes=[])
+
+        scores, cases, passes, reasons, detailed = [], [], [], [], []
+
+        for report in reports:
+            evaluator = report.evaluator_name or "Unknown"
+            for i, case in enumerate(report.cases):
+                cases.append({**case, "evaluator": evaluator})
+                scores.append(report.scores[i] if i < len(report.scores) else 0.0)
+                passes.append(report.test_passes[i] if i < len(report.test_passes) else False)
+                reasons.append(report.reasons[i] if i < len(report.reasons) else "")
+                detailed.append(report.detailed_results[i] if i < len(report.detailed_results) else [])
+
+        return cls(
+            evaluator_name="Combined",
+            overall_score=sum(scores) / len(scores) if scores else 0.0,
+            scores=scores,
+            cases=cases,
+            test_passes=passes,
+            reasons=reasons,
+            detailed_results=detailed,
+        )
 
     def _display(
         self,
@@ -60,12 +89,13 @@ class EvaluationReport(BaseModel):
         for i in range(len(self.scores)):
             name = self.cases[i].get("name", f"Test {i + 1}")
             reason = self.reasons[i] if i < len(self.reasons) else "N/A"
-            details_dict = {
-                "name": name,
-                "score": f"{self.scores[i]:.2f}",
-                "test_pass": self.test_passes[i],
-                "reason": reason,
-            }
+            details_dict = {"name": name}
+            # Include evaluator column for flattened reports (right after name)
+            if "evaluator" in self.cases[i]:
+                details_dict["evaluator"] = self.cases[i]["evaluator"]
+            details_dict["score"] = f"{self.scores[i]:.2f}"
+            details_dict["test_pass"] = self.test_passes[i]
+            details_dict["reason"] = reason
             if include_input:
                 details_dict["input"] = str(self.cases[i].get("input"))
             if include_actual_output:

--- a/tests/strands_evals/types/test_evaluation_report.py
+++ b/tests/strands_evals/types/test_evaluation_report.py
@@ -1,0 +1,344 @@
+import json
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from strands_evals.types.evaluation_report import EvaluationReport
+
+
+class TestEvaluationReportEvaluatorName:
+    """Tests for the evaluator_name field on EvaluationReport."""
+
+    def test_evaluator_name_default_empty(self):
+        """Test that evaluator_name defaults to empty string."""
+        report = EvaluationReport(
+            overall_score=0.5,
+            scores=[0.5],
+            cases=[{"name": "test"}],
+            test_passes=[True],
+        )
+        assert report.evaluator_name == ""
+
+    def test_evaluator_name_set(self):
+        """Test that evaluator_name can be set."""
+        report = EvaluationReport(
+            evaluator_name="ResponseRelevance",
+            overall_score=0.5,
+            scores=[0.5],
+            cases=[{"name": "test"}],
+            test_passes=[True],
+        )
+        assert report.evaluator_name == "ResponseRelevance"
+
+    def test_evaluator_name_serialization(self):
+        """Test that evaluator_name is included in serialization."""
+        report = EvaluationReport(
+            evaluator_name="TestEvaluator",
+            overall_score=0.5,
+            scores=[0.5],
+            cases=[{"name": "test"}],
+            test_passes=[True],
+        )
+        data = report.to_dict()
+        assert data["evaluator_name"] == "TestEvaluator"
+
+    def test_evaluator_name_deserialization(self):
+        """Test that evaluator_name is restored from dict."""
+        data = {
+            "evaluator_name": "TestEvaluator",
+            "overall_score": 0.5,
+            "scores": [0.5],
+            "cases": [{"name": "test"}],
+            "test_passes": [True],
+        }
+        report = EvaluationReport.from_dict(data)
+        assert report.evaluator_name == "TestEvaluator"
+
+    def test_evaluator_name_backward_compatible(self):
+        """Test that reports without evaluator_name can still be loaded."""
+        data = {
+            "overall_score": 0.5,
+            "scores": [0.5],
+            "cases": [{"name": "test"}],
+            "test_passes": [True],
+        }
+        report = EvaluationReport.from_dict(data)
+        assert report.evaluator_name == ""
+
+
+class TestEvaluationReportFlatten:
+    """Tests for the flatten() classmethod."""
+
+    def test_flatten_empty_list(self):
+        """Test flattening an empty list returns empty report."""
+        flattened = EvaluationReport.flatten([])
+        assert flattened.evaluator_name == ""
+        assert flattened.overall_score == 0.0
+        assert flattened.scores == []
+        assert flattened.cases == []
+        assert flattened.test_passes == []
+
+    def test_flatten_single_report(self):
+        """Test flattening a single report."""
+        report = EvaluationReport(
+            evaluator_name="Evaluator1",
+            overall_score=0.8,
+            scores=[0.9, 0.7],
+            cases=[
+                {"name": "case-1", "input": "input1"},
+                {"name": "case-2", "input": "input2"},
+            ],
+            test_passes=[True, True],
+            reasons=["reason1", "reason2"],
+        )
+
+        flattened = EvaluationReport.flatten([report])
+
+        assert flattened.evaluator_name == "Combined"
+        assert flattened.overall_score == 0.8
+        assert len(flattened.cases) == 2
+        assert flattened.cases[0]["evaluator"] == "Evaluator1"
+        assert flattened.cases[1]["evaluator"] == "Evaluator1"
+
+    def test_flatten_multiple_reports(self):
+        """Test flattening multiple reports."""
+        report1 = EvaluationReport(
+            evaluator_name="ResponseRelevance",
+            overall_score=0.85,
+            scores=[0.9, 0.8],
+            cases=[
+                {"name": "case-1", "input": "input1"},
+                {"name": "case-2", "input": "input2"},
+            ],
+            test_passes=[True, True],
+            reasons=["relevant", "relevant"],
+        )
+
+        report2 = EvaluationReport(
+            evaluator_name="Equals",
+            overall_score=0.0,
+            scores=[0.0, 0.0],
+            cases=[
+                {"name": "case-1", "input": "input1"},
+                {"name": "case-2", "input": "input2"},
+            ],
+            test_passes=[False, False],
+            reasons=["not equal", "not equal"],
+        )
+
+        flattened = EvaluationReport.flatten([report1, report2])
+
+        assert flattened.evaluator_name == "Combined"
+        assert flattened.overall_score == pytest.approx(0.425)
+        assert len(flattened.cases) == 4
+        assert len(flattened.scores) == 4
+        assert len(flattened.test_passes) == 4
+        assert len(flattened.reasons) == 4
+
+    def test_flatten_preserves_case_data(self):
+        """Test that flattening preserves all case data."""
+        report = EvaluationReport(
+            evaluator_name="Test",
+            overall_score=0.5,
+            scores=[0.5],
+            cases=[{"name": "case-1", "input": "test input", "metadata": {"key": "value"}}],
+            test_passes=[True],
+            reasons=["test reason"],
+        )
+
+        flattened = EvaluationReport.flatten([report])
+
+        assert flattened.cases[0]["name"] == "case-1"
+        assert flattened.cases[0]["input"] == "test input"
+        assert flattened.cases[0]["metadata"] == {"key": "value"}
+        assert flattened.cases[0]["evaluator"] == "Test"
+
+    def test_flatten_adds_evaluator_field(self):
+        """Test that flatten adds evaluator field to each case."""
+        report1 = EvaluationReport(
+            evaluator_name="Eval1",
+            overall_score=1.0,
+            scores=[1.0],
+            cases=[{"name": "case-1"}],
+            test_passes=[True],
+        )
+        report2 = EvaluationReport(
+            evaluator_name="Eval2",
+            overall_score=0.0,
+            scores=[0.0],
+            cases=[{"name": "case-1"}],
+            test_passes=[False],
+        )
+
+        flattened = EvaluationReport.flatten([report1, report2])
+
+        assert flattened.cases[0]["evaluator"] == "Eval1"
+        assert flattened.cases[1]["evaluator"] == "Eval2"
+
+    def test_flatten_averages_scores(self):
+        """Test that overall_score is the average of all scores."""
+        report1 = EvaluationReport(
+            evaluator_name="Eval1",
+            overall_score=1.0,
+            scores=[1.0, 1.0],
+            cases=[{"name": "c1"}, {"name": "c2"}],
+            test_passes=[True, True],
+        )
+        report2 = EvaluationReport(
+            evaluator_name="Eval2",
+            overall_score=0.0,
+            scores=[0.0, 0.0],
+            cases=[{"name": "c1"}, {"name": "c2"}],
+            test_passes=[False, False],
+        )
+
+        flattened = EvaluationReport.flatten([report1, report2])
+
+        # (1.0 + 1.0 + 0.0 + 0.0) / 4 = 0.5
+        assert flattened.overall_score == pytest.approx(0.5)
+
+    def test_flatten_handles_missing_evaluator_name(self):
+        """Test that flatten handles reports without evaluator_name."""
+        report = EvaluationReport(
+            overall_score=0.5,
+            scores=[0.5],
+            cases=[{"name": "case-1"}],
+            test_passes=[True],
+        )
+
+        flattened = EvaluationReport.flatten([report])
+
+        assert flattened.cases[0]["evaluator"] == "Unknown"
+
+    def test_flatten_handles_mismatched_lengths(self):
+        """Test that flatten handles reports with mismatched array lengths gracefully."""
+        report = EvaluationReport(
+            evaluator_name="Test",
+            overall_score=0.5,
+            scores=[0.5],  # Only 1 score
+            cases=[{"name": "c1"}, {"name": "c2"}],  # 2 cases
+            test_passes=[True],  # Only 1 pass
+            reasons=[],  # No reasons
+        )
+
+        flattened = EvaluationReport.flatten([report])
+
+        assert len(flattened.cases) == 2
+        assert flattened.scores[0] == 0.5
+        assert flattened.scores[1] == 0.0  # Default for missing
+        assert flattened.test_passes[0] is True
+        assert flattened.test_passes[1] is False  # Default for missing
+        assert flattened.reasons[0] == ""
+        assert flattened.reasons[1] == ""
+
+    def test_flatten_preserves_detailed_results(self):
+        """Test that flatten preserves detailed_results."""
+        from strands_evals.types.evaluation import EvaluationOutput
+
+        detailed = [EvaluationOutput(score=0.5, test_pass=True, reason="detail")]
+        report = EvaluationReport(
+            evaluator_name="Test",
+            overall_score=0.5,
+            scores=[0.5],
+            cases=[{"name": "case-1"}],
+            test_passes=[True],
+            detailed_results=[detailed],
+        )
+
+        flattened = EvaluationReport.flatten([report])
+
+        assert len(flattened.detailed_results) == 1
+        assert flattened.detailed_results[0] == detailed
+
+    def test_flatten_does_not_modify_original(self):
+        """Test that flatten does not modify the original reports."""
+        original_case = {"name": "case-1", "input": "test"}
+        report = EvaluationReport(
+            evaluator_name="Test",
+            overall_score=0.5,
+            scores=[0.5],
+            cases=[original_case],
+            test_passes=[True],
+        )
+
+        flattened = EvaluationReport.flatten([report])
+
+        # Original should not have evaluator field
+        assert "evaluator" not in original_case
+        # Flattened should have it
+        assert "evaluator" in flattened.cases[0]
+
+
+class TestEvaluationReportFileOperations:
+    """Tests for file save/load with evaluator_name."""
+
+    def test_to_file_includes_evaluator_name(self):
+        """Test that to_file includes evaluator_name in JSON."""
+        report = EvaluationReport(
+            evaluator_name="TestEval",
+            overall_score=0.5,
+            scores=[0.5],
+            cases=[{"name": "test"}],
+            test_passes=[True],
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "report.json"
+            report.to_file(str(path))
+
+            with open(path) as f:
+                data = json.load(f)
+
+            assert data["evaluator_name"] == "TestEval"
+
+    def test_from_file_loads_evaluator_name(self):
+        """Test that from_file loads evaluator_name."""
+        data = {
+            "evaluator_name": "LoadedEval",
+            "overall_score": 0.5,
+            "scores": [0.5],
+            "cases": [{"name": "test"}],
+            "test_passes": [True],
+        }
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "report.json"
+            with open(path, "w") as f:
+                json.dump(data, f)
+
+            report = EvaluationReport.from_file(str(path))
+
+            assert report.evaluator_name == "LoadedEval"
+
+    def test_flattened_report_roundtrip(self):
+        """Test that a flattened report can be saved and loaded."""
+        report1 = EvaluationReport(
+            evaluator_name="Eval1",
+            overall_score=1.0,
+            scores=[1.0],
+            cases=[{"name": "case-1"}],
+            test_passes=[True],
+            reasons=["pass"],
+        )
+        report2 = EvaluationReport(
+            evaluator_name="Eval2",
+            overall_score=0.0,
+            scores=[0.0],
+            cases=[{"name": "case-1"}],
+            test_passes=[False],
+            reasons=["fail"],
+        )
+
+        flattened = EvaluationReport.flatten([report1, report2])
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "flattened.json"
+            flattened.to_file(str(path))
+            loaded = EvaluationReport.from_file(str(path))
+
+            assert loaded.evaluator_name == "Combined"
+            assert loaded.overall_score == pytest.approx(0.5)
+            assert len(loaded.cases) == 2
+            assert loaded.cases[0]["evaluator"] == "Eval1"
+            assert loaded.cases[1]["evaluator"] == "Eval2"


### PR DESCRIPTION
## Description
Now we're generating list of reports given multiple evaluators passed in an experiment. This feature allows users to flatten it with an average score.


Before:
```
reports = experiment.run_evaluations(user_task_function)
report[0].run_display()

```

Example:
```
# 5. Run evaluations
reports = experiment.run_evaluations(user_task_function)

# 6. Flatten the reports to see all evaluators in one view
flattened = EvaluationReport.flatten(reports)  <--- main change here
flattened.run_display()
```

<img width="1050" height="298" alt="Screenshot 2026-03-12 at 11 53 59 AM" src="https://github.com/user-attachments/assets/aa792780-7b9d-4916-a232-eb03b8484ac6" />

## Related Issues
N/A

## Documentation PR

N/A

## Type of Change

Bug fix

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.