### PR TITLE
feat(mapper): added framework detection for traces from CloudWatch

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,9 @@ dependencies = [
     "moto>=5.1.0,<6.0.0",
 ]
 
+[[tool.hatch.envs.hatch-test.matrix]]
+python = ["3.13", "3.12", "3.11", "3.10"]
+
 [tool.hatch.envs.default.scripts]
 list = [
     "echo 'Scripts commands available for default env:'; hatch env show --json | jq --raw-output '.default.scripts | keys[]'"

--- a/src/strands_evals/mappers/cloudwatch_parser.py
+++ b/src/strands_evals/mappers/cloudwatch_parser.py
@@ -88,7 +88,12 @@ class CloudWatchLogsParser:
         return result
 
     def _is_event(self, record: dict) -> bool:
-        """Check if record is an OTEL event (has event.name attribute)."""
+        """Check if record is an OTEL event.
+
+        Recognized patterns:
+        1. Has explicit event name (EventName, eventName, or attributes.event.name)
+        2. Has body dict with input/output keys (body-format OTEL log record)
+        """
         if not isinstance(record, dict):
             return False
 
@@ -100,18 +105,34 @@ class CloudWatchLogsParser:
         if isinstance(attrs, dict) and "event.name" in attrs:
             return True
 
+        # Body-format records (body dict with input/output) are also events
+        body = record.get("body")
+        if isinstance(body, dict) and ("input" in body or "output" in body):
+            return True
+
         return False
 
     def _is_span(self, record: dict) -> bool:
-        """Check if record is an OTEL span (has start/end time)."""
+        """Check if record is an OTEL span.
+
+        Recognized patterns:
+        1. Has start/end timestamps (startTimeUnixNano/endTimeUnixNano or start_time/end_time)
+        2. Already normalized format with span_events list (pass-through)
+        """
         if not isinstance(record, dict):
             return False
 
         # Spans have startTimeUnixNano or start_time
         has_start = "startTimeUnixNano" in record or "start_time" in record
         has_end = "endTimeUnixNano" in record or "end_time" in record
+        if has_start and has_end:
+            return True
 
-        return has_start and has_end
+        # Already-normalized spans have span_events list
+        if "span_events" in record and isinstance(record.get("span_events"), list):
+            return True
+
+        return False
 
     def _normalize_event(self, record: dict) -> dict | None:
         """Normalize a CloudWatch event record."""
@@ -175,7 +196,7 @@ class CloudWatchLogsParser:
                     "version": scope.get("version", ""),
                 },
                 "status": {"code": status.get("code", "UNSET")},
-                "span_events": [],  # Will be populated later
+                "span_events": record.get("span_events", []),  # Preserve existing or populate later
             }
         except Exception as e:
             logger.warning(f"Failed to normalize span: {e}")
@@ -183,18 +204,23 @@ class CloudWatchLogsParser:
 
     def _create_synthetic_span(self, span_id: str, events: list[dict], first_event: dict) -> dict:
         """Create a synthetic span from events when no span records exist."""
-        # Get trace_id from the raw logs (need to find matching record)
+        # Get trace_id and scope from the raw logs
         trace_id = ""
+        scope_name = ""
         for record in self.raw_logs:
             if record.get("spanId") == span_id or record.get("span_id") == span_id:
-                trace_id = record.get("traceId") or record.get("trace_id", "")
-                break
+                trace_id = trace_id or record.get("traceId") or record.get("trace_id", "")
+                raw_scope = record.get("scope")
+                if isinstance(raw_scope, dict):
+                    scope_name = scope_name or raw_scope.get("name", "")
 
-        # Get scope from event name
-        event_name = first_event.get("event_name", "")
-        scope_name = first_event.get("attributes", {}).get("event.name", event_name)
+        # Fall back to event name as scope hint
+        if not scope_name:
+            event_name = first_event.get("event_name", "")
+            scope_name = first_event.get("attributes", {}).get("event.name", event_name)
 
         # Use event timestamp for span times
+        event_name = first_event.get("event_name", "")
         timestamp = first_event.get("timestamp", 0)
 
         return {

--- a/src/strands_evals/mappers/cloudwatch_session_mapper.py
+++ b/src/strands_evals/mappers/cloudwatch_session_mapper.py
@@ -2,10 +2,16 @@
 
 This mapper handles Strands telemetry data that has been normalized by CloudWatchLogsParser.
 It expects spans in the normalized format with span_events[].body containing input/output messages.
+
+.. deprecated::
+    CloudWatchSessionMapper is deprecated. Use ``CloudWatchProvider`` with auto-detection
+    (via ``detect_otel_mapper()``) instead, which automatically selects the correct mapper
+    based on the framework that produced the traces.
 """
 
 import json
 import logging
+import warnings
 from collections import defaultdict
 from datetime import datetime, timezone
 from typing import Any
@@ -35,6 +41,12 @@ logger = logging.getLogger(__name__)
 class CloudWatchSessionMapper(SessionMapper):
     """Maps normalized CloudWatch spans to Session format.
 
+    .. deprecated::
+        Use ``CloudWatchProvider`` with auto-detection instead. ``CloudWatchProvider``
+        now uses ``detect_otel_mapper()`` to automatically select the correct mapper
+        based on the span ``scope.name``, supporting Strands, LangChain, and other
+        frameworks stored in CloudWatch.
+
     This mapper handles Strands telemetry data. It expects spans in the normalized
     format produced by CloudWatchLogsParser:
     - snake_case field names (trace_id, span_id)
@@ -42,6 +54,16 @@ class CloudWatchSessionMapper(SessionMapper):
 
     For raw CloudWatch logs, use CloudWatchLogsParser first to normalize.
     """
+
+    def __init__(self):
+        super().__init__()
+        warnings.warn(
+            "CloudWatchSessionMapper is deprecated. Use CloudWatchProvider with "
+            "auto-detection (detect_otel_mapper) instead, which automatically selects "
+            "the correct mapper based on the framework that produced the traces.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
 
     def map_to_session(self, spans: list[dict[str, Any]], session_id: str) -> Session:
         """Map normalized spans to Session format.

--- a/src/strands_evals/mappers/langchain_otel_session_mapper.py
+++ b/src/strands_evals/mappers/langchain_otel_session_mapper.py
@@ -37,6 +37,26 @@ logger = logging.getLogger(__name__)
 
 SCOPE_NAME = "opentelemetry.instrumentation.langchain"
 
+# --- OTEL semantic convention attribute keys ---
+_ATTR_LLM_REQUEST_TYPE = "llm.request.type"
+
+# --- Traceloop/OpenLLMetry attribute keys ---
+_ATTR_TRACELOOP_SPAN_KIND = "traceloop.span.kind"
+_ATTR_TRACELOOP_ENTITY_NAME = "traceloop.entity.name"
+_ATTR_TRACELOOP_ENTITY_INPUT = "traceloop.entity.input"
+_ATTR_TRACELOOP_ENTITY_OUTPUT = "traceloop.entity.output"
+
+# --- Traceloop/OpenLLMetry attribute values ---
+_KIND_WORKFLOW = "workflow"
+_KIND_TOOL = "tool"
+_LLM_TYPE_CHAT = "chat"
+
+# --- ADOT body field values (LangChain serialization) ---
+_ADOT_ROLE_UNKNOWN = "unknown"
+_ADOT_LANGGRAPH_NAME = "LangGraph"
+_ADOT_TOOL_CALL_WITH_CONTEXT = "tool_call_with_context"
+_ADOT_INPUT_STR_KEY = "input_str"
+
 
 class LangChainOtelSessionMapper(SessionMapper):
     """Maps Traceloop/OpenLLMetry LangChain traces to Session format.
@@ -56,10 +76,12 @@ class LangChainOtelSessionMapper(SessionMapper):
 
     def __init__(self):
         super().__init__()
-        # Track tools per trace (LangGraph stores tools in inference spans, not agent spans)
-        self._trace_tools_map: dict[str, dict[str, ToolConfig]] = defaultdict(dict)
-        # Track system prompts per trace
-        self._trace_system_prompt_map: dict[str, str] = defaultdict(str)
+        # Cache: span_id → (input_messages, output_messages) from _get_messages_from_span_events
+        # Avoids re-parsing span_events body during detection and again during conversion.
+        # Reset at the start of each map_to_session call.
+        self._span_messages_cache: dict[str, tuple[list[dict], list[dict]]] = {}
+        # Cache: span_id → parsed input body from _parse_adot_body
+        self._adot_body_cache: dict[str, Any] = {}
 
     def map_to_session(self, data: Any, session_id: str) -> Session:
         """Map LangChain OTEL spans to Session format.
@@ -74,9 +96,8 @@ class LangChainOtelSessionMapper(SessionMapper):
         Returns:
             Session object ready for evaluation
         """
-        # Reset state for new mapping
-        self._trace_tools_map = defaultdict(dict)
-        self._trace_system_prompt_map = defaultdict(str)
+        self._span_messages_cache = {}
+        self._adot_body_cache = {}
 
         # Normalize input to flat spans
         spans = self._normalize_to_flat_spans(data)
@@ -100,13 +121,19 @@ class LangChainOtelSessionMapper(SessionMapper):
         return Session(traces=result_traces, session_id=session_id)
 
     def _build_trace(self, trace_id: str, spans: list[dict], session_id: str) -> Trace:
-        """Build a Trace from spans with the same trace_id."""
+        """Build a Trace from spans with the same trace_id.
+
+        Tools are collected from inference spans and passed to agent invocation spans,
+        since LangGraph stores tool definitions in inference spans, not agent spans.
+        """
         converted_spans: list[InferenceSpan | ToolExecutionSpan | AgentInvocationSpan] = []
+        # Local tools accumulator — populated by inference spans, consumed by agent spans
+        trace_tools: dict[str, ToolConfig] = {}
 
         for span in spans:
             try:
                 if self._is_inference_span(span):
-                    inference_span = self._convert_inference_span(span, session_id)
+                    inference_span = self._convert_inference_span(span, session_id, trace_tools)
                     if inference_span and inference_span.messages:
                         converted_spans.append(inference_span)
                 elif self._is_tool_execution_span(span):
@@ -114,11 +141,36 @@ class LangChainOtelSessionMapper(SessionMapper):
                     if tool_span:
                         converted_spans.append(tool_span)
                 elif self._is_agent_invocation_span(span):
-                    agent_span = self._convert_agent_invocation_span(span, session_id)
+                    agent_span = self._convert_agent_invocation_span(span, session_id, trace_tools)
                     if agent_span:
                         converted_spans.append(agent_span)
             except Exception as e:
                 logger.warning(f"Failed to convert span {span.get('span_id', 'unknown')}: {e}")
+
+        # In multi-agent LangGraph systems, each nested sub-graph (from
+        # create_react_agent) produces its own kwargs.name="LangGraph" record
+        # in ADOT, creating multiple AgentInvocationSpans with intermediate data.
+        # The root graph is always the LAST one (outermost scope finishes last).
+        # Keep only the root to match the live path behavior where Traceloop
+        # only marks the outermost graph as traceloop.span.kind="workflow".
+        agent_spans = [s for s in converted_spans if isinstance(s, AgentInvocationSpan)]
+        if len(agent_spans) > 1:
+            root = agent_spans[-1]
+            converted_spans = [s for s in converted_spans if not isinstance(s, AgentInvocationSpan) or s is root]
+
+        # If no tools found from attributes (common in ADOT), build from converted tool spans
+        if not trace_tools:
+            for converted in converted_spans:
+                if isinstance(converted, ToolExecutionSpan):
+                    name = converted.tool_call.name
+                    if name and name not in trace_tools:
+                        trace_tools[name] = ToolConfig(name=name, description=None, parameters=None)
+            # Back-fill available_tools into any AgentInvocationSpan already created
+            if trace_tools:
+                tools_list = sorted(trace_tools.values(), key=lambda t: t.name)
+                for converted in converted_spans:
+                    if isinstance(converted, AgentInvocationSpan) and not converted.available_tools:
+                        converted.available_tools = tools_list
 
         return Trace(spans=converted_spans, trace_id=trace_id, session_id=session_id)
 
@@ -127,33 +179,102 @@ class LangChainOtelSessionMapper(SessionMapper):
     # =========================================================================
 
     def _is_inference_span(self, span: dict) -> bool:
-        """Check if span is an LLM inference span."""
+        """Check if span is an LLM inference span.
+
+        Detection:
+        1. Live instrumentation: llm.request.type == "chat"
+        2. ADOT body: role == "unknown" with raw string content (direct LLM I/O)
+        """
         attrs = span.get("attributes", {})
-        return attrs.get("llm.request.type") == "chat"
+        if attrs.get(_ATTR_LLM_REQUEST_TYPE) == _LLM_TYPE_CHAT:
+            return True
+
+        # ADOT fallback: records with role="unknown" and raw string content are LLM calls
+        input_messages, _ = self._get_messages_from_span_events(span)
+        if input_messages and input_messages[0].get("role") == _ADOT_ROLE_UNKNOWN:
+            return True
+
+        return False
 
     def _is_tool_execution_span(self, span: dict) -> bool:
-        """Check if span is a tool execution span."""
+        """Check if span is a tool execution span.
+
+        Detection:
+        1. Live instrumentation: traceloop.span.kind == "tool"
+        2. ADOT body: input has "input_str" key (direct tool call format)
+        """
         attrs = span.get("attributes", {})
-        return attrs.get("traceloop.span.kind") == "tool"
+        if attrs.get(_ATTR_TRACELOOP_SPAN_KIND) == _KIND_TOOL:
+            return True
+
+        # ADOT fallback: "input_str" is the direct tool invocation format.
+        # Note: "tool_call_with_context" records are graph-level wrappers that
+        # duplicate the actual tool call — skip them to avoid duplicate spans.
+        in_parsed = self._parse_adot_body(span)
+        if isinstance(in_parsed, dict) and _ADOT_INPUT_STR_KEY in in_parsed:
+            return True
+
+        return False
 
     def _is_agent_invocation_span(self, span: dict) -> bool:
-        """Check if span is an agent invocation span."""
+        """Check if span is an agent invocation span.
+
+        Detection:
+        1. Live instrumentation: traceloop.span.kind == "workflow"
+        2. ADOT body: kwargs.name == "LangGraph" (root graph node only)
+
+        Only the root LangGraph node should become an AgentInvocationSpan.
+        Intermediate nodes (Prompt, call_model, should_continue, agent,
+        RunnableSequence, tools) are internal graph steps and must be skipped.
+        """
         attrs = span.get("attributes", {})
-        return attrs.get("traceloop.span.kind") == "workflow"
+        if attrs.get(_ATTR_TRACELOOP_SPAN_KIND) == _KIND_WORKFLOW:
+            return True
+
+        # ADOT fallback: only the root LangGraph node is the agent invocation
+        in_parsed = self._parse_adot_body(span)
+        if isinstance(in_parsed, dict):
+            kwargs = in_parsed.get("kwargs")
+            if isinstance(kwargs, dict) and kwargs.get("name") == _ADOT_LANGGRAPH_NAME:
+                return True
+
+        return False
+
+    def _parse_adot_body(self, span: dict) -> Any:
+        """Parse the input content from the first ADOT body message.
+
+        Returns the parsed JSON object or raw string, or None if no body found.
+        Result is cached per span_id to avoid re-parsing across detection methods.
+        """
+        span_id = span.get("span_id", "")
+        if span_id in self._adot_body_cache:
+            return self._adot_body_cache[span_id]
+
+        input_messages, _ = self._get_messages_from_span_events(span)
+        if not input_messages:
+            result = None
+        else:
+            in_content = input_messages[0].get("content", "")
+            result = self._safe_json_parse(in_content) if isinstance(in_content, str) else in_content
+
+        if span_id:
+            self._adot_body_cache[span_id] = result
+        return result
 
     # =========================================================================
     # Span Conversion
     # =========================================================================
 
-    def _convert_inference_span(self, span: dict, session_id: str) -> InferenceSpan | None:
+    def _convert_inference_span(
+        self, span: dict, session_id: str, trace_tools: dict[str, ToolConfig]
+    ) -> InferenceSpan | None:
         """Convert OTEL span to InferenceSpan."""
         span_info = self._create_span_info(span, session_id)
         attrs = span.get("attributes", {})
-        trace_id = span.get("trace_id", "")
 
-        # Extract available tools from attributes
+        # Extract available tools from attributes and accumulate for agent span
         tools = self._extract_tools_from_attributes(attrs)
-        self._trace_tools_map[trace_id].update(tools)
+        trace_tools.update(tools)
 
         # Extract messages from span events
         input_messages, output_messages = self._get_messages_from_span_events(span)
@@ -172,14 +293,6 @@ class LangChainOtelSessionMapper(SessionMapper):
             if assistant_msg:
                 messages.append(assistant_msg)
 
-        # Extract system prompt
-        for idx, msg in enumerate(input_messages):
-            if attrs.get(f"gen_ai.prompt.{idx}.role") == "system":
-                content = msg.get("content", "")
-                if isinstance(content, str):
-                    self._trace_system_prompt_map[trace_id] = content
-                break
-
         if not messages:
             return None
 
@@ -195,64 +308,72 @@ class LangChainOtelSessionMapper(SessionMapper):
         span_info = self._create_span_info(span, session_id)
         attrs = span.get("attributes", {})
 
-        tool_name = attrs.get("traceloop.entity.name")
+        tool_name = attrs.get(_ATTR_TRACELOOP_ENTITY_NAME)
         tool_parameters: dict | None = None
         tool_output_content: str | None = None
         tool_call_id: str | None = None
-        tool_status: str | None = ""
+        tool_status: str | None = None
 
         # Try ADOT/CloudWatch format first (span_events)
         input_messages, output_messages = self._get_messages_from_span_events(span)
 
         if input_messages and output_messages:
-            # ADOT format - extract from messages
-            input_content = input_messages[-1].get("content", "")
-            if isinstance(input_content, str):
-                parsed = self._safe_json_parse(input_content)
-                if isinstance(parsed, dict):
-                    if "inputs" in parsed and isinstance(parsed.get("inputs"), dict):
-                        tool_parameters = parsed.get("inputs")
-                    elif "input_str" in parsed:
-                        params_parsed = self._safe_json_parse(parsed.get("input_str", ""))
-                        if isinstance(params_parsed, dict):
-                            tool_parameters = params_parsed
+            in_parsed, out_parsed = self._parse_adot_tool_content(input_messages, output_messages)
 
-            output_content = output_messages[-1].get("content", "")
-            if isinstance(output_content, str):
-                parsed = self._safe_json_parse(output_content)
-                if isinstance(parsed, dict) and "output" in parsed:
-                    output_obj = parsed["output"]
-                    if isinstance(output_obj, dict) and "kwargs" in output_obj:
-                        kwargs = output_obj["kwargs"]
-                        if isinstance(kwargs, dict):
-                            tool_output_content = kwargs.get("content")
-                            tool_call_id = kwargs.get("tool_call_id")
-                            tool_status = kwargs.get("status")
+            # Extract tool parameters from input
+            if isinstance(in_parsed, dict):
+                inputs = in_parsed.get("inputs")
+                if isinstance(inputs, dict):
+                    # tool_call_with_context: {"inputs": {"__type": "tool_call_with_context", "tool_call": {...}}}
+                    if inputs.get("__type") == _ADOT_TOOL_CALL_WITH_CONTEXT:
+                        tc = inputs.get("tool_call", {})
+                        tool_parameters = tc.get("args", {})
+                        tool_name = tool_name or tc.get("name")
+                        tool_call_id = tool_call_id or tc.get("id")
+                    else:
+                        # Direct inputs dict: {"inputs": {"a": 1, "b": 2}}
+                        tool_parameters = inputs
+                if tool_parameters is None and _ADOT_INPUT_STR_KEY in in_parsed:
+                    params_parsed = self._safe_json_parse(in_parsed.get(_ADOT_INPUT_STR_KEY, ""))
+                    if isinstance(params_parsed, dict):
+                        tool_parameters = params_parsed
+
+            # Extract tool output, name, call_id from output
+            if isinstance(out_parsed, dict):
+                lc_kwargs = self._extract_lc_kwargs(out_parsed, "output")
+                if lc_kwargs is None:
+                    lc_kwargs = self._extract_lc_kwargs(out_parsed, "outputs")
+                if lc_kwargs:
+                    tool_output_content = str(lc_kwargs.get("content", ""))
+                    tool_call_id = tool_call_id or lc_kwargs.get("tool_call_id")
+                    tool_status = lc_kwargs.get("status", tool_status)
+                    tool_name = tool_name or lc_kwargs.get("name")
+                # Also check top-level kwargs for name
+                top_kwargs = out_parsed.get("kwargs", {})
+                if isinstance(top_kwargs, dict):
+                    tool_name = tool_name or top_kwargs.get("name")
         else:
             # Live format - extract from traceloop.entity.* attributes
-            entity_input = attrs.get("traceloop.entity.input", "")
-            entity_output = attrs.get("traceloop.entity.output", "")
+            entity_input = attrs.get(_ATTR_TRACELOOP_ENTITY_INPUT, "")
+            entity_output = attrs.get(_ATTR_TRACELOOP_ENTITY_OUTPUT, "")
 
             if entity_input:
                 parsed = self._safe_json_parse(entity_input)
                 if isinstance(parsed, dict):
                     if "inputs" in parsed and isinstance(parsed.get("inputs"), dict):
                         tool_parameters = parsed.get("inputs")
-                    elif "input_str" in parsed:
-                        params_parsed = self._safe_json_parse(parsed.get("input_str", ""))
+                    elif _ADOT_INPUT_STR_KEY in parsed:
+                        params_parsed = self._safe_json_parse(parsed.get(_ADOT_INPUT_STR_KEY, ""))
                         if isinstance(params_parsed, dict):
                             tool_parameters = params_parsed
 
             if entity_output:
                 parsed = self._safe_json_parse(entity_output)
-                if isinstance(parsed, dict) and "output" in parsed:
-                    output_obj = parsed["output"]
-                    if isinstance(output_obj, dict) and "kwargs" in output_obj:
-                        kwargs = output_obj["kwargs"]
-                        if isinstance(kwargs, dict):
-                            tool_output_content = kwargs.get("content")
-                            tool_call_id = kwargs.get("tool_call_id")
-                            tool_status = kwargs.get("status")
+                lc_kwargs = self._extract_lc_kwargs(parsed, "output") if isinstance(parsed, dict) else None
+                if lc_kwargs:
+                    tool_output_content = str(lc_kwargs.get("content", ""))
+                    tool_call_id = lc_kwargs.get("tool_call_id")
+                    tool_status = lc_kwargs.get("status", tool_status)
 
         # Validate required fields
         if not tool_name or tool_parameters is None or tool_output_content is None:
@@ -262,13 +383,15 @@ class LangChainOtelSessionMapper(SessionMapper):
         tool_call = ToolCall(name=tool_name, arguments=tool_parameters or {}, tool_call_id=tool_call_id)
         tool_result = ToolResult(
             content=tool_output_content or "",
-            error=None if tool_status == "success" else tool_status,
+            error=None if tool_status in ("success", None) else tool_status,
             tool_call_id=tool_call_id,
         )
 
         return ToolExecutionSpan(span_info=span_info, tool_call=tool_call, tool_result=tool_result, metadata={})
 
-    def _convert_agent_invocation_span(self, span: dict, session_id: str) -> AgentInvocationSpan | None:
+    def _convert_agent_invocation_span(
+        self, span: dict, session_id: str, trace_tools: dict[str, ToolConfig]
+    ) -> AgentInvocationSpan | None:
         """Convert OTEL span to AgentInvocationSpan.
 
         Handles two formats:
@@ -276,7 +399,6 @@ class LangChainOtelSessionMapper(SessionMapper):
         2. Live instrumentation: Data in traceloop.entity.input/output attributes
         """
         span_info = self._create_span_info(span, session_id)
-        trace_id = span.get("trace_id", "")
         attrs = span.get("attributes", {})
 
         user_query: str | None = None
@@ -291,8 +413,8 @@ class LangChainOtelSessionMapper(SessionMapper):
             agent_response = self._extract_agent_response_from_output(output_messages)
         else:
             # Live format - extract from traceloop.entity.* attributes
-            entity_input = attrs.get("traceloop.entity.input", "")
-            entity_output = attrs.get("traceloop.entity.output", "")
+            entity_input = attrs.get(_ATTR_TRACELOOP_ENTITY_INPUT, "")
+            entity_output = attrs.get(_ATTR_TRACELOOP_ENTITY_OUTPUT, "")
 
             if entity_input:
                 parsed = self._safe_json_parse(entity_input)
@@ -308,12 +430,12 @@ class LangChainOtelSessionMapper(SessionMapper):
                     if isinstance(outputs, dict) and "messages" in outputs:
                         agent_response = self._get_last_message_text(outputs["messages"])
 
-        if not user_query or not agent_response:
+        if user_query is None or agent_response is None:
             logger.warning(f"Missing user_query or agent_response for span {span.get('span_id')}")
             return None
 
         available_tools = sorted(
-            self._trace_tools_map.get(trace_id, {}).values(),
+            trace_tools.values(),
             key=lambda t: t.name,
         )
 
@@ -379,6 +501,40 @@ class LangChainOtelSessionMapper(SessionMapper):
                 return content
         return content
 
+    def _parse_adot_tool_content(self, input_messages: list[dict], output_messages: list[dict]) -> tuple[Any, Any]:
+        """Parse and return (input_parsed, output_parsed) from ADOT body messages."""
+        in_content = input_messages[-1].get("content", "")
+        in_parsed = self._safe_json_parse(in_content) if isinstance(in_content, str) else in_content
+
+        out_content = output_messages[-1].get("content", "")
+        out_parsed = self._safe_json_parse(out_content) if isinstance(out_content, str) else out_content
+
+        return in_parsed, out_parsed
+
+    def _extract_lc_kwargs(self, parsed: dict, key: str) -> dict | None:
+        """Extract kwargs from a LangChain serialized object at parsed[key].
+
+        Handles: {"output": {"lc": 1, "kwargs": {...}}}
+        Also handles list of LC objects: {"outputs": [{"lc": 1, "kwargs": {...}}]}
+        Also handles nested messages: {"outputs": {"messages": [{"kwargs": {...}}]}}
+        """
+        obj = parsed.get(key)
+        if isinstance(obj, dict):
+            if "kwargs" in obj:
+                return obj["kwargs"]
+            # Nested messages list
+            if "messages" in obj:
+                msgs = obj["messages"]
+                if isinstance(msgs, list) and msgs:
+                    last = msgs[-1]
+                    if isinstance(last, dict) and "kwargs" in last:
+                        return last["kwargs"]
+        if isinstance(obj, list) and obj:
+            last = obj[-1]
+            if isinstance(last, dict) and "kwargs" in last:
+                return last["kwargs"]
+        return None
+
     def _get_messages_from_span_events(self, span: dict) -> tuple[list[dict], list[dict]]:
         """Extract input and output messages from span events or attributes.
 
@@ -386,6 +542,17 @@ class LangChainOtelSessionMapper(SessionMapper):
         1. ADOT/CloudWatch: Messages in span_events[].body.input/output.messages
         2. Live instrumentation: Messages in gen_ai.prompt.*/gen_ai.completion.* attributes
         """
+        span_id = span.get("span_id", "")
+        if span_id in self._span_messages_cache:
+            return self._span_messages_cache[span_id]
+
+        result = self._extract_messages_from_span(span)
+        if span_id:
+            self._span_messages_cache[span_id] = result
+        return result
+
+    def _extract_messages_from_span(self, span: dict) -> tuple[list[dict], list[dict]]:
+        """Extract messages without caching — called by _get_messages_from_span_events."""
         # Try ADOT/CloudWatch format first (span_events)
         span_events = span.get("span_events", [])
         for event in span_events:
@@ -478,11 +645,16 @@ class LangChainOtelSessionMapper(SessionMapper):
 
         msg_content = message.get("content", "")
         if isinstance(msg_content, str):
+            # ADOT double-encodes strings — decode outer JSON quotes if present
+            text = self._safe_json_parse(msg_content) if msg_content.startswith('"') else msg_content
+            if not isinstance(text, str):
+                text = msg_content
             if is_tool_msg:
-                content.append(ToolResultContent(content=msg_content, error=None, tool_call_id=tool_call_id))
-            else:
-                content.append(TextContent(text=msg_content))
-            return UserMessage(content=content)
+                content.append(ToolResultContent(content=text, error=None, tool_call_id=tool_call_id))
+            elif text:
+                content.append(TextContent(text=text))
+            if content:
+                return UserMessage(content=content)
 
         return None
 
@@ -492,13 +664,19 @@ class LangChainOtelSessionMapper(SessionMapper):
 
         msg_content = message.get("content", "")
         if isinstance(msg_content, str):
-            content.append(TextContent(text=msg_content))
+            # ADOT double-encodes empty strings as '""' — decode and skip if empty
+            text = self._safe_json_parse(msg_content) if msg_content.startswith('"') else msg_content
+            if not isinstance(text, str):
+                text = msg_content
+            if text:
+                content.append(TextContent(text=text))
 
             # Check for tool calls
             tool_calls = self._get_assistant_tool_calls(index, attrs)
             content.extend(tool_calls)
 
-            return AssistantMessage(content=content)
+            if content:
+                return AssistantMessage(content=content)
 
         return None
 
@@ -554,45 +732,110 @@ class LangChainOtelSessionMapper(SessionMapper):
         return None
 
     def _extract_agent_response_from_output(self, output_messages: list[dict]) -> str | None:
-        """Extract agent response from agent invocation output messages."""
+        """Extract agent response from agent invocation output messages.
+
+        Handles multiple LangChain output formats:
+        1. {"outputs": {"messages": [...]}} — LangGraph state with messages list
+        2. {"outputs": {"lc": 1, "kwargs": {"content": "..."}}} — single LC object
+        3. {"outputs": [{"lc": 1, "kwargs": {"content": "..."}}]} — list of LC objects
+        4. {"output": "..."} / {"output": {"kwargs": {"content": "..."}}} — singular key
+        """
         if not output_messages:
             return None
 
         msg = output_messages[-1]
         content = msg.get("content", "")
-        if isinstance(content, str):
-            parsed = self._safe_json_parse(content)
-            if isinstance(parsed, dict) and "outputs" in parsed:
-                outputs = parsed["outputs"]
-                if isinstance(outputs, dict) and "messages" in outputs:
-                    messages = outputs["messages"]
-                    return self._get_last_message_text(messages)
+        if not isinstance(content, str):
+            return None
+
+        parsed = self._safe_json_parse(content)
+        if not isinstance(parsed, dict):
+            return None
+
+        # Try "outputs" key first, then "output"
+        for key in ("outputs", "output"):
+            if key not in parsed:
+                continue
+            value = parsed[key]
+
+            # Direct string
+            if isinstance(value, str) and value:
+                return value
+
+            # Dict with messages list: {"messages": [...]}
+            if isinstance(value, dict) and "messages" in value:
+                text = self._get_last_message_text(value["messages"])
+                if text:
+                    return text
+
+            # Single LC object: {"lc": 1, "kwargs": {"content": "..."}}
+            if isinstance(value, dict) and "kwargs" in value:
+                text = self._get_lc_text_content(value)
+                if text:
+                    return text
+
+            # List of LC objects: [{"lc": 1, "kwargs": {"content": "..."}}]
+            if isinstance(value, list) and value:
+                text = self._get_last_message_text(value)
+                if text:
+                    return text
+
+        return None
+
+    def _get_lc_text_content(self, lc_obj: dict) -> str | None:
+        """Extract text content from a LangChain serialized object.
+
+        Format: {"lc": 1, "type": "constructor", "id": [...], "kwargs": {"content": "..."}}
+        Content can be a string or a list of content blocks.
+        """
+        kwargs = lc_obj.get("kwargs", {})
+        if not isinstance(kwargs, dict):
+            return None
+        content = kwargs.get("content")
+        if isinstance(content, str) and content:
+            return content
+        if isinstance(content, list):
+            for item in content:
+                if isinstance(item, dict) and "text" in item:
+                    return item["text"]
         return None
 
     def _get_last_message_text(self, messages: list) -> str | None:
-        """Extract text from the last message in a LangGraph state messages list."""
+        """Extract text from the last message in a LangGraph state messages list.
+
+        Searches backward through messages to find the last one with non-empty text content.
+        Skips tool messages (type="tool") since they aren't agent responses.
+        """
         if not messages:
             return None
 
-        msg = messages[-1]
+        # Search backward for last message with non-empty content
+        for msg in reversed(messages):
+            text = self._extract_message_text(msg)
+            if text:
+                return text
 
-        # LangGraph-native format: {"kwargs": {"content": "..."}}
+        return None
+
+    def _extract_message_text(self, msg) -> str | None:
+        """Extract text content from a single message."""
         if isinstance(msg, dict):
+            # Skip tool messages — they aren't agent responses
+            if isinstance(msg.get("kwargs"), dict) and msg["kwargs"].get("type") == "tool":
+                return None
+
             if "kwargs" in msg:
                 kwargs = msg["kwargs"]
                 if isinstance(kwargs, dict) and "content" in kwargs:
                     content = kwargs["content"]
-                    # Handle list content (multi-part messages)
                     if isinstance(content, list):
                         for item in content:
                             if isinstance(item, dict) and "text" in item:
                                 return item["text"]
                     return content
-            # OpenAI format: {"content": "..."}
             if "content" in msg:
                 return msg["content"]
 
-        # Tuple format: ["role", "content"]
         elif isinstance(msg, list):
             return msg[-1] if msg else None
 

--- a/src/strands_evals/mappers/utils.py
+++ b/src/strands_evals/mappers/utils.py
@@ -61,6 +61,13 @@ def detect_otel_mapper(spans: list[Any]) -> SessionMapper:
             else:
                 return StrandsInMemorySessionMapper()
 
+    # Fallback: check if spans use the CloudWatch body format (no scope.name
+    # but have body.input/output structure). This handles raw CloudWatch
+    # log records that haven't been normalized by CloudWatchLogsParser.
+    for span in spans:
+        if get_body(span) is not None:
+            return CloudWatchSessionMapper()
+
     # Default to StrandsInMemorySessionMapper
     return StrandsInMemorySessionMapper()
 

--- a/src/strands_evals/providers/cloudwatch_provider.py
+++ b/src/strands_evals/providers/cloudwatch_provider.py
@@ -9,7 +9,9 @@ from typing import Any
 
 import boto3
 
-from ..mappers.cloudwatch_session_mapper import CloudWatchSessionMapper
+from ..mappers.cloudwatch_parser import CloudWatchLogsParser
+from ..mappers.session_mapper import SessionMapper
+from ..mappers.utils import detect_otel_mapper
 from ..providers.exceptions import ProviderError, SessionNotFoundError
 from ..providers.trace_provider import TraceProvider
 from ..types.evaluation import TaskOutput
@@ -29,6 +31,8 @@ class CloudWatchProvider(TraceProvider):
     and returns Session objects ready for the evaluation pipeline.
     """
 
+    SPANS_LOG_GROUP = "aws/spans"
+
     def __init__(
         self,
         region: str | None = None,
@@ -36,6 +40,7 @@ class CloudWatchProvider(TraceProvider):
         agent_name: str | None = None,
         lookback_days: int = 30,
         query_timeout_seconds: float = 60.0,
+        mapper: SessionMapper | None = None,
     ):
         """Initialize the CloudWatch provider.
 
@@ -47,13 +52,20 @@ class CloudWatchProvider(TraceProvider):
 
             from strands_evals.providers import CloudWatchProvider
 
-            # Explicit log group
+            # Explicit log group — auto-detects framework from span scope
             provider = CloudWatchProvider(
                 log_group="/aws/bedrock-agentcore/runtimes/my-agent-abc123-DEFAULT",
             )
 
             # Discover log group from agent name
             provider = CloudWatchProvider(agent_name="my-agent")
+
+            # Override mapper for a specific framework
+            from strands_evals.mappers import LangChainOtelSessionMapper
+            provider = CloudWatchProvider(
+                log_group="/aws/...",
+                mapper=LangChainOtelSessionMapper(),
+            )
 
         Args:
             region: AWS region. Falls back to AWS_REGION / AWS_DEFAULT_REGION env vars.
@@ -63,6 +75,10 @@ class CloudWatchProvider(TraceProvider):
                 `agent_name` must be provided.
             lookback_days: How many days back to search for traces.
             query_timeout_seconds: Maximum seconds to wait for a Logs Insights query.
+            mapper: Optional SessionMapper to use for converting spans to Session.
+                If not provided, the mapper is auto-detected from the span data
+                using ``detect_otel_mapper()``, which inspects ``scope.name``
+                to determine the correct framework mapper.
 
         Raises:
             ProviderError: If neither `log_group` nor `agent_name` is provided,
@@ -84,7 +100,7 @@ class CloudWatchProvider(TraceProvider):
 
         self._lookback_days = lookback_days
         self._query_timeout_seconds = query_timeout_seconds
-        self._mapper = CloudWatchSessionMapper()
+        self._mapper = mapper
 
     def _discover_log_group(self, agent_name: str) -> str:
         """Discover the runtime log group for an agent via describe_log_groups."""
@@ -96,20 +112,44 @@ class CloudWatchProvider(TraceProvider):
         return log_groups[0]["logGroupName"]
 
     def get_evaluation_data(self, session_id: str) -> TaskOutput:
-        """Fetch all traces for a session and return evaluation data."""
-        query = f"fields @message | filter attributes.session.id = '{session_id}' | sort @timestamp asc | limit 10000"
+        """Fetch all traces for a session and return evaluation data.
+
+        Queries two CloudWatch log groups:
+
+        1. **Runtimes log group** — event records with ``body.input/output.messages``
+        2. **aws/spans** — lightweight hierarchy lookup (``spanId → parentSpanId``)
+           to enrich the events with proper parent-child relationships.
+        """
+        query = (
+            f"fields @message | filter attributes.session.id like '{session_id}' | sort @timestamp asc | limit 10000"
+        )
 
         try:
-            span_dicts = self._run_logs_insights_query(query)
+            raw_records = self._run_logs_insights_query(query)
         except ProviderError:
             raise
         except Exception as e:
             raise ProviderError(f"CloudWatch: failed to query spans for session '{session_id}': {e}") from e
 
-        if not span_dicts:
+        if not raw_records:
             raise SessionNotFoundError(f"CloudWatch: no spans found for session_id='{session_id}'")
 
-        session = self._mapper.map_to_session(span_dicts, session_id)
+        # Normalize raw CloudWatch log records into the standard span format.
+        span_dicts = CloudWatchLogsParser(raw_records).parse()
+
+        if not span_dicts:
+            raise SessionNotFoundError(f"CloudWatch: no normalizable spans found for session_id='{session_id}'")
+
+        # Enrich with hierarchy from aws/spans (best-effort).
+        hierarchy = self._fetch_span_hierarchy(session_id)
+        if hierarchy:
+            for span in span_dicts:
+                parent = hierarchy.get(span.get("span_id", ""))
+                if parent:
+                    span["parent_span_id"] = parent
+
+        mapper = self._mapper or detect_otel_mapper(span_dicts)
+        session = mapper.map_to_session(span_dicts, session_id)
 
         if not session.traces:
             raise SessionNotFoundError(
@@ -119,19 +159,44 @@ class CloudWatchProvider(TraceProvider):
         output = self._extract_output(session)
         return TaskOutput(output=output, trajectory=session)
 
+    def _fetch_span_hierarchy(self, session_id: str) -> dict[str, str]:
+        """Fetch spanId→parentSpanId map from aws/spans. Returns empty dict on failure."""
+        query = f"fields spanId, parentSpanId | filter attributes.session.id like '{session_id}' | limit 10000"
+        now = datetime.now(tz=timezone.utc)
+        try:
+            response = self._client.start_query(
+                logGroupName=self.SPANS_LOG_GROUP,
+                startTime=int((now - timedelta(days=self._lookback_days)).timestamp()),
+                endTime=int(now.timestamp()),
+                queryString=query,
+            )
+            raw_results = self._poll_query_results(response["queryId"])
+        except Exception:
+            logger.debug("CloudWatch: aws/spans hierarchy query failed, continuing without hierarchy")
+            return {}
+
+        hierarchy: dict[str, str] = {}
+        for row in raw_results:
+            fields = {f["field"]: f["value"] for f in row}
+            span_id = fields.get("spanId", "")
+            parent_span_id = fields.get("parentSpanId", "")
+            if span_id and parent_span_id:
+                hierarchy[span_id] = parent_span_id
+
+        return hierarchy
+
     # --- Internal: CW Logs Insights query execution ---
 
     def _run_logs_insights_query(self, query: str) -> list[dict[str, Any]]:
         """Execute a CW Logs Insights query and return parsed span dicts from @message fields."""
         now = datetime.now(tz=timezone.utc)
-        end_time = now
         start_time = now - timedelta(days=self._lookback_days)
 
         try:
             response = self._client.start_query(
                 logGroupName=self._log_group,
                 startTime=int(start_time.timestamp()),
-                endTime=int(end_time.timestamp()),
+                endTime=int(now.timestamp()),
                 queryString=query,
             )
         except Exception as e:

--- a/tests/strands_evals/mappers/test_cloudwatch_parser.py
+++ b/tests/strands_evals/mappers/test_cloudwatch_parser.py
@@ -208,6 +208,73 @@ class TestParserIntegration:
         assert span_ids == {"s1", "s2"}
 
 
+class TestScopePreservation:
+    """Verify scope.name is preserved for all frameworks."""
+
+    def test_langchain_traceloop_scope_preserved(self):
+        """LangChain OpenLLMetry spans preserve scope.name through normalization."""
+        span = make_span_record(
+            scope_name="opentelemetry.instrumentation.langchain",
+            attributes={"traceloop.span.kind": "workflow"},
+        )
+        parser = CloudWatchLogsParser([span])
+        result = parser.parse()
+
+        assert len(result) == 1
+        assert result[0]["scope"]["name"] == "opentelemetry.instrumentation.langchain"
+
+    def test_openinference_scope_preserved(self):
+        """LangChain OpenInference spans preserve scope.name through normalization."""
+        span = make_span_record(
+            scope_name="openinference.instrumentation.langchain",
+            attributes={"openinference.span.kind": "CHAIN"},
+        )
+        parser = CloudWatchLogsParser([span])
+        result = parser.parse()
+
+        assert len(result) == 1
+        assert result[0]["scope"]["name"] == "openinference.instrumentation.langchain"
+
+    def test_strands_scope_preserved(self):
+        """Strands spans preserve scope.name through normalization."""
+        span = make_span_record(scope_name="strands.telemetry.tracer")
+        parser = CloudWatchLogsParser([span])
+        result = parser.parse()
+
+        assert result[0]["scope"]["name"] == "strands.telemetry.tracer"
+
+    def test_scope_preserved_with_events(self):
+        """Scope is preserved when span has associated events."""
+        span = make_span_record(
+            span_id="s1",
+            scope_name="opentelemetry.instrumentation.langchain",
+        )
+        event = make_event_record(span_id="s1", body={"data": "test"})
+
+        parser = CloudWatchLogsParser([span, event])
+        result = parser.parse()
+
+        assert result[0]["scope"]["name"] == "opentelemetry.instrumentation.langchain"
+
+    def test_synthetic_span_picks_up_scope_from_raw_record(self):
+        """Synthetic spans use scope.name from raw record if available."""
+        # Event record that also has a scope field on it
+        event_with_scope = {
+            "spanId": "s1",
+            "EventName": "test.event",
+            "timeUnixNano": 1000,
+            "attributes": {},
+            "body": {"input": {"messages": []}, "output": {"messages": []}},
+            "scope": {"name": "opentelemetry.instrumentation.langchain", "version": "0.1"},
+        }
+
+        parser = CloudWatchLogsParser([event_with_scope])
+        result = parser.parse()
+
+        assert len(result) == 1
+        assert result[0]["scope"]["name"] == "opentelemetry.instrumentation.langchain"
+
+
 class TestConvenienceFunction:
     def test_parse_cloudwatch_logs_function(self):
         """Convenience function works same as class."""

--- a/tests/strands_evals/mappers/test_cloudwatch_session_mapper.py
+++ b/tests/strands_evals/mappers/test_cloudwatch_session_mapper.py
@@ -2,6 +2,8 @@
 
 import json
 
+import pytest
+
 from strands_evals.mappers.cloudwatch_session_mapper import CloudWatchSessionMapper
 from strands_evals.types.trace import (
     AgentInvocationSpan,
@@ -9,6 +11,12 @@ from strands_evals.types.trace import (
     ToolExecutionSpan,
 )
 from tests.strands_evals.cloudwatch_helpers import make_assistant_text_message, make_log_record, make_user_message
+
+
+@pytest.fixture
+def mapper():
+    return CloudWatchSessionMapper()
+
 
 # --- Helpers for body-format log records ---
 
@@ -38,23 +46,20 @@ def _make_tool_result_message(tool_use_id, result_text):
 
 
 class TestSpanConversion:
-    def setup_method(self):
-        self.mapper = CloudWatchSessionMapper()
-
-    def test_single_record_produces_inference_span(self):
+    def test_single_record_produces_inference_span(self, mapper):
         """One log record produces an InferenceSpan with input/output messages."""
         record = make_log_record(
             input_messages=[make_user_message("Hi")],
             output_messages=[make_assistant_text_message("Hello!")],
         )
-        session = self.mapper.map_to_session([record], "sess-1")
+        session = mapper.map_to_session([record], "sess-1")
         spans = session.traces[0].spans
         inference_spans = [s for s in spans if isinstance(s, InferenceSpan)]
         assert len(inference_spans) == 1
         assert inference_spans[0].messages[0].content[0].text == "Hi"
         assert inference_spans[0].messages[1].content[0].text == "Hello!"
 
-    def test_record_with_tool_use_and_result(self):
+    def test_record_with_tool_use_and_result(self, mapper):
         """toolUse in output + toolResult in next record's input → ToolExecutionSpan."""
         record1 = make_log_record(
             trace_id="t1",
@@ -73,14 +78,14 @@ class TestSpanConversion:
             output_messages=[make_assistant_text_message("The answer is 42.")],
             time_nano=2000,
         )
-        session = self.mapper.map_to_session([record1, record2], "sess-1")
+        session = mapper.map_to_session([record1, record2], "sess-1")
         tool_spans = [s for s in session.traces[0].spans if isinstance(s, ToolExecutionSpan)]
         assert len(tool_spans) == 1
         assert tool_spans[0].tool_call.name == "calculator"
         assert tool_spans[0].tool_call.arguments == {"expr": "6*7"}
         assert tool_spans[0].tool_result.content == "42"
 
-    def test_agent_invocation_from_trace(self):
+    def test_agent_invocation_from_trace(self, mapper):
         """User prompt from first record, response from last → AgentInvocationSpan."""
         record1 = make_log_record(
             trace_id="t1",
@@ -89,13 +94,13 @@ class TestSpanConversion:
             output_messages=[make_assistant_text_message("Why did the chicken cross the road?")],
             time_nano=1000,
         )
-        session = self.mapper.map_to_session([record1], "sess-1")
+        session = mapper.map_to_session([record1], "sess-1")
         agent_spans = [s for s in session.traces[0].spans if isinstance(s, AgentInvocationSpan)]
         assert len(agent_spans) == 1
         assert agent_spans[0].user_prompt == "Tell me a joke"
         assert agent_spans[0].agent_response == "Why did the chicken cross the road?"
 
-    def test_agent_invocation_extracts_tools(self):
+    def test_agent_invocation_extracts_tools(self, mapper):
         """available_tools populated from tool call names in the trace."""
         record1 = make_log_record(
             trace_id="t1",
@@ -111,24 +116,24 @@ class TestSpanConversion:
             output_messages=[make_assistant_text_message("Here's what I found about X.")],
             time_nano=2000,
         )
-        session = self.mapper.map_to_session([record1, record2], "sess-1")
+        session = mapper.map_to_session([record1, record2], "sess-1")
         agent_spans = [s for s in session.traces[0].spans if isinstance(s, AgentInvocationSpan)]
         assert len(agent_spans) == 1
         tool_names = [t.name for t in agent_spans[0].available_tools]
         assert "web_search" in tool_names
 
-    def test_double_encoded_content_parsed(self):
+    def test_double_encoded_content_parsed(self, mapper):
         """Content field is a JSON string that must be parsed to get content blocks."""
         record = make_log_record(
             input_messages=[make_user_message("test double encoding")],
             output_messages=[make_assistant_text_message("parsed correctly")],
         )
-        session = self.mapper.map_to_session([record], "sess-1")
+        session = mapper.map_to_session([record], "sess-1")
         inference_spans = [s for s in session.traces[0].spans if isinstance(s, InferenceSpan)]
         assert inference_spans[0].messages[0].content[0].text == "test double encoding"
         assert inference_spans[0].messages[1].content[0].text == "parsed correctly"
 
-    def test_tool_call_matched_to_result_by_id(self):
+    def test_tool_call_matched_to_result_by_id(self, mapper):
         """toolUseId matching works across records in the same trace."""
         record1 = make_log_record(
             trace_id="t1",
@@ -162,7 +167,7 @@ class TestSpanConversion:
             output_messages=[make_assistant_text_message("Both done.")],
             time_nano=3000,
         )
-        session = self.mapper.map_to_session([record1, record2, record3], "sess-1")
+        session = mapper.map_to_session([record1, record2, record3], "sess-1")
         tool_spans = [s for s in session.traces[0].spans if isinstance(s, ToolExecutionSpan)]
         assert len(tool_spans) == 2
         tool_span_by_name = {ts.tool_call.name: ts for ts in tool_spans}
@@ -174,10 +179,7 @@ class TestSpanConversion:
 
 
 class TestSessionBuilding:
-    def setup_method(self):
-        self.mapper = CloudWatchSessionMapper()
-
-    def test_multiple_records_grouped_by_trace_id(self):
+    def test_multiple_records_grouped_by_trace_id(self, mapper):
         """Records with different traceIds become separate Trace objects."""
         records = [
             make_log_record(
@@ -191,14 +193,14 @@ class TestSessionBuilding:
                 output_messages=[make_assistant_text_message("a2")],
             ),
         ]
-        session = self.mapper.map_to_session(records, "sess-1")
+        session = mapper.map_to_session(records, "sess-1")
         assert session.session_id == "sess-1"
         assert len(session.traces) == 2
         trace_ids = {t.trace_id for t in session.traces}
         assert trace_ids == {"t1", "t2"}
 
-    def test_multi_step_agent_loop(self):
-        """user→LLM→tool→LLM→response produces InferenceSpan + ToolExecutionSpan + AgentInvocationSpan."""
+    def test_multi_step_agent_loop(self, mapper):
+        """user->LLM->tool->LLM->response produces InferenceSpan + ToolExecutionSpan + AgentInvocationSpan."""
         record1 = make_log_record(
             trace_id="t1",
             span_id="s1",
@@ -216,7 +218,7 @@ class TestSessionBuilding:
             output_messages=[make_assistant_text_message("The answer is 42.")],
             time_nano=2000,
         )
-        session = self.mapper.map_to_session([record1, record2], "sess-1")
+        session = mapper.map_to_session([record1, record2], "sess-1")
         assert len(session.traces) == 1
         spans = session.traces[0].spans
         span_types = [type(s).__name__ for s in spans]
@@ -224,12 +226,12 @@ class TestSessionBuilding:
         assert "ToolExecutionSpan" in span_types
         assert "AgentInvocationSpan" in span_types
 
-    def test_empty_records_list(self):
-        session = self.mapper.map_to_session([], "sess-1")
+    def test_empty_records_list(self, mapper):
+        session = mapper.map_to_session([], "sess-1")
         assert session.session_id == "sess-1"
         assert session.traces == []
 
-    def test_record_with_no_body_skipped(self):
+    def test_record_with_no_body_skipped(self, mapper):
         """Malformed records without body don't crash."""
         records = [
             {"traceId": "t1", "spanId": "s1", "timeUnixNano": 1000},
@@ -240,6 +242,6 @@ class TestSessionBuilding:
                 time_nano=2000,
             ),
         ]
-        session = self.mapper.map_to_session(records, "sess-1")
+        session = mapper.map_to_session(records, "sess-1")
         assert len(session.traces) == 1
         assert len(session.traces[0].spans) > 0

--- a/tests/strands_evals/providers/test_cloudwatch_provider.py
+++ b/tests/strands_evals/providers/test_cloudwatch_provider.py
@@ -2,17 +2,34 @@
 
 import json
 import os
+from datetime import datetime, timezone
 from unittest.mock import MagicMock, patch
 
 import pytest
 
+from strands_evals.mappers import LangChainOtelSessionMapper, OpenInferenceSessionMapper
 from strands_evals.providers.cloudwatch_provider import CloudWatchProvider
 from strands_evals.providers.exceptions import (
     ProviderError,
     SessionNotFoundError,
 )
-from strands_evals.types.trace import Session
+from strands_evals.types.trace import AgentInvocationSpan, Session, SpanInfo, Trace
 from tests.strands_evals.cloudwatch_helpers import make_assistant_text_message, make_log_record, make_user_message
+
+# --- Helpers ---
+
+
+def _session_with_agent_span(session_id: str, trace_id: str, user_prompt: str, agent_response: str) -> Session:
+    """Build a minimal valid Session that passes CloudWatchProvider's post-mapping checks."""
+    now = datetime.now(timezone.utc)
+    span = AgentInvocationSpan(
+        span_info=SpanInfo(session_id=session_id, trace_id=trace_id, span_id="s1", start_time=now, end_time=now),
+        user_prompt=user_prompt,
+        agent_response=agent_response,
+        available_tools=[],
+    )
+    return Session(session_id=session_id, traces=[Trace(trace_id=trace_id, session_id=session_id, spans=[span])])
+
 
 # --- Fixtures ---
 
@@ -25,7 +42,10 @@ def mock_logs_client():
 @pytest.fixture
 def provider(mock_logs_client):
     with patch("boto3.client", return_value=mock_logs_client):
-        return CloudWatchProvider(log_group="/test/group")
+        p = CloudWatchProvider(log_group="/test/group")
+    # Skip hierarchy lookup for tests that only exercise the events path
+    p._fetch_span_hierarchy = lambda session_id: {}
+    return p
 
 
 # --- Constructor ---
@@ -142,7 +162,7 @@ def _setup_query_results(mock_logs_client, records):
 
 
 class TestExtractOutput:
-    def test_extract_output_from_agent_response(self, provider):
+    def test_extract_output_from_agent_response(self, provider, mock_logs_client):
         """_extract_output returns last agent response text."""
         records = [
             make_log_record(
@@ -160,9 +180,9 @@ class TestExtractOutput:
                 time_nano=2000,
             ),
         ]
-        session = provider._mapper.map_to_session(records, "sess-1")
-        output = provider._extract_output(session)
-        assert output == "Final response"
+        _setup_query_results(mock_logs_client, records)
+        result = provider.get_evaluation_data("sess-1")
+        assert result["output"] == "Final response"
 
 
 # --- CW Logs Insights polling ---
@@ -317,11 +337,13 @@ class TestGetEvaluationData:
         records = [
             make_log_record(
                 trace_id="t1",
+                span_id="s1",
                 input_messages=[make_user_message("q1")],
                 output_messages=[make_assistant_text_message("first")],
             ),
             make_log_record(
                 trace_id="t2",
+                span_id="s2",
                 input_messages=[make_user_message("q2")],
                 output_messages=[make_assistant_text_message("second")],
             ),
@@ -350,3 +372,209 @@ class TestGetEvaluationData:
         ]
         _setup_query_results(mock_logs_client, records)
         assert provider.get_evaluation_data("sess-1")["output"] == "last"
+
+
+# --- Mapper auto-detection ---
+
+
+class TestMapperAutoDetection:
+    def test_default_mapper_is_none(self, mock_logs_client):
+        """When no mapper is provided, auto-detection is used."""
+        with patch("boto3.client", return_value=mock_logs_client):
+            p = CloudWatchProvider(log_group="/test/group")
+            assert p._mapper is None
+
+    def test_explicit_mapper_override(self, mock_logs_client):
+        """User can provide a specific mapper to skip auto-detection."""
+        with patch("boto3.client", return_value=mock_logs_client):
+            mapper = LangChainOtelSessionMapper()
+            p = CloudWatchProvider(log_group="/test/group", mapper=mapper)
+            assert p._mapper is mapper
+
+    def test_auto_detects_strands_mapper_for_strands_spans(self, mock_logs_client):
+        """Strands body-format spans auto-detect to CloudWatchSessionMapper."""
+        records = [
+            make_log_record(
+                trace_id="t1",
+                input_messages=[make_user_message("Hi")],
+                output_messages=[make_assistant_text_message("Hello!")],
+            )
+        ]
+        _setup_query_results(mock_logs_client, records)
+
+        with patch("boto3.client", return_value=mock_logs_client):
+            p = CloudWatchProvider(log_group="/test/group")
+            p._fetch_span_hierarchy = lambda session_id: {}
+            result = p.get_evaluation_data("sess-1")
+            assert isinstance(result["trajectory"], Session)
+            assert result["output"] == "Hello!"
+
+    def test_auto_detects_langchain_otel_mapper(self, mock_logs_client):
+        """Spans with opentelemetry.instrumentation.langchain scope trigger LangChainOtelSessionMapper."""
+        span = {
+            "trace_id": "t1",
+            "span_id": "s1",
+            "scope": {"name": "opentelemetry.instrumentation.langchain", "version": "0.1"},
+            "attributes": {"traceloop.span.kind": "workflow"},
+            "span_events": [],
+        }
+        _setup_query_results(mock_logs_client, [span])
+
+        with patch("boto3.client", return_value=mock_logs_client):
+            p = CloudWatchProvider(log_group="/test/group")
+            p._fetch_span_hierarchy = lambda session_id: {}
+            with patch.object(LangChainOtelSessionMapper, "map_to_session") as mock_map:
+                mock_map.return_value = _session_with_agent_span("sess-1", "t1", "Hello", "Hi!")
+                result = p.get_evaluation_data("sess-1")
+                mock_map.assert_called_once()
+                assert result["output"] == "Hi!"
+
+    def test_auto_detects_openinference_mapper(self, mock_logs_client):
+        """Spans with openinference.instrumentation.langchain scope trigger OpenInferenceSessionMapper."""
+        span = {
+            "trace_id": "t1",
+            "span_id": "s1",
+            "scope": {"name": "openinference.instrumentation.langchain", "version": "0.1"},
+            "attributes": {"openinference.span.kind": "CHAIN"},
+            "span_events": [],
+        }
+        _setup_query_results(mock_logs_client, [span])
+
+        with patch("boto3.client", return_value=mock_logs_client):
+            p = CloudWatchProvider(log_group="/test/group")
+            p._fetch_span_hierarchy = lambda session_id: {}
+            with patch.object(OpenInferenceSessionMapper, "map_to_session") as mock_map:
+                mock_map.return_value = _session_with_agent_span("sess-1", "t1", "Hello", "Hi!")
+                result = p.get_evaluation_data("sess-1")
+                mock_map.assert_called_once()
+                assert result["output"] == "Hi!"
+
+
+# --- Span hierarchy (aws/spans) ---
+
+
+def _make_hierarchy_row(span_id: str, parent_span_id: str) -> list[dict[str, str]]:
+    """Build a Logs Insights result row with spanId and parentSpanId fields."""
+    return [
+        {"field": "spanId", "value": span_id},
+        {"field": "parentSpanId", "value": parent_span_id},
+    ]
+
+
+class TestSpanHierarchy:
+    def test_hierarchy_enriches_parent_span_id(self, mock_logs_client):
+        """Events get parent_span_id from aws/spans hierarchy lookup."""
+        events = [
+            make_log_record(
+                trace_id="t1",
+                span_id="s1",
+                input_messages=[make_user_message("Hi")],
+                output_messages=[make_assistant_text_message("Hello!")],
+            ),
+            make_log_record(
+                trace_id="t1",
+                span_id="s2",
+                input_messages=[make_user_message("More")],
+                output_messages=[make_assistant_text_message("Done")],
+            ),
+        ]
+        hierarchy_rows = [
+            _make_hierarchy_row("s1", "root"),
+            _make_hierarchy_row("s2", "s1"),
+        ]
+
+        # First query → events, second query → hierarchy
+        call_count = 0
+
+        def start_query(**kwargs):
+            nonlocal call_count
+            call_count += 1
+            return {"queryId": f"q-{call_count}"}
+
+        def get_results(**kwargs):
+            qid = kwargs["queryId"]
+            if qid == "q-1":  # events
+                return {
+                    "status": "Complete",
+                    "results": [[{"field": "@message", "value": json.dumps(e)}] for e in events],
+                }
+            else:  # hierarchy
+                return {"status": "Complete", "results": hierarchy_rows}
+
+        mock_logs_client.start_query.side_effect = start_query
+        mock_logs_client.get_query_results.side_effect = get_results
+
+        with patch("boto3.client", return_value=mock_logs_client):
+            p = CloudWatchProvider(log_group="/test/group")
+            p.get_evaluation_data("sess-1")
+            # Verify hierarchy query was made
+            assert mock_logs_client.start_query.call_count == 2
+            # Second query targets aws/spans
+            second_call = mock_logs_client.start_query.call_args_list[1][1]
+            assert second_call["logGroupName"] == "aws/spans"
+            assert "spanId, parentSpanId" in second_call["queryString"]
+
+    def test_hierarchy_failure_still_works(self, mock_logs_client):
+        """If aws/spans query fails, events still produce a valid session."""
+        events = [
+            make_log_record(
+                trace_id="t1",
+                span_id="s1",
+                input_messages=[make_user_message("Hi")],
+                output_messages=[make_assistant_text_message("Works!")],
+            ),
+        ]
+        call_count = 0
+
+        def start_query(**kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 2:  # hierarchy query
+                raise Exception("access denied to aws/spans")
+            return {"queryId": "q-1"}
+
+        mock_logs_client.start_query.side_effect = start_query
+        mock_logs_client.get_query_results.return_value = {
+            "status": "Complete",
+            "results": [[{"field": "@message", "value": json.dumps(e)}] for e in events],
+        }
+
+        with patch("boto3.client", return_value=mock_logs_client):
+            p = CloudWatchProvider(log_group="/test/group")
+            result = p.get_evaluation_data("sess-1")
+            assert result["output"] == "Works!"
+
+    def test_hierarchy_empty_is_fine(self, mock_logs_client):
+        """Empty hierarchy (no spans in aws/spans) doesn't break anything."""
+        events = [
+            make_log_record(
+                trace_id="t1",
+                span_id="s1",
+                input_messages=[make_user_message("Hi")],
+                output_messages=[make_assistant_text_message("OK")],
+            ),
+        ]
+        call_count = 0
+
+        def start_query(**kwargs):
+            nonlocal call_count
+            call_count += 1
+            return {"queryId": f"q-{call_count}"}
+
+        def get_results(**kwargs):
+            qid = kwargs["queryId"]
+            if qid == "q-1":
+                return {
+                    "status": "Complete",
+                    "results": [[{"field": "@message", "value": json.dumps(e)}] for e in events],
+                }
+            else:
+                return {"status": "Complete", "results": []}
+
+        mock_logs_client.start_query.side_effect = start_query
+        mock_logs_client.get_query_results.side_effect = get_results
+
+        with patch("boto3.client", return_value=mock_logs_client):
+            p = CloudWatchProvider(log_group="/test/group")
+            result = p.get_evaluation_data("sess-1")
+            assert result["output"] == "OK"

--- a/tests_integ/test_langchain_openinference_eval.py
+++ b/tests_integ/test_langchain_openinference_eval.py
@@ -70,8 +70,10 @@ class ToolUsageEvaluator(Evaluator[str, str]):
 def telemetry():
     """Setup OTEL tracing with StrandsEvalsTelemetry for OpenInference."""
     telemetry = StrandsEvalsTelemetry().setup_in_memory_exporter()
-    LangChainInstrumentor().instrument()
-    return telemetry
+    instrumentor = LangChainInstrumentor()
+    instrumentor.instrument()
+    yield telemetry
+    instrumentor.uninstrument()
 
 
 @pytest.fixture

--- a/tests_integ/test_langchain_traceloop_eval.py
+++ b/tests_integ/test_langchain_traceloop_eval.py
@@ -73,8 +73,10 @@ class ToolUsageEvaluator(Evaluator[str, str]):
 def telemetry():
     """Setup OTEL tracing with StrandsEvalsTelemetry for Traceloop."""
     telemetry = StrandsEvalsTelemetry().setup_in_memory_exporter()
-    LangchainInstrumentor().instrument()
-    return telemetry
+    instrumentor = LangchainInstrumentor()
+    instrumentor.instrument()
+    yield telemetry
+    instrumentor.uninstrument()
 
 
 @pytest.fixture


### PR DESCRIPTION
## Description
Users could have non-Strands traces in CloudWatch (via the collector). Our current CloudWatchProvider is using CloudWatchSessionMapper which only works for Strands.

Since we're going to have the mapper which is "framework / convention specific", we will deprecate CloudWatchSessionMapper and route the traces / spans to the correct mapper via `detect_otel_mapper` method.

### What has been changed                                                                                                                                                                             
  - **CloudWatchProvider now queries** `aws/spans` log group for **span hierarchy** (spanId → parentSpanId), enriching event records that previously had parent_span_id: None for all spans. 
  This is a best-effort enrichment — failure falls back gracefully.                                                                                                                
  - **LangChainOtelSessionMapper — ADOT span type detection** fixed:                                                                                                                   
    - Inference spans: `role == "unknown"` with raw string content                                                                                                                   
    - Tool execution spans: `input_str` in parsed body (skips `tool_call_with_context` duplicates)                                                                                     
    - Agent invocation spans: `kwargs.name == "LangGraph"`                                                                                                                           
  - **Multi-agent AgentInvocationSpan dedup**:
    - In multi-agent LangGraph systems, each nested sub-graph produces its own LangGraph record. Only the last (root graph) is kept, matching 
  live/Traceloop behavior.                                                                                                                                                         
  - **Fixed leaking mutable state**: 
    - `_trace_tools_map` replaced with local `trace_tools` dict. Added per-call caches (_span_messages_cache, _adot_body_cache) reset each map_to_session() 
  call.                                                                                                                                                                            
  - **available_tools back-fill**: When llm.request.functions.* attributes are missing (ADOT path), builds ToolConfig from converted ToolExecutionSpans.                             
  - **Fixed AgentInvocationSpan creation**: if not user_query → if user_query is None (empty string is valid). _get_last_message_text() now skips tool messages and searches backward  
  for non-empty text.                                                                                                                                                              
  - **Fixed ADOT double-encoded empty strings:** Raw "" (2-char literal) decoded properly, empty assistant messages now return None instead of AssistantMessage(content=[]).           
  - **Extracted hard-coded strings** into module-level constants (_ATTR_*, _KIND_*, _ADOT_*).                                                                                          
  - **Cleanup:** Removed unused log_group parameter from _run_logs_insights_query, removed dead _ATTR_GEN_AI_PREFIX constant, fixed tool_status default from "" to None.

### Tested
  - `TestMapperAutoDetection` — verifies auto-detection for Strands, LangChain (OpenLLMetry), OpenInference scopes, explicit mapper override, and default None mapper
  - `TestScopePreservation` — verifies CloudWatchLogsParser preserves scope.name for LangChain (OpenLLMetry), OpenInference, Strands, spans with events, and synthetic spans
  - Existing `TestSpanConversion` and `TestSessionBuilding` updated to use pytest fixtures (deprecation warning compat)
  - **Tested and compared the mapped sessions using langchain/traceloop, and in_memory_exporter langchain/traceloop.**

## Related Issues

https://github.com/strands-agents/evals/issues/91

## Documentation PR

N/A

## Type of Change
Bug fix
Breaking change

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.