### PR TITLE
feat: add OpenSearchProvider and OpenSearchSessionMapper

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ dev = [
 ]
 
 langfuse = ["langfuse>=2.0.0,<4"]
+opensearch = ["opensearch-genai-observability-sdk-py[opensearch]>=0.2.7"]
 otel = ["opentelemetry-exporter-otlp-proto-http>=1.30.0,<2.0.0"]
 langchain = [
     "langchain>=0.3.0",
@@ -61,7 +62,7 @@ include = ["src/**/*.py", "tests/**/*.py", "tests_integ/**/*.py"]
 [tool.hatch.envs.hatch-test]
 installer = "uv"
 extra-args = ["-n", "auto", "-vv"]
-features = ["otel", "langfuse", "langchain"]
+features = ["otel", "langfuse", "langchain", "opensearch"]
 dependencies = [
     "pytest>=8.0.0,<10.0.0",
     "pytest-cov>=7.0.0,<8.0.0",
@@ -102,7 +103,7 @@ prepare = [
 
 [tool.hatch.envs.hatch-static-analysis]
 installer = "uv"
-features = ["otel", "langfuse"]
+features = ["otel", "langfuse", "langchain", "opensearch"]
 dependencies = [
   "mypy>=1.15.0,<2.0.0",
   "ruff>=0.13.0,<0.15.0",
@@ -148,6 +149,10 @@ disable_error_code = [
 ]
 # Allow untyped decorators (helps with @property in Generic classes)
 disallow_untyped_decorators = false
+
+[[tool.mypy.overrides]]
+module = "opensearch_genai_observability_sdk_py.*"
+ignore_missing_imports = true
 
 [tool.hatch.version]
 source = "vcs"  # Use git tags for versioning

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ dev = [
 ]
 
 langfuse = ["langfuse>=2.0.0,<4"]
-opensearch = ["opensearch-genai-observability-sdk-py[opensearch]>=0.2.7"]
+opensearch = ["opensearch-genai-observability-sdk-py[opensearch]>=0.2.7,<1.0.0"]
 otel = ["opentelemetry-exporter-otlp-proto-http>=1.30.0,<2.0.0"]
 langchain = [
     "langchain>=0.3.0",

--- a/src/strands_evals/mappers/__init__.py
+++ b/src/strands_evals/mappers/__init__.py
@@ -4,6 +4,7 @@ from .cloudwatch_parser import CloudWatchLogsParser, parse_cloudwatch_logs
 from .cloudwatch_session_mapper import CloudWatchSessionMapper
 from .langchain_otel_session_mapper import LangChainOtelSessionMapper
 from .openinference_session_mapper import OpenInferenceSessionMapper
+from .opensearch_session_mapper import OpenSearchSessionMapper
 from .session_mapper import SessionMapper
 from .strands_in_memory_session_mapper import GenAIConventionVersion, StrandsInMemorySessionMapper
 from .utils import detect_otel_mapper, get_scope_name, readable_spans_to_dicts
@@ -14,6 +15,7 @@ __all__ = [
     "GenAIConventionVersion",
     "LangChainOtelSessionMapper",
     "OpenInferenceSessionMapper",
+    "OpenSearchSessionMapper",
     "SessionMapper",
     "StrandsInMemorySessionMapper",
     "detect_otel_mapper",

--- a/src/strands_evals/mappers/opensearch_session_mapper.py
+++ b/src/strands_evals/mappers/opensearch_session_mapper.py
@@ -1,0 +1,151 @@
+"""OpenSearch session mapper — converts genai-sdk SpanRecords to Session format."""
+
+import json
+import logging
+from collections import defaultdict
+from datetime import datetime, timezone
+from typing import Any
+
+from strands_evals.mappers.session_mapper import SessionMapper
+from strands_evals.types.trace import (
+    AgentInvocationSpan,
+    AssistantMessage,
+    InferenceSpan,
+    Session,
+    SpanInfo,
+    TextContent,
+    ToolCall,
+    ToolConfig,
+    ToolExecutionSpan,
+    ToolResult,
+    ToolResultContent,
+    Trace,
+    UserMessage,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class OpenSearchSessionMapper(SessionMapper):
+    """Maps genai-sdk SpanRecords (from OpenSearch) to strands-evals Session format."""
+
+    def map_to_session(self, span_records: list[Any], session_id: str) -> Session:
+        """Group SpanRecords by trace_id, convert each group to a Trace."""
+        traces_by_id: dict[str, list[Any]] = defaultdict(list)
+        for record in span_records:
+            if record.trace_id:
+                traces_by_id[record.trace_id].append(record)
+
+        traces = []
+        for trace_id, records in traces_by_id.items():
+            trace = self._convert_trace(trace_id, records, session_id)
+            if trace.spans:
+                traces.append(trace)
+
+        return Session(session_id=session_id, traces=traces)
+
+    def _convert_trace(self, trace_id: str, records: list[Any], session_id: str) -> Trace:
+        """Convert SpanRecords sharing a trace_id into a Trace with typed spans."""
+        sorted_records = sorted(records, key=lambda r: r.start_time or "")
+        spans = []
+
+        for record in sorted_records:
+            span_info = self._make_span_info(record, session_id)
+
+            if record.operation_name == "chat":
+                messages = self._build_messages(record)
+                if messages:
+                    spans.append(InferenceSpan(span_info=span_info, messages=messages, metadata={}))
+
+            elif record.operation_name == "execute_tool":
+                arguments = self._parse_json(record.tool_call_arguments)
+                tool_call = ToolCall(
+                    name=record.tool_name,
+                    arguments=arguments if isinstance(arguments, dict) else {},
+                    tool_call_id=record.span_id,
+                )
+                tool_result = ToolResult(
+                    content=record.tool_call_result or "",
+                    tool_call_id=record.span_id,
+                )
+                spans.append(ToolExecutionSpan(
+                    span_info=span_info, tool_call=tool_call, tool_result=tool_result, metadata={}
+                ))
+
+            elif record.operation_name == "invoke_agent":
+                user_prompt = self._first_message_by_role(record.input_messages, "user")
+                agent_response = self._last_message_by_role(record.output_messages, "assistant")
+                if user_prompt or agent_response:
+                    # Collect tool names only from direct child spans
+                    tool_names = sorted({
+                        r.tool_name for r in sorted_records
+                        if r.operation_name == "execute_tool" and r.tool_name
+                        and r.parent_span_id == record.span_id
+                    })
+                    spans.append(AgentInvocationSpan(
+                        span_info=span_info,
+                        user_prompt=user_prompt or "",
+                        agent_response=agent_response or "",
+                        available_tools=[ToolConfig(name=n) for n in tool_names],
+                        metadata={},
+                    ))
+
+        return Trace(spans=spans, trace_id=trace_id, session_id=session_id)
+
+    @staticmethod
+    def _make_span_info(record: Any, session_id: str) -> SpanInfo:
+        return SpanInfo(
+            trace_id=record.trace_id,
+            span_id=record.span_id,
+            session_id=session_id,
+            parent_span_id=record.parent_span_id or None,
+            start_time=_parse_time(record.start_time),
+            end_time=_parse_time(record.end_time),
+        )
+
+    @staticmethod
+    def _build_messages(record: Any) -> list[UserMessage | AssistantMessage]:
+        messages = []
+        for msg in record.input_messages:
+            if msg.role == "user":
+                messages.append(UserMessage(content=[TextContent(text=msg.content)]))
+            elif msg.role == "tool":
+                messages.append(UserMessage(content=[ToolResultContent(content=msg.content, tool_call_id=None)]))
+        for msg in record.output_messages:
+            if msg.role == "assistant":
+                messages.append(AssistantMessage(content=[TextContent(text=msg.content)]))
+        return messages
+
+    @staticmethod
+    def _first_message_by_role(messages: list, role: str) -> str | None:
+        for msg in messages:
+            if msg.role == role and msg.content:
+                return msg.content
+        return None
+
+    @staticmethod
+    def _last_message_by_role(messages: list, role: str) -> str | None:
+        for msg in reversed(messages):
+            if msg.role == role and msg.content:
+                return msg.content
+        return None
+
+    @staticmethod
+    def _parse_json(value: str) -> dict | str:
+        if not value:
+            return {}
+        try:
+            return json.loads(value)
+        except (json.JSONDecodeError, TypeError):
+            return value
+
+
+def _parse_time(value: str) -> datetime:
+    """Parse ISO timestamp string to datetime, defaulting to epoch on failure."""
+    if not value:
+        return datetime.fromtimestamp(0, tz=timezone.utc)
+    try:
+        dt = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        return dt if dt.tzinfo else dt.replace(tzinfo=timezone.utc)
+    except (ValueError, AttributeError):
+        return datetime.fromtimestamp(0, tz=timezone.utc)

--- a/src/strands_evals/providers/README.md
+++ b/src/strands_evals/providers/README.md
@@ -8,6 +8,7 @@ Trace providers fetch agent execution data from observability backends and conve
 |----------|---------|------|
 | `CloudWatchProvider` | AWS CloudWatch Logs (Bedrock AgentCore runtime logs) | AWS credentials (boto3) |
 | `LangfuseProvider` | Langfuse | API keys |
+| `OpenSearchProvider` | OpenSearch (via Data Prepper) | Basic auth, SigV4, or none |
 
 ## Quick Start
 
@@ -39,6 +40,30 @@ provider = LangfuseProvider(
     public_key="pk-...",
     secret_key="sk-...",
     host="https://us.cloud.langfuse.com",
+)
+```
+
+### OpenSearch
+
+```python
+from strands_evals.providers import OpenSearchProvider
+
+# Local / development (basic auth)
+provider = OpenSearchProvider(
+    host="https://localhost:9200",
+    auth=("admin", "password"),
+    verify_certs=False,
+)
+
+# Amazon OpenSearch Service (SigV4)
+from opensearchpy import RequestsAWSV4SignerAuth
+import boto3
+
+credentials = boto3.Session().get_credentials()
+auth = RequestsAWSV4SignerAuth(credentials, "us-east-1", "es")
+provider = OpenSearchProvider(
+    host="https://my-domain.us-east-1.es.amazonaws.com",
+    auth=auth,
 )
 ```
 

--- a/src/strands_evals/providers/__init__.py
+++ b/src/strands_evals/providers/__init__.py
@@ -12,6 +12,7 @@ from .trace_provider import (
 __all__ = [
     "CloudWatchProvider",
     "LangfuseProvider",
+    "OpenSearchProvider",
     "ProviderError",
     "SessionNotFoundError",
     "TraceProvider",
@@ -29,4 +30,8 @@ def __getattr__(name: str) -> Any:
         from .langfuse_provider import LangfuseProvider
 
         return LangfuseProvider
+    if name == "OpenSearchProvider":
+        from .opensearch_provider import OpenSearchProvider
+
+        return OpenSearchProvider
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/strands_evals/providers/opensearch_provider.py
+++ b/src/strands_evals/providers/opensearch_provider.py
@@ -1,0 +1,104 @@
+"""OpenSearch trace provider for retrieving agent evaluation data.
+
+Requires the opensearch extra:
+    pip install strands-agents-evals[opensearch]
+"""
+
+import logging
+from typing import Any
+
+from strands_evals.mappers.opensearch_session_mapper import OpenSearchSessionMapper
+from strands_evals.providers.exceptions import ProviderError, SessionNotFoundError
+from strands_evals.providers.trace_provider import TraceProvider
+from strands_evals.types.evaluation import TaskOutput
+from strands_evals.types.trace import AgentInvocationSpan
+
+logger = logging.getLogger(__name__)
+
+
+class OpenSearchProvider(TraceProvider):
+    """Retrieves agent traces from OpenSearch via genai-observability-sdk-py.
+
+    Wraps OpenSearchTraceRetriever to query spans by session (conversation)
+    ID or trace ID and returns Session objects for the evaluation pipeline.
+
+    Example::
+
+        from strands_evals.providers import OpenSearchProvider
+
+        # Basic auth (local / development)
+        provider = OpenSearchProvider(
+            host="https://localhost:9200",
+            auth=("admin", "password"),
+            verify_certs=False,
+        )
+
+        # SigV4 auth (Amazon OpenSearch Service)
+        from opensearchpy import RequestsAWSV4SignerAuth
+        import boto3
+        credentials = boto3.Session().get_credentials()
+        auth = RequestsAWSV4SignerAuth(credentials, "us-east-1", "es")
+        provider = OpenSearchProvider(
+            host="https://my-domain.us-east-1.es.amazonaws.com",
+            auth=auth,
+        )
+    """
+
+    def __init__(
+        self,
+        host: str = "https://localhost:9200",
+        index: str = "otel-v1-apm-span-*",
+        auth: Any = None,
+        verify_certs: bool = True,
+    ):
+        """Initialize the OpenSearch provider.
+
+        Args:
+            host: OpenSearch endpoint URL.
+            index: Index pattern for span documents.
+            auth: Authentication credentials. Accepts a (username, password) tuple
+                for basic auth, a RequestsAWSV4SignerAuth instance for SigV4, or None.
+            verify_certs: Whether to verify TLS certificates.
+
+        Raises:
+            ImportError: If opensearch-genai-observability-sdk-py is not installed.
+        """
+        try:
+            from opensearch_genai_observability_sdk_py import OpenSearchTraceRetriever
+        except ImportError:
+            raise ImportError(
+                "opensearch-genai-observability-sdk-py is required. "
+                "Install with: pip install strands-agents-evals[opensearch]"
+            ) from None
+
+        self._retriever = OpenSearchTraceRetriever(
+            host=host, index=index, auth=auth, verify_certs=verify_certs
+        )
+        self._mapper = OpenSearchSessionMapper()
+
+    def get_evaluation_data(self, session_id: str) -> TaskOutput:
+        """Retrieve traces for a session and return evaluation data."""
+        try:
+            session_record = self._retriever.get_traces(session_id)
+        except ProviderError:
+            raise
+        except Exception as e:
+            raise ProviderError(f"Failed to query OpenSearch: {e}") from e
+
+        if not session_record.traces:
+            raise SessionNotFoundError(f"No traces found for session: {session_id}")
+
+        span_records = [span for trace in session_record.traces for span in trace.spans]
+        session = self._mapper.map_to_session(span_records, session_id)
+        output = self._extract_output(session)
+
+        return TaskOutput(output=output, trajectory=session)
+
+    @staticmethod
+    def _extract_output(session):
+        """Extract final agent response from the last AgentInvocationSpan."""
+        for trace in reversed(session.traces):
+            for span in reversed(trace.spans):
+                if isinstance(span, AgentInvocationSpan) and span.agent_response:
+                    return span.agent_response
+        return ""

--- a/tests/strands_evals/mappers/test_opensearch_session_mapper.py
+++ b/tests/strands_evals/mappers/test_opensearch_session_mapper.py
@@ -1,0 +1,380 @@
+"""Tests for OpenSearchSessionMapper."""
+
+from strands_evals.mappers.opensearch_session_mapper import OpenSearchSessionMapper
+from strands_evals.types.trace import AgentInvocationSpan, InferenceSpan, ToolExecutionSpan
+from tests.strands_evals.opensearch_helpers import (
+    Message,
+    SpanRecord,
+    make_agent_span,
+    make_chat_span,
+    make_tool_span,
+)
+
+
+class TestSpanConversion:
+    def setup_method(self):
+        self.mapper = OpenSearchSessionMapper()
+
+    def test_invoke_agent_span_creates_agent_invocation(self):
+        """invoke_agent operation maps to AgentInvocationSpan with prompt and response."""
+        records = [make_agent_span(user_prompt="What's the weather?", agent_response="It's sunny.")]
+        session = self.mapper.map_to_session(records, "sess-1")
+
+        assert len(session.traces) == 1
+        assert len(session.traces[0].spans) == 1
+        span = session.traces[0].spans[0]
+        assert isinstance(span, AgentInvocationSpan)
+        assert span.user_prompt == "What's the weather?"
+        assert span.agent_response == "It's sunny."
+
+    def test_chat_span_creates_inference_span(self):
+        """chat operation maps to InferenceSpan with user and assistant messages."""
+        records = [make_chat_span(user_input="Hello", assistant_output="Hi")]
+        session = self.mapper.map_to_session(records, "sess-1")
+
+        span = session.traces[0].spans[0]
+        assert isinstance(span, InferenceSpan)
+        assert len(span.messages) == 2  # user + assistant
+
+    def test_execute_tool_span_creates_tool_execution(self):
+        """execute_tool operation maps to ToolExecutionSpan with call and result."""
+        records = [make_tool_span(tool_name="get_weather", arguments='{"city":"Paris"}', result="Sunny")]
+        session = self.mapper.map_to_session(records, "sess-1")
+
+        span = session.traces[0].spans[0]
+        assert isinstance(span, ToolExecutionSpan)
+        assert span.tool_call.name == "get_weather"
+        assert span.tool_call.arguments == {"city": "Paris"}
+        assert span.tool_result.content == "Sunny"
+
+    def test_tool_call_arguments_invalid_json_kept_as_empty_dict(self):
+        """Non-JSON tool arguments fall back to empty dict (ToolCall.arguments requires dict)."""
+        records = [make_tool_span(arguments="not json")]
+        session = self.mapper.map_to_session(records, "sess-1")
+
+        span = session.traces[0].spans[0]
+        assert span.tool_call.arguments == {}
+
+    def test_chat_span_without_messages_is_skipped(self):
+        """chat spans with no input/output messages produce no InferenceSpan."""
+        records = [SpanRecord(
+            trace_id="t1", span_id="s1", operation_name="chat",
+            start_time="2026-01-01T00:00:00Z", end_time="2026-01-01T00:00:01Z",
+        )]
+        session = self.mapper.map_to_session(records, "sess-1")
+
+        # Trace with no typed spans is filtered out entirely
+        assert len(session.traces) == 0
+
+    def test_invoke_agent_without_messages_is_skipped(self):
+        """invoke_agent spans with no prompt or response produce no span."""
+        records = [SpanRecord(
+            trace_id="t1", span_id="s1", operation_name="invoke_agent",
+            start_time="2026-01-01T00:00:00Z", end_time="2026-01-01T00:00:01Z",
+        )]
+        session = self.mapper.map_to_session(records, "sess-1")
+
+        assert len(session.traces) == 0
+
+    def test_chat_span_with_tool_role_message(self):
+        """Tool-role messages in chat spans map to UserMessage with ToolResultContent."""
+        records = [SpanRecord(
+            trace_id="t1", span_id="s1", operation_name="chat",
+            start_time="2026-01-01T00:00:00Z", end_time="2026-01-01T00:00:01Z",
+            input_messages=[Message(role="tool", content="tool output here")],
+            output_messages=[Message(role="assistant", content="Got it")],
+        )]
+        session = self.mapper.map_to_session(records, "sess-1")
+
+        span = session.traces[0].spans[0]
+        assert isinstance(span, InferenceSpan)
+        assert len(span.messages) == 2
+
+
+class TestSessionBuilding:
+    def setup_method(self):
+        self.mapper = OpenSearchSessionMapper()
+
+    def test_empty_records_returns_empty_session(self):
+        session = self.mapper.map_to_session([], "sess-1")
+        assert session.session_id == "sess-1"
+        assert len(session.traces) == 0
+
+    def test_records_grouped_by_trace_id(self):
+        """Records with different trace_ids produce separate Traces."""
+        records = [
+            make_agent_span(trace_id="t1", span_id="s1"),
+            make_agent_span(trace_id="t2", span_id="s2"),
+        ]
+        session = self.mapper.map_to_session(records, "sess-1")
+
+        assert len(session.traces) == 2
+        trace_ids = {t.trace_id for t in session.traces}
+        assert trace_ids == {"t1", "t2"}
+
+    def test_spans_sorted_by_start_time(self):
+        """Spans within a trace are ordered by start_time."""
+        records = [
+            make_tool_span(span_id="late", start_time="2026-01-01T00:00:02Z"),
+            make_tool_span(span_id="early", start_time="2026-01-01T00:00:01Z"),
+        ]
+        session = self.mapper.map_to_session(records, "sess-1")
+
+        spans = session.traces[0].spans
+        assert spans[0].span_info.span_id == "early"
+        assert spans[1].span_info.span_id == "late"
+
+    def test_full_trace_with_all_span_types(self):
+        """A realistic trace with agent, chat, and tool spans produces all three types."""
+        records = [
+            make_agent_span(span_id="agent-1", start_time="2026-01-01T00:00:00Z"),
+            make_chat_span(span_id="chat-1", parent_span_id="agent-1", start_time="2026-01-01T00:00:00.1Z"),
+            make_tool_span(span_id="tool-1", parent_span_id="agent-1", start_time="2026-01-01T00:00:00.5Z"),
+        ]
+        session = self.mapper.map_to_session(records, "sess-1")
+
+        spans = session.traces[0].spans
+        assert len(spans) == 3
+        types = {type(s).__name__ for s in spans}
+        assert types == {"InferenceSpan", "ToolExecutionSpan", "AgentInvocationSpan"}
+
+
+class TestSingleAgentTrace:
+    """Single agent with tools (no sub-agents)."""
+
+    def setup_method(self):
+        self.mapper = OpenSearchSessionMapper()
+
+    def test_single_agent_with_tools(self):
+        """A single invoke_agent span with direct child tool spans."""
+        records = [
+            make_agent_span(
+                span_id="agent", parent_span_id="",
+                user_prompt="What's the weather?", agent_response="It's sunny in Paris.",
+            ),
+            make_tool_span(span_id="t1", parent_span_id="agent", tool_name="get_weather"),
+            make_tool_span(span_id="t2", parent_span_id="agent", tool_name="get_forecast"),
+        ]
+        session = self.mapper.map_to_session(records, "sess-1")
+
+        assert len(session.traces) == 1
+        spans = session.traces[0].spans
+        assert len(spans) == 3
+
+        agent_span = [s for s in spans if isinstance(s, AgentInvocationSpan)][0]
+        assert agent_span.user_prompt == "What's the weather?"
+        assert agent_span.agent_response == "It's sunny in Paris."
+        assert [t.name for t in agent_span.available_tools] == ["get_forecast", "get_weather"]
+
+    def test_agent_without_tools(self):
+        """Agent span with no tool children gets empty available_tools."""
+        records = [make_agent_span(span_id="agent", parent_span_id="")]
+        session = self.mapper.map_to_session(records, "sess-1")
+
+        agent_span = session.traces[0].spans[0]
+        assert isinstance(agent_span, AgentInvocationSpan)
+        assert agent_span.available_tools == []
+
+
+class TestInferenceSpanMapping:
+    """Chat/inference span mapping with realistic message patterns."""
+
+    def setup_method(self):
+        self.mapper = OpenSearchSessionMapper()
+
+    def test_chat_with_user_and_assistant(self):
+        """Standard chat span with user input and assistant output."""
+        records = [make_chat_span(user_input="Hello", assistant_output="Hi there")]
+        session = self.mapper.map_to_session(records, "sess-1")
+
+        span = session.traces[0].spans[0]
+        assert isinstance(span, InferenceSpan)
+        assert len(span.messages) == 2
+        assert span.messages[0].content[0].text == "Hello"
+        assert span.messages[1].content[0].text == "Hi there"
+
+    def test_chat_with_only_assistant_output(self):
+        """Chat span with no user input, only assistant output."""
+        records = [SpanRecord(
+            trace_id="t1", span_id="s1", operation_name="chat",
+            start_time="2026-01-01T00:00:00Z", end_time="2026-01-01T00:00:01Z",
+            input_messages=[],
+            output_messages=[Message(role="assistant", content="Thinking out loud")],
+        )]
+        session = self.mapper.map_to_session(records, "sess-1")
+
+        span = session.traces[0].spans[0]
+        assert isinstance(span, InferenceSpan)
+        assert len(span.messages) == 1
+
+    def test_chat_with_multiple_turns(self):
+        """Multiple user/assistant messages in a single chat span."""
+        records = [SpanRecord(
+            trace_id="t1", span_id="s1", operation_name="chat",
+            start_time="2026-01-01T00:00:00Z", end_time="2026-01-01T00:00:01Z",
+            input_messages=[
+                Message(role="user", content="First question"),
+                Message(role="user", content="Follow up"),
+            ],
+            output_messages=[
+                Message(role="assistant", content="First answer"),
+                Message(role="assistant", content="Second answer"),
+            ],
+        )]
+        session = self.mapper.map_to_session(records, "sess-1")
+
+        span = session.traces[0].spans[0]
+        assert isinstance(span, InferenceSpan)
+        assert len(span.messages) == 4
+
+
+class TestAgentWithoutMessages:
+    """Edge cases for invoke_agent spans with partial or missing messages."""
+
+    def setup_method(self):
+        self.mapper = OpenSearchSessionMapper()
+
+    def test_agent_with_input_only(self):
+        """invoke_agent with input but no output still produces a span."""
+        records = [SpanRecord(
+            trace_id="t1", span_id="s1", operation_name="invoke_agent",
+            start_time="2026-01-01T00:00:00Z", end_time="2026-01-01T00:00:01Z",
+            input_messages=[Message(role="user", content="Hello")],
+            output_messages=[],
+        )]
+        session = self.mapper.map_to_session(records, "sess-1")
+
+        span = session.traces[0].spans[0]
+        assert isinstance(span, AgentInvocationSpan)
+        assert span.user_prompt == "Hello"
+        assert span.agent_response == ""
+
+    def test_agent_with_output_only(self):
+        """invoke_agent with output but no input still produces a span."""
+        records = [SpanRecord(
+            trace_id="t1", span_id="s1", operation_name="invoke_agent",
+            start_time="2026-01-01T00:00:00Z", end_time="2026-01-01T00:00:01Z",
+            input_messages=[],
+            output_messages=[Message(role="assistant", content="Done")],
+        )]
+        session = self.mapper.map_to_session(records, "sess-1")
+
+        span = session.traces[0].spans[0]
+        assert isinstance(span, AgentInvocationSpan)
+        assert span.user_prompt == ""
+        assert span.agent_response == "Done"
+
+
+class TestLargeTrace:
+    """Behavior with many spans."""
+
+    def setup_method(self):
+        self.mapper = OpenSearchSessionMapper()
+
+    def test_trace_with_many_tool_spans(self):
+        """Mapper handles a trace with many tool execution spans."""
+        records = [make_agent_span(span_id="agent", parent_span_id="")]
+        for i in range(100):
+            records.append(make_tool_span(
+                span_id=f"tool-{i}", parent_span_id="agent",
+                tool_name=f"tool_{i}", start_time=f"2026-01-01T00:00:{i:02d}Z",
+            ))
+        session = self.mapper.map_to_session(records, "sess-1")
+
+        spans = session.traces[0].spans
+        tool_spans = [s for s in spans if isinstance(s, ToolExecutionSpan)]
+        assert len(tool_spans) == 100
+
+        agent_span = [s for s in spans if isinstance(s, AgentInvocationSpan)][0]
+        assert len(agent_span.available_tools) == 100
+
+
+class TestMultiAgentTraces:
+    """Tests for multi-agent scenarios where tool attribution matters."""
+
+    def setup_method(self):
+        self.mapper = OpenSearchSessionMapper()
+
+    def test_tool_names_scoped_to_parent_agent(self):
+        """Each AgentInvocationSpan should only list tools that are its children, not all tools in the trace."""
+        records = [
+            # Orchestrator agent
+            make_agent_span(
+                span_id="orchestrator", parent_span_id="",
+                user_prompt="Plan a trip", agent_response="Here's your plan",
+                start_time="2026-01-01T00:00:00Z",
+            ),
+            # Weather sub-agent (child of orchestrator)
+            make_agent_span(
+                span_id="weather-agent", parent_span_id="orchestrator",
+                user_prompt="Get weather", agent_response="Sunny",
+                start_time="2026-01-01T00:00:01Z",
+            ),
+            # Weather tool (child of weather-agent)
+            make_tool_span(
+                span_id="weather-tool", parent_span_id="weather-agent",
+                tool_name="get_weather",
+                start_time="2026-01-01T00:00:01.5Z",
+            ),
+            # Events sub-agent (child of orchestrator)
+            make_agent_span(
+                span_id="events-agent", parent_span_id="orchestrator",
+                user_prompt="Get events", agent_response="Concert tonight",
+                start_time="2026-01-01T00:00:02Z",
+            ),
+            # Events tool (child of events-agent)
+            make_tool_span(
+                span_id="events-tool", parent_span_id="events-agent",
+                tool_name="get_events",
+                start_time="2026-01-01T00:00:02.5Z",
+            ),
+        ]
+        session = self.mapper.map_to_session(records, "sess-1")
+
+        agent_spans = [s for s in session.traces[0].spans if isinstance(s, AgentInvocationSpan)]
+        assert len(agent_spans) == 3
+
+        # Find each agent by span_id
+        by_id = {s.span_info.span_id: s for s in agent_spans}
+
+        # Weather agent should only know about get_weather
+        weather_tools = [t.name for t in by_id["weather-agent"].available_tools]
+        assert weather_tools == ["get_weather"]
+
+        # Events agent should only know about get_events
+        events_tools = [t.name for t in by_id["events-agent"].available_tools]
+        assert events_tools == ["get_events"]
+
+        # Orchestrator has no direct tool children
+        orchestrator_tools = [t.name for t in by_id["orchestrator"].available_tools]
+        assert orchestrator_tools == []
+
+
+class TestParseTime:
+    """Tests for timestamp parsing edge cases."""
+
+    def test_valid_iso_with_z_suffix(self):
+        from strands_evals.mappers.opensearch_session_mapper import _parse_time
+        dt = _parse_time("2026-01-01T00:00:00Z")
+        assert dt.year == 2026
+        assert dt.tzinfo is not None
+
+    def test_valid_iso_with_offset(self):
+        from strands_evals.mappers.opensearch_session_mapper import _parse_time
+        dt = _parse_time("2026-01-01T00:00:00+00:00")
+        assert dt.year == 2026
+
+    def test_empty_string_returns_epoch(self):
+        from strands_evals.mappers.opensearch_session_mapper import _parse_time
+        dt = _parse_time("")
+        assert dt.year == 1970
+
+    def test_none_returns_epoch(self):
+        from strands_evals.mappers.opensearch_session_mapper import _parse_time
+        dt = _parse_time(None)
+        assert dt.year == 1970
+
+    def test_invalid_string_returns_epoch(self):
+        from strands_evals.mappers.opensearch_session_mapper import _parse_time
+        dt = _parse_time("not-a-date")
+        assert dt.year == 1970

--- a/tests/strands_evals/opensearch_helpers.py
+++ b/tests/strands_evals/opensearch_helpers.py
@@ -1,0 +1,100 @@
+"""Helpers for building mock genai-sdk SpanRecord objects for OpenSearch tests."""
+
+from dataclasses import dataclass, field
+
+
+@dataclass
+class Message:
+    role: str
+    content: str
+
+
+@dataclass
+class SpanRecord:
+    """Mimics opensearch_genai_observability_sdk_py.retrieval.SpanRecord."""
+
+    trace_id: str = ""
+    span_id: str = ""
+    parent_span_id: str = ""
+    name: str = ""
+    start_time: str = ""
+    end_time: str = ""
+    operation_name: str = ""
+    agent_name: str = ""
+    model: str = ""
+    input_messages: list = field(default_factory=list)
+    output_messages: list = field(default_factory=list)
+    tool_name: str = ""
+    tool_call_arguments: str = ""
+    tool_call_result: str = ""
+    input_tokens: int = 0
+    output_tokens: int = 0
+    raw: dict = field(default_factory=dict)
+
+
+def make_agent_span(
+    trace_id="trace-1",
+    span_id="agent-1",
+    parent_span_id="",
+    user_prompt="Hello",
+    agent_response="Hi there",
+    start_time="2026-01-01T00:00:00Z",
+    end_time="2026-01-01T00:00:01Z",
+) -> SpanRecord:
+    return SpanRecord(
+        trace_id=trace_id,
+        span_id=span_id,
+        parent_span_id=parent_span_id,
+        name="invoke_agent",
+        start_time=start_time,
+        end_time=end_time,
+        operation_name="invoke_agent",
+        input_messages=[Message(role="user", content=user_prompt)],
+        output_messages=[Message(role="assistant", content=agent_response)],
+    )
+
+
+def make_chat_span(
+    trace_id="trace-1",
+    span_id="chat-1",
+    parent_span_id="agent-1",
+    user_input="Hello",
+    assistant_output="Hi there",
+    start_time="2026-01-01T00:00:00.1Z",
+    end_time="2026-01-01T00:00:00.5Z",
+) -> SpanRecord:
+    return SpanRecord(
+        trace_id=trace_id,
+        span_id=span_id,
+        parent_span_id=parent_span_id,
+        name="chat",
+        start_time=start_time,
+        end_time=end_time,
+        operation_name="chat",
+        input_messages=[Message(role="user", content=user_input)],
+        output_messages=[Message(role="assistant", content=assistant_output)],
+    )
+
+
+def make_tool_span(
+    trace_id="trace-1",
+    span_id="tool-1",
+    parent_span_id="agent-1",
+    tool_name="get_weather",
+    arguments='{"city": "Paris"}',
+    result="Sunny, 22C",
+    start_time="2026-01-01T00:00:00.5Z",
+    end_time="2026-01-01T00:00:00.8Z",
+) -> SpanRecord:
+    return SpanRecord(
+        trace_id=trace_id,
+        span_id=span_id,
+        parent_span_id=parent_span_id,
+        name="execute_tool",
+        start_time=start_time,
+        end_time=end_time,
+        operation_name="execute_tool",
+        tool_name=tool_name,
+        tool_call_arguments=arguments,
+        tool_call_result=result,
+    )

--- a/tests/strands_evals/providers/test_opensearch_provider.py
+++ b/tests/strands_evals/providers/test_opensearch_provider.py
@@ -1,0 +1,127 @@
+"""Tests for OpenSearchProvider."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from strands_evals.providers.exceptions import ProviderError, SessionNotFoundError
+from strands_evals.providers.opensearch_provider import OpenSearchProvider
+from tests.strands_evals.opensearch_helpers import make_agent_span, make_tool_span
+
+
+# Mock the genai-sdk types
+class MockSessionRecord:
+    def __init__(self, session_id="sess-1", traces=None, truncated=False):
+        self.session_id = session_id
+        self.traces = traces or []
+        self.truncated = truncated
+
+
+class MockTraceRecord:
+    def __init__(self, trace_id="trace-1", spans=None):
+        self.trace_id = trace_id
+        self.spans = spans or []
+
+
+@pytest.fixture
+def mock_retriever():
+    return MagicMock()
+
+
+@pytest.fixture
+def provider(mock_retriever):
+    with patch(
+        "strands_evals.providers.opensearch_provider.OpenSearchProvider.__init__",
+        lambda self, **kwargs: None,
+    ):
+        p = OpenSearchProvider()
+        p._retriever = mock_retriever
+        from strands_evals.mappers.opensearch_session_mapper import OpenSearchSessionMapper
+        p._mapper = OpenSearchSessionMapper()
+        return p
+
+
+class TestGetEvaluationData:
+    def test_happy_path(self, provider, mock_retriever):
+        """Returns TaskOutput with output and trajectory from a valid trace."""
+        spans = [
+            make_agent_span(user_prompt="Hello", agent_response="Hi there"),
+            make_tool_span(tool_name="greet"),
+        ]
+        mock_retriever.get_traces.return_value = MockSessionRecord(
+            traces=[MockTraceRecord(spans=spans)]
+        )
+
+        result = provider.get_evaluation_data("sess-1")
+
+        assert result["output"] == "Hi there"
+        assert result["trajectory"] is not None
+        assert len(result["trajectory"].traces) == 1
+
+    def test_no_traces_raises_session_not_found(self, provider, mock_retriever):
+        """Raises SessionNotFoundError when no traces exist for the session."""
+        mock_retriever.get_traces.return_value = MockSessionRecord(traces=[])
+
+        with pytest.raises(SessionNotFoundError, match="No traces found"):
+            provider.get_evaluation_data("nonexistent")
+
+    def test_retriever_error_raises_provider_error(self, provider, mock_retriever):
+        """Wraps retriever exceptions in ProviderError."""
+        mock_retriever.get_traces.side_effect = ConnectionError("connection refused")
+
+        with pytest.raises(ProviderError, match="Failed to query OpenSearch"):
+            provider.get_evaluation_data("sess-1")
+
+
+
+class TestMultipleTraces:
+    def test_spans_from_multiple_traces_are_regrouped(self, provider, mock_retriever):
+        """Spans from multiple TraceRecords are flattened and re-grouped by trace_id."""
+        mock_retriever.get_traces.return_value = MockSessionRecord(
+            traces=[
+                MockTraceRecord(trace_id="t1", spans=[
+                    make_agent_span(trace_id="t1", span_id="a1", user_prompt="Q1", agent_response="A1"),
+                ]),
+                MockTraceRecord(trace_id="t2", spans=[
+                    make_agent_span(trace_id="t2", span_id="a2", user_prompt="Q2", agent_response="A2"),
+                ]),
+            ]
+        )
+
+        result = provider.get_evaluation_data("sess-1")
+        session = result["trajectory"]
+        assert len(session.traces) == 2
+        trace_ids = {t.trace_id for t in session.traces}
+        assert trace_ids == {"t1", "t2"}
+
+class TestExtractOutput:
+    def test_extracts_last_agent_response(self, provider, mock_retriever):
+        """Output comes from the last AgentInvocationSpan's response."""
+        spans = [
+            make_agent_span(span_id="a1", agent_response="First", start_time="2026-01-01T00:00:00Z"),
+            make_agent_span(span_id="a2", agent_response="Final answer", start_time="2026-01-01T00:00:01Z"),
+        ]
+        mock_retriever.get_traces.return_value = MockSessionRecord(
+            traces=[MockTraceRecord(spans=spans)]
+        )
+
+        result = provider.get_evaluation_data("sess-1")
+        assert result["output"] == "Final answer"
+
+    def test_empty_output_when_no_agent_spans(self, provider, mock_retriever):
+        """Returns empty string when there are no AgentInvocationSpans."""
+        spans = [make_tool_span()]
+        mock_retriever.get_traces.return_value = MockSessionRecord(
+            traces=[MockTraceRecord(spans=spans)]
+        )
+
+        result = provider.get_evaluation_data("sess-1")
+        assert result["output"] == ""
+
+
+class TestImportError:
+    def test_missing_sdk_raises_import_error(self):
+        """Raises ImportError with install instructions when SDK is missing."""
+        with patch.dict("sys.modules", {"opensearch_genai_observability_sdk_py": None}):
+            with pytest.raises(ImportError, match="opensearch-genai-observability-sdk-py is required"):
+                OpenSearchProvider(host="https://localhost:9200")


### PR DESCRIPTION
## Description

Add OpenSearch as a trace provider for evaluations. This enables users storing agent traces in OpenSearch (local or Amazon OpenSearch Service) to retrieve them and run evaluators against them.

- `OpenSearchProvider(TraceProvider)` queries OpenSearch for spans by session/trace ID, returns `TaskOutput`
- `OpenSearchSessionMapper(SessionMapper)` converts span documents to strands-evals `Session`/`Trace`/`Span` types
- `opensearch` optional dependency group (`pip install strands-agents-evals[opensearch]`)
- Lazy-loaded provider (same pattern as CloudWatch/Langfuse)

Uses [opensearch-genai-observability-sdk-py](https://github.com/opensearch-project/genai-observability-sdk-py) for OpenSearch querying, auth (basic, SigV4), and span field mapping.

## Related Issues

Closes #191

## Type of Change

New feature

## Testing

- 32 unit tests covering mapper, provider, edge cases, multi-agent tool scoping, and large traces
- Passes `hatch run test-lint` (ruff + mypy)

<details>
<summary>E2E verification with Strands agent traces</summary>

Sent a Strands agent request (Bedrock Claude) with traces exported to OpenSearch via OTel Collector + Data Prepper. Verified `OpenSearchProvider.get_evaluation_data()` correctly returns typed spans:

| Backend | Auth | Result |
|---------|------|--------|
| OpenSearch (local) | Basic auth | ✅ AgentInvocationSpan + InferenceSpan with correct prompt/response |
| Amazon OpenSearch Service | SigV4 | ✅ Multi-agent trace: 4 AgentInvocationSpans + 7 ToolExecutionSpans |

Full eval loop — Strands agent traces retrieved from OpenSearch and scored:

```
>>> provider = OpenSearchProvider(host="https://localhost:9200", auth=("admin", "pw"), verify_certs=False)
>>> experiment = Experiment(cases=cases, evaluators=[HelpfulnessEvaluator(...)])
>>> reports = experiment.run_evaluations(task)

evaluator_name='HelpfulnessEvaluator' overall_score=0.833 test_passes=[True]
```

</details>

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings
