### PR TITLE
ci: add weekly markdown link check workflow

### DIFF
--- a/.github/workflows/check-markdown-links.yml
+++ b/.github/workflows/check-markdown-links.yml
@@ -7,45 +7,4 @@ on:
 
 jobs:
   check-links:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: gaurav-nelson/github-action-markdown-link-check@3c3b66f1f7d0900e37b71eca45b63ea9eedfce31 # v1.0.17
-        id: link-check
-        with:
-          use-quiet-mode: 'yes'
-          use-verbose-mode: 'yes'
-          config-file: '.markdown-link-check.json'
-        continue-on-error: true
-
-      - name: Create issue if links are broken
-        if: steps.link-check.outcome == 'failure'
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const title = '🔗 Broken markdown links detected';
-            const label = 'broken-links';
-
-            // Check for existing open issue to avoid duplicates
-            const existing = await github.rest.issues.listForRepo({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              state: 'open',
-              labels: label,
-            });
-
-            if (existing.data.length > 0) {
-              console.log(`Issue already exists: #${existing.data[0].number}`);
-              return;
-            }
-
-            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
-
-            await github.rest.issues.create({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              title,
-              body: `The weekly markdown link check found broken links.\n\nSee the [workflow run](${runUrl}) for details.`,
-              labels: [label],
-            });
+    uses: strands-agents/devtools/.github/workflows/check-markdown-links.yml@main

--- a/.github/workflows/check-markdown-links.yml
+++ b/.github/workflows/check-markdown-links.yml
@@ -1,0 +1,51 @@
+name: Check Markdown Links
+
+on:
+  schedule:
+    - cron: '0 9 * * 1' # Every Monday at 9am UTC
+  workflow_dispatch: # Allow manual trigger
+
+jobs:
+  check-links:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: gaurav-nelson/github-action-markdown-link-check@3c3b66f1f7d0900e37b71eca45b63ea9eedfce31 # v1.0.17
+        id: link-check
+        with:
+          use-quiet-mode: 'yes'
+          use-verbose-mode: 'yes'
+          config-file: '.markdown-link-check.json'
+        continue-on-error: true
+
+      - name: Create issue if links are broken
+        if: steps.link-check.outcome == 'failure'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const title = '🔗 Broken markdown links detected';
+            const label = 'broken-links';
+
+            // Check for existing open issue to avoid duplicates
+            const existing = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: label,
+            });
+
+            if (existing.data.length > 0) {
+              console.log(`Issue already exists: #${existing.data[0].number}`);
+              return;
+            }
+
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title,
+              body: `The weekly markdown link check found broken links.\n\nSee the [workflow run](${runUrl}) for details.`,
+              labels: [label],
+            });

--- a/.markdown-link-check.json
+++ b/.markdown-link-check.json
@@ -1,0 +1,6 @@
+{
+  "retryOn429": true,
+  "retryCount": 3,
+  "fallbackRetryDelay": "30s",
+  "aliveStatusCodes": [200, 206]
+}

--- a/.markdown-link-check.json
+++ b/.markdown-link-check.json
@@ -1,6 +1,0 @@
-{
-  "retryOn429": true,
-  "retryCount": 3,
-  "fallbackRetryDelay": "30s",
-  "aliveStatusCodes": [200, 206]
-}


### PR DESCRIPTION
## Description

Adds a weekly markdown link check workflow that runs every Monday at 9am UTC. If broken links are found, it automatically creates a GitHub issue.

This is the same workflow from [sdk-python#2088](https://github.com/strands-agents/sdk-python/pull/2088), applied to this repo.

## Related Issues

https://github.com/strands-agents/sdk-python/issues/1905

## Type of Change

CI

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.