### PR TITLE
refactor(evaluators): use PEP 604 union syntax and add Model type to HarmfulnessEvaluator

### DIFF
--- a/src/strands_evals/evaluators/coherence_evaluator.py
+++ b/src/strands_evals/evaluators/coherence_evaluator.py
@@ -4,7 +4,6 @@ from typing import cast
 from pydantic import BaseModel, Field
 from strands import Agent
 from strands.models.model import Model
-from typing_extensions import Union
 
 from ..types.evaluation import EvaluationData, EvaluationOutput, InputT, OutputT
 from ..types.trace import EvaluationLevel, TextContent, ToolExecution, TraceLevelInput
@@ -57,7 +56,7 @@ class CoherenceEvaluator(Evaluator[InputT, OutputT]):
     def __init__(
         self,
         version: str = "v0",
-        model: Union[Model, str, None] = None,
+        model: Model | str | None = None,
         system_prompt: str | None = None,
         include_inputs: bool = True,
     ):

--- a/src/strands_evals/evaluators/conciseness_evaluator.py
+++ b/src/strands_evals/evaluators/conciseness_evaluator.py
@@ -4,7 +4,6 @@ from typing import cast
 from pydantic import BaseModel, Field
 from strands import Agent
 from strands.models.model import Model
-from typing_extensions import Union
 
 from ..types.evaluation import EvaluationData, EvaluationOutput, InputT, OutputT
 from ..types.trace import EvaluationLevel
@@ -41,7 +40,7 @@ class ConcisenessEvaluator(Evaluator[InputT, OutputT]):
     def __init__(
         self,
         version: str = "v0",
-        model: Union[Model, str, None] = None,
+        model: Model | str | None = None,
         system_prompt: str | None = None,
         include_inputs: bool = True,
     ):

--- a/src/strands_evals/evaluators/correctness_evaluator.py
+++ b/src/strands_evals/evaluators/correctness_evaluator.py
@@ -4,7 +4,6 @@ from typing import cast
 from pydantic import BaseModel, Field
 from strands import Agent
 from strands.models.model import Model
-from typing_extensions import Union
 
 from ..types.evaluation import EvaluationData, EvaluationOutput, InputT, OutputT
 from ..types.trace import EvaluationLevel, TraceLevelInput
@@ -73,7 +72,7 @@ class CorrectnessEvaluator(Evaluator[InputT, OutputT]):
     def __init__(
         self,
         version: str = "v0",
-        model: Union[Model, str, None] = None,
+        model: Model | str | None = None,
         system_prompt: str | None = None,
         reference_system_prompt: str | None = None,
     ):

--- a/src/strands_evals/evaluators/evaluator.py
+++ b/src/strands_evals/evaluators/evaluator.py
@@ -3,7 +3,7 @@ import inspect
 import logging
 
 from strands.models.model import Model
-from typing_extensions import Any, Generic, TypeGuard, Union
+from typing_extensions import Any, Generic, TypeGuard
 
 from ..extractors import TraceExtractor
 from ..types.evaluation import EvaluationData, EvaluationOutput, InputT, OutputT
@@ -49,7 +49,7 @@ class Evaluator(Generic[InputT, OutputT]):
         elif self.evaluation_level:
             self._trace_extractor = TraceExtractor(self.evaluation_level)
 
-    def _get_model_id(self, model: Union[Model, str, None]) -> str:
+    def _get_model_id(self, model: Model | str | None) -> str:
         """Extract model_id from a Model instance or string for serialization.
 
         This helper method should be called in subclass __init__ methods that accept a model parameter.

--- a/src/strands_evals/evaluators/faithfulness_evaluator.py
+++ b/src/strands_evals/evaluators/faithfulness_evaluator.py
@@ -4,7 +4,6 @@ from typing import cast
 from pydantic import BaseModel, Field
 from strands import Agent
 from strands.models.model import Model
-from typing_extensions import Union
 
 from ..types.evaluation import EvaluationData, EvaluationOutput, InputT, OutputT
 from ..types.trace import EvaluationLevel
@@ -45,7 +44,7 @@ class FaithfulnessEvaluator(Evaluator[InputT, OutputT]):
     def __init__(
         self,
         version: str = "v0",
-        model: Union[Model, str, None] = None,
+        model: Model | str | None = None,
         system_prompt: str | None = None,
     ):
         super().__init__()

--- a/src/strands_evals/evaluators/goal_success_rate_evaluator.py
+++ b/src/strands_evals/evaluators/goal_success_rate_evaluator.py
@@ -4,7 +4,6 @@ from typing import cast
 from pydantic import BaseModel, Field
 from strands import Agent
 from strands.models.model import Model
-from typing_extensions import Union
 
 from ..types.evaluation import EvaluationData, EvaluationOutput, InputT, OutputT
 from ..types.trace import EvaluationLevel, SessionLevelInput
@@ -70,7 +69,7 @@ class GoalSuccessRateEvaluator(Evaluator[InputT, OutputT]):
     def __init__(
         self,
         version: str = "v0",
-        model: Union[Model, str, None] = None,
+        model: Model | str | None = None,
         system_prompt: str | None = None,
         assertion_system_prompt: str | None = None,
     ):

--- a/src/strands_evals/evaluators/harmfulness_evaluator.py
+++ b/src/strands_evals/evaluators/harmfulness_evaluator.py
@@ -3,6 +3,7 @@ from typing import cast
 
 from pydantic import BaseModel, Field
 from strands import Agent
+from strands.models.model import Model
 
 from ..types.evaluation import EvaluationData, EvaluationOutput, InputT, OutputT
 from ..types.trace import EvaluationLevel
@@ -37,7 +38,7 @@ class HarmfulnessEvaluator(Evaluator[InputT, OutputT]):
     def __init__(
         self,
         version: str = "v0",
-        model: str | None = None,
+        model: Model | str | None = None,
         system_prompt: str | None = None,
     ):
         super().__init__()

--- a/src/strands_evals/evaluators/helpfulness_evaluator.py
+++ b/src/strands_evals/evaluators/helpfulness_evaluator.py
@@ -4,7 +4,6 @@ from typing import cast
 from pydantic import BaseModel, Field
 from strands import Agent
 from strands.models.model import Model
-from typing_extensions import Union
 
 from ..types.evaluation import EvaluationData, EvaluationOutput, InputT, OutputT
 from ..types.trace import EvaluationLevel
@@ -49,7 +48,7 @@ class HelpfulnessEvaluator(Evaluator[InputT, OutputT]):
     def __init__(
         self,
         version: str = "v0",
-        model: Union[Model, str, None] = None,
+        model: Model | str | None = None,
         system_prompt: str | None = None,
         include_inputs: bool = True,
     ):

--- a/src/strands_evals/evaluators/interactions_evaluator.py
+++ b/src/strands_evals/evaluators/interactions_evaluator.py
@@ -3,7 +3,6 @@ from typing import cast
 from strands import Agent
 from strands.agent.conversation_manager import SlidingWindowConversationManager
 from strands.models.model import Model
-from typing_extensions import Union
 
 from ..types.evaluation import EvaluationData, EvaluationOutput, InputT, OutputT
 from .evaluator import Evaluator
@@ -30,7 +29,7 @@ class InteractionsEvaluator(Evaluator[InputT, OutputT]):
         self,
         rubric: str | dict[str, str],
         interaction_description: dict | None = None,
-        model: Union[Model, str, None] = None,
+        model: Model | str | None = None,
         system_prompt: str = SYSTEM_PROMPT,
         include_inputs: bool = True,
     ):

--- a/src/strands_evals/evaluators/output_evaluator.py
+++ b/src/strands_evals/evaluators/output_evaluator.py
@@ -2,7 +2,6 @@ from typing import cast
 
 from strands import Agent
 from strands.models.model import Model
-from typing_extensions import Union
 
 from ..types.evaluation import EvaluationData, EvaluationOutput, InputT, OutputT
 from .evaluator import Evaluator
@@ -26,7 +25,7 @@ class OutputEvaluator(Evaluator[InputT, OutputT]):
     def __init__(
         self,
         rubric: str,
-        model: Union[Model, str, None] = None,
+        model: Model | str | None = None,
         system_prompt: str = SYSTEM_PROMPT,
         include_inputs: bool = True,
         uses_environment_state: bool = False,

--- a/src/strands_evals/evaluators/response_relevance_evaluator.py
+++ b/src/strands_evals/evaluators/response_relevance_evaluator.py
@@ -5,7 +5,6 @@ from pydantic import BaseModel, Field
 from strands import Agent
 from strands.agent.agent_result import AgentResult
 from strands.models.model import Model
-from typing_extensions import Union
 
 from ..types.evaluation import EvaluationData, EvaluationOutput, InputT, OutputT
 from ..types.trace import EvaluationLevel
@@ -46,7 +45,7 @@ class ResponseRelevanceEvaluator(Evaluator[InputT, OutputT]):
     def __init__(
         self,
         version: str = "v0",
-        model: Union[Model, str, None] = None,
+        model: Model | str | None = None,
         system_prompt: str | None = None,
         include_inputs: bool = True,
     ):

--- a/src/strands_evals/evaluators/tool_parameter_accuracy_evaluator.py
+++ b/src/strands_evals/evaluators/tool_parameter_accuracy_evaluator.py
@@ -4,7 +4,6 @@ from typing import cast
 from pydantic import BaseModel, Field
 from strands import Agent
 from strands.models.model import Model
-from typing_extensions import Union
 
 from ..types.evaluation import EvaluationData, EvaluationOutput, InputT, OutputT
 from ..types.trace import EvaluationLevel
@@ -39,7 +38,7 @@ class ToolParameterAccuracyEvaluator(Evaluator[InputT, OutputT]):
     def __init__(
         self,
         version: str = "v0",
-        model: Union[Model, str, None] = None,
+        model: Model | str | None = None,
         system_prompt: str | None = None,
     ):
         super().__init__()

--- a/src/strands_evals/evaluators/tool_selection_accuracy_evaluator.py
+++ b/src/strands_evals/evaluators/tool_selection_accuracy_evaluator.py
@@ -4,7 +4,6 @@ from typing import cast
 from pydantic import BaseModel, Field
 from strands import Agent
 from strands.models.model import Model
-from typing_extensions import Union
 
 from ..types.evaluation import EvaluationData, EvaluationOutput, InputT, OutputT
 from ..types.trace import EvaluationLevel
@@ -39,7 +38,7 @@ class ToolSelectionAccuracyEvaluator(Evaluator[InputT, OutputT]):
     def __init__(
         self,
         version: str = "v0",
-        model: Union[Model, str, None] = None,
+        model: Model | str | None = None,
         system_prompt: str | None = None,
     ):
         super().__init__()

--- a/src/strands_evals/evaluators/trajectory_evaluator.py
+++ b/src/strands_evals/evaluators/trajectory_evaluator.py
@@ -2,7 +2,7 @@ from typing import cast
 
 from strands import Agent
 from strands.models.model import Model
-from typing_extensions import Any, Union
+from typing_extensions import Any
 
 from ..tools.evaluation_tools import any_order_match_scorer, exact_match_scorer, in_order_match_scorer
 from ..types.evaluation import EvaluationData, EvaluationOutput, InputT, OutputT
@@ -29,7 +29,7 @@ class TrajectoryEvaluator(Evaluator[InputT, OutputT]):
         self,
         rubric: str,
         trajectory_description: dict | None = None,
-        model: Union[Model, str, None] = None,
+        model: Model | str | None = None,
         system_prompt: str = SYSTEM_PROMPT,
         include_inputs: bool = True,
     ):
@@ -38,7 +38,7 @@ class TrajectoryEvaluator(Evaluator[InputT, OutputT]):
         self.trajectory_description = trajectory_description
         self.model = model
         self.include_inputs = include_inputs
-        self._tools: list[Union[str, dict[str, str], Any]] | None = [
+        self._tools: list[str | dict[str, str] | Any] | None = [
             exact_match_scorer,
             in_order_match_scorer,
             any_order_match_scorer,

--- a/src/strands_evals/extractors/tools_use_extractor.py
+++ b/src/strands_evals/extractors/tools_use_extractor.py
@@ -1,4 +1,4 @@
-from typing import Union, cast
+from typing import cast
 
 from strands import Agent
 
@@ -129,7 +129,7 @@ def extract_agent_tools_used_from_trace(session: Session) -> list[dict]:
     return tools_used
 
 
-def extract_agent_tools_used(source: Union[list, Session]) -> list[dict]:
+def extract_agent_tools_used(source: list | Session) -> list[dict]:
     """
     Extract tool usage information from either agent messages or trace data.
     This is a unified interface that automatically detects the input type and uses

--- a/src/strands_evals/extractors/trace_extractor.py
+++ b/src/strands_evals/extractors/trace_extractor.py
@@ -1,7 +1,5 @@
 import logging
 
-from typing_extensions import Union
-
 from ..types.trace import (
     AgentInvocationSpan,
     AssistantMessage,
@@ -28,7 +26,7 @@ class TraceExtractor:
     def __init__(self, evaluation_level: EvaluationLevel):
         self.evaluation_level = evaluation_level
 
-    def extract(self, session: Session) -> Union[list[TraceLevelInput], list[ToolLevelInput], SessionLevelInput]:
+    def extract(self, session: Session) -> list[TraceLevelInput] | list[ToolLevelInput] | SessionLevelInput:
         """Extract evaluation inputs based on configured level."""
         if not isinstance(session, Session):
             raise TypeError(f"Expected Session object, got {type(session).__name__}")
@@ -45,7 +43,7 @@ class TraceExtractor:
     def _extract_trace_level(self, session: Session) -> list[TraceLevelInput]:
         """Extract trace-level inputs with session history up to each turn."""
         evaluation_inputs: list[TraceLevelInput] = []
-        previous_turns: list[Union[UserMessage, list[ToolExecution], AssistantMessage]] = []
+        previous_turns: list[UserMessage | list[ToolExecution] | AssistantMessage] = []
 
         for trace in session.traces:
             tool_spans = self._find_tool_execution_spans(trace)
@@ -89,7 +87,7 @@ class TraceExtractor:
     def _extract_tool_level(self, session: Session) -> list[ToolLevelInput]:
         """Extract tool-level inputs with session and tool context."""
         evaluator_inputs: list[ToolLevelInput] = []
-        session_history: list[Union[UserMessage, list[ToolExecution], AssistantMessage]] = []
+        session_history: list[UserMessage | list[ToolExecution] | AssistantMessage] = []
         available_tools: list[ToolConfig] = []
 
         for trace in session.traces:

--- a/src/strands_evals/types/evaluation.py
+++ b/src/strands_evals/types/evaluation.py
@@ -1,5 +1,5 @@
 from pydantic import BaseModel
-from typing_extensions import Any, Generic, TypedDict, TypeVar, Union
+from typing_extensions import Any, Generic, TypedDict, TypeVar
 
 from .trace import Session
 
@@ -68,7 +68,7 @@ class TaskOutput(TypedDict, total=False):
     """
 
     output: Any
-    trajectory: Union[list[Any], Session, None]
+    trajectory: list[Any] | Session | None
     interactions: list[Interaction]
     input: Any
     environment_state: list[EnvironmentState]
@@ -100,8 +100,8 @@ class EvaluationData(BaseModel, Generic[InputT, OutputT]):
     name: str | None = None
     expected_output: OutputT | None = None
     expected_assertion: str | None = None
-    expected_trajectory: Union[list[Any], Session, None] = None
-    actual_trajectory: Union[list[Any], Session, None] = None
+    expected_trajectory: list[Any] | Session | None = None
+    actual_trajectory: list[Any] | Session | None = None
     metadata: dict[str, Any] | None = None
     actual_interactions: list[Interaction] | None = None
     expected_interactions: list[Interaction] | None = None

--- a/src/strands_evals/types/trace.py
+++ b/src/strands_evals/types/trace.py
@@ -8,7 +8,7 @@ from datetime import datetime, timezone
 from enum import Enum
 
 from pydantic import BaseModel, field_serializer
-from typing_extensions import Mapping, Sequence, TypeAlias, Union
+from typing_extensions import Mapping, Sequence, TypeAlias
 
 
 class Role(str, Enum):
@@ -69,12 +69,12 @@ class ToolResultContent(ToolResult):
 
 class UserMessage(BaseModel):
     role: Role = Role.USER
-    content: list[Union[TextContent, ToolResultContent]]
+    content: list[TextContent | ToolResultContent]
 
 
 class AssistantMessage(BaseModel):
     role: Role = Role.ASSISTANT
-    content: list[Union[TextContent, ToolCallContent]]
+    content: list[TextContent | ToolCallContent]
 
 
 class SpanInfo(BaseModel):
@@ -104,7 +104,7 @@ class BaseSpan(BaseModel):
 
 class InferenceSpan(BaseSpan):
     span_type: SpanType = SpanType.INFERENCE
-    messages: list[Union[UserMessage, AssistantMessage]]
+    messages: list[UserMessage | AssistantMessage]
 
 
 class ToolExecutionSpan(BaseSpan):
@@ -120,7 +120,7 @@ class AgentInvocationSpan(BaseSpan):
     available_tools: list[ToolConfig]
 
 
-SpanUnion: TypeAlias = Union[InferenceSpan, ToolExecutionSpan, AgentInvocationSpan]
+SpanUnion: TypeAlias = InferenceSpan | ToolExecutionSpan | AgentInvocationSpan
 
 
 class Trace(BaseModel):
@@ -162,7 +162,7 @@ class TraceLevelInput(BaseEvaluationInput):
     """Input for trace-level evaluators"""
 
     agent_response: TextContent
-    session_history: list[Union[UserMessage, list[ToolExecution], AssistantMessage]]
+    session_history: list[UserMessage | list[ToolExecution] | AssistantMessage]
 
 
 class ToolLevelInput(BaseEvaluationInput):
@@ -170,12 +170,12 @@ class ToolLevelInput(BaseEvaluationInput):
 
     available_tools: list[ToolConfig]
     tool_execution_details: ToolExecutionSpan
-    session_history: list[Union[UserMessage, list[ToolExecution], AssistantMessage]]
+    session_history: list[UserMessage | list[ToolExecution] | AssistantMessage]
 
 
 class EvaluatorScore(BaseModel):
     explanation: str
-    value: Union[int, float] | None = None
+    value: int | float | None = None
     error: str | None = None
 
 


### PR DESCRIPTION


## Description
Replace Union[X, Y, Z] with X | Y | Z across evaluators, extractors, and types modules to adopt modern Python 3.10+ union syntax. (PEP 604 union syntax)

Add Model type support to HarmfulnessEvaluator to match the pattern used by other evaluators, allowing callers to pass a Model instance, a string model ID, or None.

## Related Issues

https://github.com/strands-agents/evals/issues/205

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

Bug fix
Documentation update

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [ ] I ran `hatch run prepare`

## Checklist
- [ ] I have read the CONTRIBUTING document
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.