### PR TITLE
feat: add correctness evaluator, trace-based and reference-based

### DIFF
--- a/src/strands_evals/evaluators/__init__.py
+++ b/src/strands_evals/evaluators/__init__.py
@@ -1,5 +1,6 @@
 from .coherence_evaluator import CoherenceEvaluator
 from .conciseness_evaluator import ConcisenessEvaluator
+from .correctness_evaluator import CorrectnessEvaluator
 from .deterministic import Contains, Equals, StartsWith, StateEquals, ToolCalled
 from .evaluator import Evaluator
 from .faithfulness_evaluator import FaithfulnessEvaluator
@@ -21,6 +22,7 @@ __all__ = [
     "HelpfulnessEvaluator",
     "HarmfulnessEvaluator",
     "GoalSuccessRateEvaluator",
+    "CorrectnessEvaluator",
     "FaithfulnessEvaluator",
     "ResponseRelevanceEvaluator",
     "ToolSelectionAccuracyEvaluator",

--- a/src/strands_evals/evaluators/coherence_evaluator.py
+++ b/src/strands_evals/evaluators/coherence_evaluator.py
@@ -74,13 +74,6 @@ class CoherenceEvaluator(Evaluator[InputT, OutputT]):
         result = evaluator_agent(prompt, structured_output_model=CoherenceRating)
         return self._create_evaluation_output(result)
 
-    async def evaluate_async(self, evaluation_case: EvaluationData[InputT, OutputT]) -> list[EvaluationOutput]:
-        parsed_input = self._get_last_turn(evaluation_case)
-        prompt = self._format_prompt(parsed_input)
-        evaluator_agent = Agent(model=self.model, system_prompt=self.system_prompt, callback_handler=None)
-        result = await evaluator_agent.invoke_async(prompt, structured_output_model=CoherenceRating)
-        return self._create_evaluation_output(result)
-
     def _create_evaluation_output(self, result) -> list[EvaluationOutput]:
         rating = cast(CoherenceRating, result.structured_output)
         normalized_score = self._score_mapping[rating.score]
@@ -92,36 +85,6 @@ class CoherenceEvaluator(Evaluator[InputT, OutputT]):
                 label=rating.score,
             )
         ]
-
-    def _get_last_turn(self, evaluation_case: EvaluationData[InputT, OutputT]) -> TraceLevelInput:
-        """Extract the most recent turn from the conversation for evaluation."""
-        parsed_inputs = self._parse_trajectory(evaluation_case)
-        if not parsed_inputs:
-            raise ValueError(
-                "No turn-level inputs could be parsed from the trajectory. "
-                "Ensure actual_trajectory is a Session with at least one AgentInvocationSpan."
-            )
-        return parsed_inputs[-1]
-
-    def _extract_user_prompt(self, parsed_input: TraceLevelInput) -> str:
-        """Extract user prompt from last message in session history.
-
-        Args:
-            parsed_input: Trace-level input containing session history
-
-        Returns:
-            User prompt text, or empty string if not available
-        """
-        if not parsed_input.session_history:
-            return ""
-
-        last_msg = parsed_input.session_history[-1]
-        if not isinstance(last_msg, list) and self._has_text_content(last_msg):
-            first_content = last_msg.content[0]
-            if isinstance(first_content, TextContent):
-                return first_content.text
-
-        return ""
 
     def _format_prompt(self, parsed_input: TraceLevelInput) -> str:
         """Format evaluation prompt from parsed trace data.

--- a/src/strands_evals/evaluators/correctness_evaluator.py
+++ b/src/strands_evals/evaluators/correctness_evaluator.py
@@ -1,0 +1,164 @@
+from enum import Enum
+from typing import cast
+
+from pydantic import BaseModel, Field
+from strands import Agent
+from strands.models.model import Model
+from typing_extensions import Union
+
+from ..types.evaluation import EvaluationData, EvaluationOutput, InputT, OutputT
+from ..types.trace import EvaluationLevel, TraceLevelInput
+from .evaluator import Evaluator
+from .prompt_templates.correctness import get_reference_template, get_template
+
+
+class CorrectnessScore(str, Enum):
+    """Categorical correctness ratings."""
+
+    PERFECTLY_CORRECT = "Perfectly Correct"
+    PARTIALLY_CORRECT = "Partially Correct"
+    INCORRECT = "Incorrect"
+
+
+class CorrectnessRating(BaseModel):
+    """Structured output for correctness evaluation."""
+
+    reasoning: str = Field(
+        description="Step by step reasoning to derive the final answer, using no more than 250 words"
+    )
+    score: CorrectnessScore = Field(
+        description="Score should be one of 'Perfectly Correct', 'Partially Correct' or 'Incorrect'"
+    )
+
+
+class CorrectnessReferenceScore(str, Enum):
+    """Binary correctness ratings for reference-based evaluation."""
+
+    CORRECT = "CORRECT"
+    INCORRECT = "INCORRECT"
+
+
+class CorrectnessReferenceRating(BaseModel):
+    """Structured output for reference-based correctness evaluation."""
+
+    reasoning: str = Field(description="Explanation of the evaluation focusing on core information accuracy")
+    verdict: CorrectnessReferenceScore = Field(description="Verdict should be one of 'CORRECT' or 'INCORRECT'")
+
+
+class CorrectnessEvaluator(Evaluator[InputT, OutputT]):
+    """Evaluates the correctness of the assistant's response.
+
+    Supports two modes:
+    - **Basic mode**: Evaluates correctness based on the conversation context and the
+      assistant's response alone. Uses a 3-level scoring rubric
+      (Perfectly Correct=1.0, Partially Correct=0.5, Incorrect=0.0).
+    - **Reference mode**: When `expected_assertion` is provided on the evaluation case,
+      evaluates whether the agent's response is correct by comparing it to the reference.
+      Uses a binary CORRECT/INCORRECT scoring rubric (CORRECT=1.0, INCORRECT=0.0).
+    """
+
+    evaluation_level = EvaluationLevel.TRACE_LEVEL
+
+    _score_mapping = {
+        CorrectnessScore.PERFECTLY_CORRECT: 1.0,
+        CorrectnessScore.PARTIALLY_CORRECT: 0.5,
+        CorrectnessScore.INCORRECT: 0.0,
+    }
+
+    _reference_score_mapping = {
+        CorrectnessReferenceScore.CORRECT: 1.0,
+        CorrectnessReferenceScore.INCORRECT: 0.0,
+    }
+
+    def __init__(
+        self,
+        version: str = "v0",
+        model: Union[Model, str, None] = None,
+        system_prompt: str | None = None,
+        reference_system_prompt: str | None = None,
+    ):
+        super().__init__()
+        self.system_prompt = system_prompt if system_prompt is not None else get_template(version).SYSTEM_PROMPT
+        self.reference_system_prompt = (
+            reference_system_prompt
+            if reference_system_prompt is not None
+            else get_reference_template(version).SYSTEM_PROMPT
+        )
+        self.version = version
+        self.model = model
+
+    def _has_reference(self, evaluation_case: EvaluationData[InputT, OutputT]) -> bool:
+        """Check if the evaluation case contains an expected_assertion for reference-based evaluation."""
+        return bool(evaluation_case.expected_assertion)
+
+    def evaluate(self, evaluation_case: EvaluationData[InputT, OutputT]) -> list[EvaluationOutput]:
+        parsed_input = self._get_last_turn(evaluation_case)
+
+        if self._has_reference(evaluation_case):
+            return self._evaluate_with_reference(parsed_input, evaluation_case)
+
+        return self._evaluate_basic(parsed_input)
+
+    def _evaluate_basic(self, parsed_input: TraceLevelInput) -> list[EvaluationOutput]:
+        """Evaluate correctness using the basic 3-level prompt."""
+        prompt = self._format_prompt(parsed_input)
+        evaluator_agent = Agent(model=self.model, system_prompt=self.system_prompt, callback_handler=None)
+        result = evaluator_agent(prompt, structured_output_model=CorrectnessRating)
+        rating = cast(CorrectnessRating, result.structured_output)
+        normalized_score = self._score_mapping[rating.score]
+        return [
+            EvaluationOutput(
+                score=normalized_score,
+                test_pass=normalized_score >= 1.0,
+                reason=rating.reasoning,
+                label=rating.score,
+            )
+        ]
+
+    def _evaluate_with_reference(
+        self,
+        parsed_input: TraceLevelInput,
+        evaluation_case: EvaluationData[InputT, OutputT],
+    ) -> list[EvaluationOutput]:
+        """Evaluate correctness using reference-based prompt."""
+        prompt = self._format_reference_prompt(parsed_input, evaluation_case)
+        evaluator_agent = Agent(model=self.model, system_prompt=self.reference_system_prompt, callback_handler=None)
+        result = evaluator_agent(prompt, structured_output_model=CorrectnessReferenceRating)
+        rating = cast(CorrectnessReferenceRating, result.structured_output)
+        normalized_score = self._reference_score_mapping[rating.verdict]
+        return [
+            EvaluationOutput(
+                score=normalized_score,
+                test_pass=normalized_score >= 1.0,
+                reason=rating.reasoning,
+                label=rating.verdict,
+            )
+        ]
+
+    def _format_prompt(self, parsed_input: TraceLevelInput) -> str:
+        """Format evaluation prompt for basic correctness evaluation."""
+        parts = []
+
+        # Format conversation context
+        parts.append(f"Context: {self._format_trace_level_prompt(parsed_input)}")
+
+        # Format the candidate response (the assistant's last response)
+        parts.append(f"Candidate Response: {parsed_input.agent_response.text}")
+
+        return "\n\n".join(parts)
+
+    def _format_reference_prompt(
+        self,
+        parsed_input: TraceLevelInput,
+        evaluation_case: EvaluationData[InputT, OutputT],
+    ) -> str:
+        """Format evaluation prompt for reference-based correctness evaluation."""
+        # Extract user prompt from the last user message in session history
+        user_prompt = self._extract_user_prompt(parsed_input)
+
+        parts = []
+        parts.append(f"USER QUERY:\n{user_prompt}")
+        parts.append(f"AGENT RESPONSE:\n{parsed_input.agent_response.text}")
+        parts.append(f"EXPECTED RESPONSE:\n{evaluation_case.expected_assertion}")
+
+        return "\n\n".join(parts)

--- a/src/strands_evals/evaluators/evaluator.py
+++ b/src/strands_evals/evaluators/evaluator.py
@@ -127,6 +127,26 @@ class Evaluator(Generic[InputT, OutputT]):
             )
         return parsed_inputs[-1]
 
+    def _extract_user_prompt(self, parsed_input: TraceLevelInput) -> str:
+        """Extract user prompt from last message in session history.
+
+        Args:
+            parsed_input: Trace-level input containing session history
+
+        Returns:
+            User prompt text, or empty string if not available
+        """
+        if not parsed_input.session_history:
+            return ""
+
+        last_msg = parsed_input.session_history[-1]
+        if not isinstance(last_msg, list) and self._has_text_content(last_msg):
+            first_content = last_msg.content[0]
+            if isinstance(first_content, TextContent):
+                return first_content.text
+
+        return ""
+
     def _format_tools(self, tools: list[ToolConfig]) -> str:
         """Format available tools for prompt display."""
         return "\n".join([f"- {tool.name}: {tool.description or 'No description'}" for tool in tools])

--- a/src/strands_evals/evaluators/goal_success_rate_evaluator.py
+++ b/src/strands_evals/evaluators/goal_success_rate_evaluator.py
@@ -47,7 +47,7 @@ class GoalSuccessRateEvaluator(Evaluator[InputT, OutputT]):
     - **Basic mode**: Evaluates goal success based on conversation analysis alone.
       The judge LLM infers user goals from the conversation and checks whether they were met.
       Uses a Yes/No scoring rubric (Yes=1.0, No=0.0).
-    - **Assertion mode**: When ``expected_assertion`` is provided on the evaluation case,
+    - **Assertion mode**: When `expected_assertion` is provided on the evaluation case,
       evaluates whether the agent's behavior satisfies the specified success assertions —
       human-authored statements describing expected agent actions, responses, or behaviors.
       Unlike basic mode, assertion mode judges against explicit criteria defined upfront

--- a/src/strands_evals/evaluators/prompt_templates/correctness/__init__.py
+++ b/src/strands_evals/evaluators/prompt_templates/correctness/__init__.py
@@ -1,0 +1,19 @@
+from . import correctness_v0, correctness_with_reference_v0
+
+VERSIONS = {
+    "v0": correctness_v0,
+}
+
+REFERENCE_VERSIONS = {
+    "v0": correctness_with_reference_v0,
+}
+
+DEFAULT_VERSION = "v0"
+
+
+def get_template(version: str = DEFAULT_VERSION):
+    return VERSIONS[version]
+
+
+def get_reference_template(version: str = DEFAULT_VERSION):
+    return REFERENCE_VERSIONS[version]

--- a/src/strands_evals/evaluators/prompt_templates/correctness/correctness_v0.py
+++ b/src/strands_evals/evaluators/prompt_templates/correctness/correctness_v0.py
@@ -1,0 +1,5 @@
+SYSTEM_PROMPT = """You are evaluating the correctness of the Assistant's response. You are given a task and a candidate response. Is this a correct and accurate response to the task?
+
+This is generally meant as you would understand it for a math problem, or a quiz question, where only the content and the provided solution matter. Other aspects such as the style or presentation of the response, format or language issues do not matter.
+
+**IMPORTANT**: The tool output ALWAYS takes priority over your own knowledge."""

--- a/src/strands_evals/evaluators/prompt_templates/correctness/correctness_with_reference_v0.py
+++ b/src/strands_evals/evaluators/prompt_templates/correctness/correctness_with_reference_v0.py
@@ -1,0 +1,26 @@
+SYSTEM_PROMPT = """You are an evaluator assessing whether an agent's response correctly addresses a user query.
+
+You will be provided with:
+1. The user query.
+2. The agent's response.
+3. The expected (reference) response.
+
+TASK:
+Determine if the agent response is CORRECT by comparing it to the expected response.
+
+EVALUATION RULES:
+
+1. CORRECT means the agent response conveys the same core factual content as the expected response, even if it uses different wording, format, or level of detail.
+
+2. INCORRECT means the agent response contains critical factual errors, fundamentally contradicts the expected response, or is too vague/incomplete to meaningfully answer the query.
+
+SPECIFIC GUIDANCE:
+
+- Different wording, structure, additional context, extra detail, or alternative examples are acceptable as long as the core answer is accurate.
+- Omitting minor supplementary details is acceptable if the main answer is correct.
+- For open-ended queries (recommendations, plans, creative content), the agent may provide different but equally valid alternatives. Judge whether the response addresses the user's underlying need, not whether it lists the exact same items.
+- For factual queries with a single correct answer, the agent must provide the correct specific values (names, numbers, dates, locations).
+- A response that is vague or generic and lacks the key specific facts from the expected response is INCORRECT, even if nothing stated is technically wrong.
+- Do not fabricate reasons to reject a response. Only mark INCORRECT for clear, substantive errors or critical missing information — not for stylistic differences or minor variations.
+
+IMPORTANT: Keep your reasoning concise - use no more than 200 words to explain your evaluation."""

--- a/tests/strands_evals/evaluators/test_coherence_evaluator.py
+++ b/tests/strands_evals/evaluators/test_coherence_evaluator.py
@@ -101,31 +101,6 @@ def test_score_mapping(mock_agent_class, evaluation_data, score, expected_value,
     assert result[0].label == score
 
 
-@pytest.mark.asyncio
-@patch("strands_evals.evaluators.coherence_evaluator.Agent")
-async def test_evaluate_async(mock_agent_class, evaluation_data):
-    mock_agent = Mock()
-
-    async def mock_invoke_async(*args, **kwargs):
-        mock_result = Mock()
-        mock_result.structured_output = CoherenceRating(
-            reasoning="The response is logically coherent with no contradictions", score=CoherenceScore.COMPLETELY_YES
-        )
-        return mock_result
-
-    mock_agent.invoke_async = mock_invoke_async
-    mock_agent_class.return_value = mock_agent
-    evaluator = CoherenceEvaluator()
-
-    result = await evaluator.evaluate_async(evaluation_data)
-
-    assert len(result) == 1
-    assert result[0].score == 1.0
-    assert result[0].test_pass is True
-    assert result[0].reason == "The response is logically coherent with no contradictions"
-    assert result[0].label == CoherenceScore.COMPLETELY_YES
-
-
 def test_coherence_score_enum_values():
     """Test that CoherenceScore enum has all expected values."""
     assert CoherenceScore.NOT_AT_ALL.value == "Not At All"

--- a/tests/strands_evals/evaluators/test_correctness_evaluator.py
+++ b/tests/strands_evals/evaluators/test_correctness_evaluator.py
@@ -1,0 +1,211 @@
+from datetime import datetime
+from unittest.mock import Mock, patch
+
+import pytest
+
+from strands_evals.evaluators import CorrectnessEvaluator
+from strands_evals.evaluators.correctness_evaluator import (
+    CorrectnessRating,
+    CorrectnessReferenceRating,
+    CorrectnessReferenceScore,
+    CorrectnessScore,
+)
+from strands_evals.types import EvaluationData
+from strands_evals.types.trace import (
+    AgentInvocationSpan,
+    EvaluationLevel,
+    Session,
+    SpanInfo,
+    ToolCall,
+    ToolConfig,
+    ToolExecutionSpan,
+    ToolResult,
+    Trace,
+)
+
+
+@pytest.fixture
+def evaluation_data():
+    now = datetime.now()
+    span_info = SpanInfo(session_id="test-session", start_time=now, end_time=now)
+
+    tool_config = ToolConfig(name="calculator", description="Evaluate mathematical expressions")
+
+    agent_span = AgentInvocationSpan(
+        span_info=span_info,
+        user_prompt="What is 2 + 2?",
+        agent_response="The answer is 4.",
+        available_tools=[tool_config],
+    )
+
+    tool_span = ToolExecutionSpan(
+        span_info=span_info,
+        tool_call=ToolCall(name="calculator", arguments={"expression": "2+2"}, tool_call_id="1"),
+        tool_result=ToolResult(content="4", tool_call_id="1"),
+    )
+
+    trace = Trace(spans=[agent_span, tool_span], trace_id="trace1", session_id="test-session")
+    session = Session(traces=[trace], session_id="test-session")
+
+    return EvaluationData(
+        input="What is 2 + 2?",
+        actual_output="The answer is 4.",
+        actual_trajectory=session,
+        name="test",
+    )
+
+
+@pytest.fixture
+def evaluation_data_with_reference():
+    now = datetime.now()
+    span_info = SpanInfo(session_id="test-session", start_time=now, end_time=now)
+
+    tool_config = ToolConfig(name="calculator", description="Evaluate mathematical expressions")
+
+    agent_span = AgentInvocationSpan(
+        span_info=span_info,
+        user_prompt="What is 2 + 2?",
+        agent_response="The answer is 4.",
+        available_tools=[tool_config],
+    )
+
+    tool_span = ToolExecutionSpan(
+        span_info=span_info,
+        tool_call=ToolCall(name="calculator", arguments={"expression": "2+2"}, tool_call_id="1"),
+        tool_result=ToolResult(content="4", tool_call_id="1"),
+    )
+
+    trace = Trace(spans=[agent_span, tool_span], trace_id="trace1", session_id="test-session")
+    session = Session(traces=[trace], session_id="test-session")
+
+    return EvaluationData(
+        input="What is 2 + 2?",
+        actual_output="The answer is 4.",
+        expected_assertion="The agent should return the correct answer of 4.",
+        actual_trajectory=session,
+        name="test-reference",
+    )
+
+
+def test_init_with_defaults():
+    evaluator = CorrectnessEvaluator()
+
+    assert evaluator.version == "v0"
+    assert evaluator.model is None
+    assert evaluator.system_prompt is not None
+    assert evaluator.reference_system_prompt is not None
+    assert evaluator.system_prompt != evaluator.reference_system_prompt
+    assert evaluator.evaluation_level == EvaluationLevel.TRACE_LEVEL
+
+
+def test_init_with_custom_values():
+    evaluator = CorrectnessEvaluator(
+        version="v0", model="gpt-4", system_prompt="Custom", reference_system_prompt="Custom reference"
+    )
+
+    assert evaluator.version == "v0"
+    assert evaluator.model == "gpt-4"
+    assert evaluator.system_prompt == "Custom"
+    assert evaluator.reference_system_prompt == "Custom reference"
+
+
+def test_has_reference_true(evaluation_data_with_reference):
+    evaluator = CorrectnessEvaluator()
+    assert evaluator._has_reference(evaluation_data_with_reference) is True
+
+
+def test_has_reference_false(evaluation_data):
+    evaluator = CorrectnessEvaluator()
+    assert evaluator._has_reference(evaluation_data) is False
+
+
+@patch("strands_evals.evaluators.correctness_evaluator.Agent")
+def test_evaluate(mock_agent_class, evaluation_data):
+    mock_agent = Mock()
+    mock_result = Mock()
+    mock_result.structured_output = CorrectnessRating(
+        reasoning="The response correctly states 2+2=4", score=CorrectnessScore.PERFECTLY_CORRECT
+    )
+    mock_agent.return_value = mock_result
+    mock_agent_class.return_value = mock_agent
+    evaluator = CorrectnessEvaluator()
+
+    result = evaluator.evaluate(evaluation_data)
+
+    assert len(result) == 1
+    assert result[0].score == 1.0
+    assert result[0].test_pass is True
+    assert result[0].reason == "The response correctly states 2+2=4"
+    assert result[0].label == CorrectnessScore.PERFECTLY_CORRECT
+
+
+@pytest.mark.parametrize(
+    "score,expected_value,expected_pass",
+    [
+        (CorrectnessScore.PERFECTLY_CORRECT, 1.0, True),
+        (CorrectnessScore.PARTIALLY_CORRECT, 0.5, False),
+        (CorrectnessScore.INCORRECT, 0.0, False),
+    ],
+)
+@patch("strands_evals.evaluators.correctness_evaluator.Agent")
+def test_score_mapping(mock_agent_class, evaluation_data, score, expected_value, expected_pass):
+    mock_agent = Mock()
+    mock_result = Mock()
+    mock_result.structured_output = CorrectnessRating(reasoning="Test", score=score)
+    mock_agent.return_value = mock_result
+    mock_agent_class.return_value = mock_agent
+    evaluator = CorrectnessEvaluator()
+
+    result = evaluator.evaluate(evaluation_data)
+
+    assert len(result) == 1
+    assert result[0].score == expected_value
+    assert result[0].test_pass == expected_pass
+    assert result[0].label == score
+
+
+@patch("strands_evals.evaluators.correctness_evaluator.Agent")
+def test_evaluate_with_reference(mock_agent_class, evaluation_data_with_reference):
+    mock_agent = Mock()
+    mock_result = Mock()
+    mock_result.structured_output = CorrectnessReferenceRating(
+        reasoning="The agent response matches the expected answer of 4",
+        verdict=CorrectnessReferenceScore.CORRECT,
+    )
+    mock_agent.return_value = mock_result
+    mock_agent_class.return_value = mock_agent
+    evaluator = CorrectnessEvaluator()
+
+    result = evaluator.evaluate(evaluation_data_with_reference)
+
+    assert len(result) == 1
+    assert result[0].score == 1.0
+    assert result[0].test_pass is True
+    assert result[0].reason == "The agent response matches the expected answer of 4"
+    assert result[0].label == CorrectnessReferenceScore.CORRECT
+
+
+@pytest.mark.parametrize(
+    "verdict,expected_value,expected_pass",
+    [
+        (CorrectnessReferenceScore.CORRECT, 1.0, True),
+        (CorrectnessReferenceScore.INCORRECT, 0.0, False),
+    ],
+)
+@patch("strands_evals.evaluators.correctness_evaluator.Agent")
+def test_reference_score_mapping(
+    mock_agent_class, evaluation_data_with_reference, verdict, expected_value, expected_pass
+):
+    mock_agent = Mock()
+    mock_result = Mock()
+    mock_result.structured_output = CorrectnessReferenceRating(reasoning="Test", verdict=verdict)
+    mock_agent.return_value = mock_result
+    mock_agent_class.return_value = mock_agent
+    evaluator = CorrectnessEvaluator()
+
+    result = evaluator.evaluate(evaluation_data_with_reference)
+
+    assert len(result) == 1
+    assert result[0].score == expected_value
+    assert result[0].test_pass == expected_pass
+    assert result[0].label == verdict


### PR DESCRIPTION
## Description
Add correctness evaluator, supporting both trace-based and reference-based evaluation

## Related Issues

#95 

## Documentation PR

https://github.com/strands-agents/docs/pull/714

## Type of Change

New feature

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.