### PR TITLE
feat(simulation): add optional tools parameter to ToolSimulator (#208)

### DIFF
--- a/src/strands_evals/simulation/tool_simulator.py
+++ b/src/strands_evals/simulation/tool_simulator.py
@@ -166,6 +166,7 @@ class ToolSimulator:
         state_registry: StateRegistry | None = None,
         model: Model | str | None = None,
         max_tool_call_cache_size: int = 20,
+        tools: list | None = None,
     ):
         """
         Initialize a ToolSimulator instance.
@@ -178,8 +179,12 @@ class ToolSimulator:
                                      Only used when creating a new StateRegistry (ignored if state_registry
                                      is provided). Older calls are automatically evicted when limit is exceeded.
                                      Default is 20.
+            tools: Optional list of tools to provide to the internal simulation agent.
+                   When provided, the agent can use these tools (e.g. calculator) to improve
+                   accuracy of generated responses. Defaults to an empty list.
         """
         self.model = model
+        self.tools = tools or []
         self.state_registry = state_registry or StateRegistry(max_tool_call_cache_size=max_tool_call_cache_size)
         self._registered_tools: dict[str, RegisteredTool] = {}
 
@@ -229,7 +234,7 @@ class ToolSimulator:
     def _simulate_tool_call(self, prompt: str, structured_output_model=None) -> Any:
         """Tool simulation agent creation and response generation."""
         agent = Agent(
-            tools=[],
+            tools=self.tools,
             model=self.model,
             callback_handler=None,
         )

--- a/tests/strands_evals/simulation/test_tool_simulator.py
+++ b/tests/strands_evals/simulation/test_tool_simulator.py
@@ -465,3 +465,75 @@ def test_no_parameters_tool_input_model():
     properties = schema.get("properties", {})
     # Empty model should mean no properties
     assert len(properties) == 0, "Tool with empty schema should have no properties"
+
+
+def test_tool_simulator_init_default_tools():
+    """Test ToolSimulator initializes with empty tools list by default."""
+    simulator = ToolSimulator()
+    assert simulator.tools == []
+
+
+def test_tool_simulator_init_with_tools():
+    """Test ToolSimulator stores provided tools."""
+    mock_tool = MagicMock()
+    simulator = ToolSimulator(tools=[mock_tool])
+    assert simulator.tools == [mock_tool]
+
+
+def test_tool_simulator_init_tools_none_becomes_empty_list():
+    """Test ToolSimulator converts None tools to empty list."""
+    simulator = ToolSimulator(tools=None)
+    assert simulator.tools == []
+
+
+def test_simulate_tool_call_passes_tools_to_agent(mock_model):
+    """Test that tools are passed through to the internal Agent."""
+    mock_tool = MagicMock()
+    simulator = ToolSimulator(model=mock_model, tools=[mock_tool])
+
+    @simulator.tool(output_schema=GenericOutput)
+    def test_func(message: str) -> dict:
+        """Test function."""
+        pass
+
+    captured_kwargs = {}
+
+    def mock_agent_constructor(**kwargs):
+        captured_kwargs.update(kwargs)
+        mock_agent = MagicMock()
+        mock_result = MagicMock()
+        mock_result.__str__ = MagicMock(return_value='{"result": "response"}')
+        mock_agent.return_value = mock_result
+        return mock_agent
+
+    with pytest.MonkeyPatch().context() as m:
+        m.setattr("strands_evals.simulation.tool_simulator.Agent", mock_agent_constructor)
+        simulator.test_func("hello")
+
+    assert captured_kwargs["tools"] == [mock_tool]
+
+
+def test_simulate_tool_call_default_empty_tools(mock_model):
+    """Test that default simulator passes empty tools list to Agent."""
+    simulator = ToolSimulator(model=mock_model)
+
+    @simulator.tool(output_schema=GenericOutput)
+    def test_func(message: str) -> dict:
+        """Test function."""
+        pass
+
+    captured_kwargs = {}
+
+    def mock_agent_constructor(**kwargs):
+        captured_kwargs.update(kwargs)
+        mock_agent = MagicMock()
+        mock_result = MagicMock()
+        mock_result.__str__ = MagicMock(return_value='{"result": "response"}')
+        mock_agent.return_value = mock_result
+        return mock_agent
+
+    with pytest.MonkeyPatch().context() as m:
+        m.setattr("strands_evals.simulation.tool_simulator.Agent", mock_agent_constructor)
+        simulator.test_func("hello")
+
+    assert captured_kwargs["tools"] == []


### PR DESCRIPTION
## Description

Add an optional `tools` parameter to `ToolSimulator.__init__` that gets passed through to the internal simulation `Agent`. This lets users provide helper tools (like `calculator` from `strands-agents-tools`) to improve the accuracy of simulated responses, especially for stateful, arithmetic-heavy simulations.

Currently the simulation agent is created with `tools=[]` hardcoded. This works fine for simple simulations, but when simulating APIs that require arithmetic consistency across multiple tool calls (e.g. inventory reconciliation, order metrics, settlement calculations), the LLM frequently gets the math wrong. Those errors compound because the `StateRegistry` feeds previous responses back into subsequent prompts.

The change is minimal and fully backward compatible. `tools` defaults to `None` (stored as `[]`), so existing behavior is unchanged.

### What changed

- `ToolSimulator.__init__` accepts an optional `tools` parameter
- `_simulate_tool_call` passes `self.tools` to the `Agent` constructor instead of `[]`
- 5 new unit tests covering default behavior, storage, and pass-through to Agent

### Example usage

```python
from strands_tools import calculator
from strands_evals.simulation import ToolSimulator

simulator = ToolSimulator(
    model="us.anthropic.claude-sonnet-4-20250514",
    tools=[calculator],
)
```

## Related Issues

Closes #208

## Documentation PR

No documentation changes needed. The new parameter follows existing patterns and is optional with a sensible default.

## Type of Change

New feature

## Testing

- [x] I ran `hatch run prepare`
- All 982 existing tests continue to pass
- 5 new unit tests added covering:
  - Default tools is `[]`
  - Tools parameter is stored correctly
  - `None` becomes `[]`
  - Tools are passed through to the internal Agent
  - Default simulator passes empty list to Agent

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
