### PR TITLE
feat(detectors): integrated rca into evaluation workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Strands Evaluation is a powerful framework for evaluating AI agents and LLM appl
 - **Custom Evaluators**: Extensible framework for domain-specific evaluation logic
 - **Experiment Management**: Save, load, and version your evaluation experiments with JSON serialization
 - **Built-in Scoring Tools**: Helper functions for exact, in-order, and any-order trajectory matching
+- **Failure Detection & Root Cause Analysis**: Automatically detect failures in agent sessions and diagnose root causes with actionable fix recommendations
 
 ## Quick Start
 
@@ -348,6 +349,50 @@ experiment = await generator.from_context_async(
 experiment.to_file("generated_experiment", "json")
 ```
 
+### Failure Detection & Diagnosis
+
+Detect failures in agent sessions and analyze root causes to get actionable fix recommendations:
+
+```python
+from strands_evals import Case, DiagnosisConfig, Experiment
+from strands_evals.evaluators import HelpfulnessEvaluator
+
+# Enable diagnosis on failing cases — runs failure detection then root cause analysis
+experiment = Experiment(
+    cases=test_cases,
+    evaluators=[HelpfulnessEvaluator()],
+    diagnosis_config=DiagnosisConfig(
+        trigger="on_failure",           # "on_failure" or "always"
+        confidence_threshold="medium",  # "low", "medium", or "high"
+    ),
+)
+
+reports = experiment.run_evaluations(task_function)
+
+# Display results with recommendations
+reports[0].display(include_recommendations=True)
+```
+
+You can also use the detectors standalone on any `Session` object (`strands_evals.types.trace.Session`):
+
+```python
+from strands_evals.detectors import detect_failures, analyze_root_cause, diagnose_session
+
+# Full pipeline: detect failures → root cause analysis
+result = diagnose_session(session, confidence_threshold="medium")
+
+for rc in result.root_causes:
+    print(f"{rc.fix_type}: {rc.fix_recommendation}")
+
+# Or run each step independently
+failures = detect_failures(session, confidence_threshold="medium")
+if failures.failures:
+    rca = analyze_root_cause(session, failures=failures.failures)
+
+# analyze_root_cause calls detect_failures automatically if failures is not provided
+rca = analyze_root_cause(session)
+```
+
 ### Custom Evaluators with Structured Output
 
 Create domain-specific evaluation logic with standardized output format:
@@ -494,6 +539,13 @@ These evaluators assess multimodal (image-to-text) responses using MLLM-as-a-Jud
 - **MultimodalOverallQualityEvaluator**: Holistic evaluation across visual accuracy, instruction adherence, completeness, and coherence
 - **MultimodalOutputEvaluator**: Base class for custom multimodal evaluators with configurable rubrics
 
+### Detectors
+Analyze agent sessions to identify failures and their root causes:
+
+- **detect_failures**: Scans a Session for failures with configurable confidence thresholds
+- **analyze_root_cause**: Identifies root causes for detected failures with fix recommendations
+- **diagnose_session**: End-to-end pipeline combining failure detection and root cause analysis
+
 ## Experiment Management and Serialization
 
 Save, load, and version experiments for reproducibility:
@@ -531,6 +583,11 @@ metrics = {
 # Generate analysis reports
 reports = experiment.run_evaluations(task_function)
 reports[0].run_display()  # Interactive display with metrics breakdown
+
+# Flatten multiple evaluator reports into a single combined view
+from strands_evals.types.evaluation_report import EvaluationReport
+combined = EvaluationReport.flatten(reports)
+combined.display(include_recommendations=True)
 ```
 
 ## Best Practices

--- a/src/strands_evals/__init__.py
+++ b/src/strands_evals/__init__.py
@@ -6,8 +6,10 @@ from .experiment import Experiment
 from .local_file_task_result_store import LocalFileTaskResultStore
 from .simulation import ActorSimulator, UserSimulator
 from .telemetry import StrandsEvalsTelemetry, get_tracer
+from .types.detector import DiagnosisConfig
 
 __all__ = [
+    "DiagnosisConfig",
     "Experiment",
     "Case",
     "LocalFileTaskResultStore",

--- a/src/strands_evals/detectors/__init__.py
+++ b/src/strands_evals/detectors/__init__.py
@@ -7,6 +7,8 @@ performing root cause analysis.
 
 from ..types.detector import (
     ConfidenceLevel,
+    DiagnosisConfig,
+    DiagnosisResult,
     FailureDetectionStructuredOutput,
     FailureItem,
     FailureOutput,
@@ -14,6 +16,7 @@ from ..types.detector import (
     RCAOutput,
     RCAStructuredOutput,
 )
+from .diagnosis import diagnose_session
 from .failure_detector import detect_failures
 from .root_cause_analyzer import analyze_root_cause
 
@@ -21,6 +24,10 @@ __all__ = [
     # Core detectors
     "detect_failures",
     "analyze_root_cause",
+    # Diagnosis
+    "diagnose_session",
+    "DiagnosisConfig",
+    "DiagnosisResult",
     # Types
     "ConfidenceLevel",
     "FailureOutput",

--- a/src/strands_evals/detectors/diagnosis.py
+++ b/src/strands_evals/detectors/diagnosis.py
@@ -1,0 +1,48 @@
+"""Session diagnosis: detect failures and analyze root causes."""
+
+from strands.models.model import Model
+
+from ..types.detector import ConfidenceLevel, DiagnosisResult
+from ..types.trace import Session
+from .failure_detector import detect_failures
+from .root_cause_analyzer import analyze_root_cause
+
+
+def diagnose_session(
+    session: Session,
+    *,
+    model: Model | str | None = None,
+    confidence_threshold: ConfidenceLevel = "low",
+) -> DiagnosisResult:
+    """Run failure detection and root cause analysis on a session.
+
+    Pipeline: detect_failures → analyze_root_cause (if failures found).
+
+    Args:
+        session: The Session object to diagnose.
+        model: Model for LLM-based detectors. None uses default.
+        confidence_threshold: Minimum confidence for failure detection.
+
+    Returns:
+        DiagnosisResult with failures and root causes.
+    """
+    failure_output = detect_failures(
+        session,
+        confidence_threshold=confidence_threshold,
+        model=model,
+    )
+
+    root_causes = []
+    if failure_output.failures:
+        rca_output = analyze_root_cause(
+            session,
+            failures=failure_output.failures,
+            model=model,
+        )
+        root_causes = rca_output.root_causes
+
+    return DiagnosisResult(
+        session_id=session.session_id,
+        failures=failure_output.failures,
+        root_causes=root_causes,
+    )

--- a/src/strands_evals/experiment.py
+++ b/src/strands_evals/experiment.py
@@ -17,6 +17,7 @@ from tenacity import (
 from typing_extensions import Any, Generic
 
 from .case import Case
+from .detectors.diagnosis import diagnose_session
 from .evaluation_data_store import EvaluationDataStore
 from .evaluators.deterministic import Contains, Equals, StartsWith, StateEquals, ToolCalled
 from .evaluators.evaluator import Evaluator
@@ -25,8 +26,10 @@ from .evaluators.output_evaluator import OutputEvaluator
 from .evaluators.trajectory_evaluator import TrajectoryEvaluator
 from .telemetry import get_tracer, serialize
 from .telemetry._cloudwatch_logger import _send_to_cloudwatch
+from .types.detector import DiagnosisConfig
 from .types.evaluation import EvaluationData, InputT, OutputT
 from .types.evaluation_report import EvaluationReport
+from .types.trace import Session
 from .utils import is_throttling_error
 
 logger = logging.getLogger()
@@ -101,13 +104,14 @@ class Experiment(Generic[InputT, OutputT]):
         self,
         cases: list[Case[InputT, OutputT]] | None = None,
         evaluators: list[Evaluator[InputT, OutputT]] | None = None,
+        diagnosis_config: DiagnosisConfig | None = None,
     ):
         self._cases = cases or []
         self._evaluators = evaluators or [Evaluator()]
         self._tracer = get_tracer()
-        # self._logger = get_logger(__name__)
 
         self._config_id = os.environ.get("EVALUATION_RESULTS_LOG_GROUP", "default-strands-evals")
+        self._diagnosis_config = diagnosis_config
 
     @property
     def cases(self) -> list[Case[InputT, OutputT]]:
@@ -412,6 +416,35 @@ class Experiment(Generic[InputT, OutputT]):
                 "detailed_results": [],
             }
 
+    async def _run_diagnosis(
+        self,
+        evaluation_context: EvaluationData,
+        case_name: str,
+    ) -> tuple[dict | None, str | None]:
+        """Run diagnosis on a failing case's trajectory if it is a Session.
+
+        Returns:
+            (diagnosis_dict, recommendations_string) — both None if diagnosis
+            cannot run or fails.
+        """
+        trajectory = evaluation_context.actual_trajectory
+        if not isinstance(trajectory, Session) or self._diagnosis_config is None:
+            return None, None
+
+        try:
+            result = await asyncio.to_thread(
+                diagnose_session,
+                trajectory,
+                model=self._diagnosis_config.model,
+                confidence_threshold=self._diagnosis_config.confidence_threshold,
+            )
+            recs = result.recommendations
+            recs_str = "; ".join(recs) if recs else None
+            return result.model_dump(), recs_str
+        except Exception as e:
+            logger.warning("Diagnosis failed for case %s: %s", case_name, e)
+            return None, None
+
     async def _worker(
         self,
         queue: asyncio.Queue,
@@ -467,11 +500,22 @@ class Experiment(Generic[InputT, OutputT]):
                             )
                             evaluator_results.append(result)
 
+                        # Run diagnosis on failing cases if enabled
+                        diagnosis = None
+                        recommendation = None
+                        if self._diagnosis_config is not None:
+                            trigger = self._diagnosis_config.trigger
+                            any_failed = any(not r["test_pass"] for r in evaluator_results)
+                            if trigger == "always" or (trigger == "on_failure" and any_failed):
+                                diagnosis, recommendation = await self._run_diagnosis(evaluation_context, case_name)
+
                         # Store results
                         results.append(
                             {
                                 "case": evaluation_context.model_dump(),
                                 "evaluator_results": evaluator_results,
+                                "diagnosis": diagnosis,
+                                "recommendation": recommendation,
                             }
                         )
 
@@ -493,6 +537,8 @@ class Experiment(Generic[InputT, OutputT]):
                             {
                                 "case": case.model_dump(),
                                 "evaluator_results": evaluator_results,
+                                "diagnosis": None,
+                                "recommendation": None,
                             }
                         )
             finally:
@@ -571,12 +617,16 @@ class Experiment(Generic[InputT, OutputT]):
                 "cases": [],
                 "reasons": [],
                 "detailed_results": [],
+                "diagnoses": [],
+                "recommendations": [],
             }
             for evaluator in self._evaluators
         }
 
         for result in results:
             case_data = result["case"]
+            diagnosis = result.get("diagnosis")
+            recommendation = result.get("recommendation")
             for eval_result in result["evaluator_results"]:
                 eval_name = eval_result["evaluator_name"]
                 evaluator_data[eval_name]["cases"].append(case_data)
@@ -584,6 +634,8 @@ class Experiment(Generic[InputT, OutputT]):
                 evaluator_data[eval_name]["test_passes"].append(eval_result["test_pass"])
                 evaluator_data[eval_name]["reasons"].append(eval_result["reason"])
                 evaluator_data[eval_name]["detailed_results"].append(eval_result["detailed_results"])
+                evaluator_data[eval_name]["diagnoses"].append(diagnosis)
+                evaluator_data[eval_name]["recommendations"].append(recommendation)
 
         reports = []
         for evaluator in self._evaluators:
@@ -598,6 +650,8 @@ class Experiment(Generic[InputT, OutputT]):
                 cases=data["cases"],
                 reasons=data["reasons"],
                 detailed_results=data["detailed_results"],
+                diagnoses=data["diagnoses"],
+                recommendations=data["recommendations"],
             )
             reports.append(report)
 

--- a/src/strands_evals/types/__init__.py
+++ b/src/strands_evals/types/__init__.py
@@ -1,4 +1,5 @@
 from .detector import (
+    DiagnosisConfig,
     FailureDetectionStructuredOutput,
     FailureItem,
     FailureOutput,
@@ -24,6 +25,7 @@ __all__ = [
     "ImageData",
     "MultimodalInput",
     "resolve_image_bytes",
+    "DiagnosisConfig",
     "FailureDetectionStructuredOutput",
     "FailureItem",
     "FailureOutput",

--- a/src/strands_evals/types/detector.py
+++ b/src/strands_evals/types/detector.py
@@ -7,9 +7,29 @@ LLM structured output schemas (FailureDetectionStructuredOutput, etc.).
 from typing import Literal
 
 from pydantic import BaseModel, Field
+from strands.models.model import Model
 
 # Confidence levels used across detectors
 ConfidenceLevel = Literal["low", "medium", "high"]
+
+
+DiagnosisTrigger = Literal["on_failure", "always"]
+
+
+class DiagnosisConfig(BaseModel):
+    """Configuration for detectors in an experiment.
+
+    Attributes:
+        trigger: When to run diagnosis — "on_failure" or "always".
+        model: The model to use for diagnosis.
+        confidence_threshold: Minimum confidence level for failure detection.
+    """
+
+    trigger: DiagnosisTrigger = "on_failure"
+    model: Model | str | None = None
+    confidence_threshold: ConfidenceLevel = "medium"
+
+    model_config = {"arbitrary_types_allowed": True}
 
 
 class FailureItem(BaseModel):
@@ -50,6 +70,26 @@ class RCAOutput(BaseModel):
     """Output from analyze_root_cause()."""
 
     root_causes: list[RCAItem] = Field(default_factory=list)
+
+
+class DiagnosisResult(BaseModel):
+    """Output from diagnose_session()."""
+
+    session_id: str
+    failures: list[FailureItem] = Field(default_factory=list)
+    root_causes: list[RCAItem] = Field(default_factory=list)
+
+    @property
+    def recommendations(self) -> list[str]:
+        """Deduplicated fix recommendations from all root causes."""
+        seen: set[str] = set()
+        result: list[str] = []
+        for rc in self.root_causes:
+            rec = rc.fix_recommendation.strip()
+            if rec and rec not in seen:
+                result.append(rec)
+                seen.add(rec)
+        return result
 
 
 class FailureError(BaseModel):

--- a/src/strands_evals/types/evaluation_report.py
+++ b/src/strands_evals/types/evaluation_report.py
@@ -27,6 +27,8 @@ class EvaluationReport(BaseModel):
     test_passes: list[bool]
     reasons: list[str] = []
     detailed_results: list[list[EvaluationOutput]] = []
+    diagnoses: list[dict | None] = []
+    recommendations: list[str | None] = []
 
     @classmethod
     def flatten(cls, reports: list["EvaluationReport"]) -> "EvaluationReport":
@@ -34,7 +36,7 @@ class EvaluationReport(BaseModel):
         if not reports:
             return cls(overall_score=0.0, scores=[], cases=[], test_passes=[])
 
-        scores, cases, passes, reasons, detailed = [], [], [], [], []
+        scores, cases, passes, reasons, detailed, diags, recs = [], [], [], [], [], [], []
 
         for report in reports:
             evaluator = report.evaluator_name or "Unknown"
@@ -44,6 +46,8 @@ class EvaluationReport(BaseModel):
                 passes.append(report.test_passes[i] if i < len(report.test_passes) else False)
                 reasons.append(report.reasons[i] if i < len(report.reasons) else "")
                 detailed.append(report.detailed_results[i] if i < len(report.detailed_results) else [])
+                diags.append(report.diagnoses[i] if i < len(report.diagnoses) else None)
+                recs.append(report.recommendations[i] if i < len(report.recommendations) else None)
 
         return cls(
             evaluator_name="Combined",
@@ -53,6 +57,8 @@ class EvaluationReport(BaseModel):
             test_passes=passes,
             reasons=reasons,
             detailed_results=detailed,
+            diagnoses=diags,
+            recommendations=recs,
         )
 
     @staticmethod
@@ -95,6 +101,7 @@ class EvaluationReport(BaseModel):
         include_actual_interactions: bool = False,
         include_expected_interactions: bool = False,
         include_meta: bool = False,
+        include_recommendations: bool = False,
     ):
         """
         Render an interface of the report with as much details as configured using Rich.
@@ -109,6 +116,7 @@ class EvaluationReport(BaseModel):
             include_actual_interactions (Defaults to False): Include the actual interactions in the display.
             include_expected_interactions (Defaults to False): Include the expected interactions in the display.
             include_meta (Defaults to False): Include metadata in the display.
+            include_recommendations (Defaults to False): Include diagnosis recommendations in the display.
 
         Note:
             This method provides an interactive console interface where users can expand or collapse
@@ -141,6 +149,10 @@ class EvaluationReport(BaseModel):
                 details_dict["expected_interactions"] = str(self.cases[i].get("expected_interactions"))
             if include_meta:
                 details_dict["metadata"] = str(self.cases[i].get("metadata"))
+            if include_recommendations:
+                rec = self.recommendations[i] if i < len(self.recommendations) else None
+                if rec is not None:
+                    details_dict["recommendation"] = rec
 
             report_data[str(i)] = {
                 "details": details_dict,
@@ -161,6 +173,7 @@ class EvaluationReport(BaseModel):
         include_actual_interactions: bool = False,
         include_expected_interactions: bool = False,
         include_meta: bool = False,
+        include_recommendations: bool = False,
     ):
         """
         Render the report with as much details as configured using Rich. Use run_display if want
@@ -175,6 +188,7 @@ class EvaluationReport(BaseModel):
             include_actual_interactions (Defaults to False): Include the actual interactions in the display.
             include_expected_interactions (Defaults to False): Include the expected interactions in the display.
             include_meta (Defaults to False): Include metadata in the display.
+            include_recommendations (Defaults to False): Include diagnosis recommendations in the display.
         """
         self._display(
             static=True,
@@ -186,6 +200,7 @@ class EvaluationReport(BaseModel):
             include_actual_interactions=include_actual_interactions,
             include_expected_interactions=include_expected_interactions,
             include_meta=include_meta,
+            include_recommendations=include_recommendations,
         )
 
     def run_display(
@@ -198,6 +213,7 @@ class EvaluationReport(BaseModel):
         include_actual_interactions: bool = False,
         include_expected_interactions: bool = False,
         include_meta: bool = False,
+        include_recommendations: bool = False,
     ):
         """
         Render the report interactively with as much details as configured using Rich.
@@ -211,6 +227,7 @@ class EvaluationReport(BaseModel):
             include_actual_interactions (Defaults to False): Include the actual interactions in the display.
             include_expected_interactions (Defaults to False): Include the expected interactions in the display.
             include_meta (Defaults to False): Include metadata in the display.
+            include_recommendations (Defaults to False): Include diagnosis recommendations in the display.
         """
         self._display(
             static=False,
@@ -222,6 +239,7 @@ class EvaluationReport(BaseModel):
             include_actual_interactions=include_actual_interactions,
             include_expected_interactions=include_expected_interactions,
             include_meta=include_meta,
+            include_recommendations=include_recommendations,
         )
 
     def to_dict(self):

--- a/tests/strands_evals/detectors/test_diagnosis.py
+++ b/tests/strands_evals/detectors/test_diagnosis.py
@@ -1,0 +1,131 @@
+"""Tests for diagnosis module."""
+
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+
+from strands_evals.detectors.diagnosis import diagnose_session
+from strands_evals.types.detector import (
+    DiagnosisResult,
+    FailureItem,
+    FailureOutput,
+    RCAItem,
+    RCAOutput,
+)
+from strands_evals.types.trace import (
+    AgentInvocationSpan,
+    InferenceSpan,
+    Session,
+    SpanInfo,
+    TextContent,
+    ToolConfig,
+    Trace,
+    UserMessage,
+)
+
+
+def _span_info(span_id: str = "span_1") -> SpanInfo:
+    now = datetime.now()
+    return SpanInfo(session_id="sess_1", span_id=span_id, trace_id="trace_1", start_time=now, end_time=now)
+
+
+def _make_session() -> Session:
+    spans = [
+        AgentInvocationSpan(
+            span_info=_span_info("span_1"),
+            user_prompt="Hello",
+            agent_response="Hi there",
+            available_tools=[ToolConfig(name="search")],
+        ),
+        InferenceSpan(
+            span_info=_span_info("span_2"),
+            messages=[UserMessage(content=[TextContent(text="Hello")])],
+        ),
+    ]
+    return Session(
+        session_id="sess_1",
+        traces=[Trace(trace_id="trace_1", session_id="sess_1", spans=spans)],
+    )
+
+
+class TestDiagnoseSession:
+    @patch("strands_evals.detectors.diagnosis.detect_failures")
+    def test_no_failures_skips_rca(self, mock_detect):
+        mock_detect.return_value = FailureOutput(session_id="sess_1", failures=[])
+        session = _make_session()
+
+        result = diagnose_session(session)
+
+        assert isinstance(result, DiagnosisResult)
+        assert result.session_id == "sess_1"
+        assert result.failures == []
+        assert result.root_causes == []
+
+    @patch("strands_evals.detectors.diagnosis.analyze_root_cause")
+    @patch("strands_evals.detectors.diagnosis.detect_failures")
+    def test_with_failures_runs_rca(self, mock_detect, mock_rca):
+        failures = [
+            FailureItem(span_id="span_1", category=["hallucination"], confidence=[0.9], evidence=["made up data"])
+        ]
+        mock_detect.return_value = FailureOutput(session_id="sess_1", failures=failures)
+        rca_items = [
+            RCAItem(
+                failure_span_id="span_1",
+                location="span_1",
+                causality="PRIMARY_FAILURE",
+                propagation_impact=["QUALITY_DEGRADATION"],
+                root_cause_explanation="Bad tool output",
+                fix_type="TOOL_DESCRIPTION_FIX",
+                fix_recommendation="Improve tool description",
+            )
+        ]
+        mock_rca.return_value = RCAOutput(root_causes=rca_items)
+        session = _make_session()
+
+        result = diagnose_session(session)
+
+        assert len(result.failures) == 1
+        assert len(result.root_causes) == 1
+        assert result.root_causes[0].fix_recommendation == "Improve tool description"
+        mock_rca.assert_called_once()
+
+    @patch("strands_evals.detectors.diagnosis.detect_failures")
+    def test_passes_model_and_threshold(self, mock_detect):
+        mock_detect.return_value = FailureOutput(session_id="sess_1", failures=[])
+        session = _make_session()
+        mock_model = MagicMock()
+
+        diagnose_session(session, model=mock_model, confidence_threshold="high")
+
+        mock_detect.assert_called_once_with(
+            session,
+            confidence_threshold="high",
+            model=mock_model,
+        )
+
+    @patch("strands_evals.detectors.diagnosis.analyze_root_cause")
+    @patch("strands_evals.detectors.diagnosis.detect_failures")
+    def test_passes_model_to_rca(self, mock_detect, mock_rca):
+        failures = [FailureItem(span_id="s1", category=["error"], confidence=[0.9], evidence=["e"])]
+        mock_detect.return_value = FailureOutput(session_id="sess_1", failures=failures)
+        mock_rca.return_value = RCAOutput(root_causes=[])
+        session = _make_session()
+        mock_model = MagicMock()
+
+        diagnose_session(session, model=mock_model)
+
+        mock_rca.assert_called_once_with(session, failures=failures, model=mock_model)
+
+    @patch("strands_evals.detectors.diagnosis.detect_failures")
+    def test_serialization_round_trip(self, mock_detect):
+        mock_detect.return_value = FailureOutput(session_id="sess_1", failures=[])
+        session = _make_session()
+
+        result = diagnose_session(session)
+        dumped = result.model_dump()
+
+        assert dumped["session_id"] == "sess_1"
+        assert dumped["failures"] == []
+        assert dumped["root_causes"] == []
+
+        restored = DiagnosisResult.model_validate(dumped)
+        assert restored == result

--- a/tests/strands_evals/detectors/test_types.py
+++ b/tests/strands_evals/detectors/test_types.py
@@ -1,6 +1,7 @@
 """Tests for detector Pydantic models."""
 
 from strands_evals.types.detector import (
+    DiagnosisResult,
     FailureDetectionStructuredOutput,
     FailureError,
     FailureItem,
@@ -162,3 +163,44 @@ def test_failure_output_serialization_roundtrip():
     restored = FailureOutput.model_validate_json(json_str)
     assert restored.session_id == "sess_1"
     assert restored.failures[0].confidence[0] == 0.9
+
+
+def test_diagnosis_result_recommendations():
+    """Test that recommendations property extracts and deduplicates fix_recommendations."""
+    result = DiagnosisResult(
+        session_id="sess_1",
+        root_causes=[
+            RCAItem(
+                failure_span_id="s1",
+                location="s0",
+                causality="PRIMARY_FAILURE",
+                root_cause_explanation="Bad tool output",
+                fix_type="TOOL_DESCRIPTION_FIX",
+                fix_recommendation="Add disambiguation instructions",
+            ),
+            RCAItem(
+                failure_span_id="s2",
+                location="s0",
+                causality="SECONDARY_FAILURE",
+                root_cause_explanation="Missing context",
+                fix_type="SYSTEM_PROMPT_FIX",
+                fix_recommendation="Add disambiguation instructions",
+            ),
+            RCAItem(
+                failure_span_id="s3",
+                location="s1",
+                causality="PRIMARY_FAILURE",
+                root_cause_explanation="Hallucination",
+                fix_type="SYSTEM_PROMPT_FIX",
+                fix_recommendation="Add grounding examples",
+            ),
+        ],
+    )
+    recs = result.recommendations
+    assert recs == ["Add disambiguation instructions", "Add grounding examples"]
+
+
+def test_diagnosis_result_recommendations_empty():
+    """Recommendations should be empty when there are no root causes."""
+    result = DiagnosisResult(session_id="sess_1")
+    assert result.recommendations == []

--- a/tests/strands_evals/test_experiment.py
+++ b/tests/strands_evals/test_experiment.py
@@ -6,7 +6,7 @@ from botocore.exceptions import ClientError
 from strands.models.model import Model
 from strands.types.exceptions import EventLoopException, ModelThrottledException
 
-from strands_evals import Case, Experiment
+from strands_evals import Case, DiagnosisConfig, Experiment
 from strands_evals.evaluators import (
     Contains,
     Equals,
@@ -1860,3 +1860,161 @@ class TestProviderIntegration:
 
         assert len(reports) == 1
         assert reports[0].scores == [1.0]
+
+
+class TestDiagnoseOnFailure:
+    def _make_session(self):
+        from datetime import datetime
+
+        from strands_evals.types.trace import (
+            AgentInvocationSpan,
+            Session,
+            SpanInfo,
+            ToolConfig,
+            Trace,
+        )
+
+        now = datetime.now()
+        info = SpanInfo(session_id="sess_1", span_id="span_1", trace_id="trace_1", start_time=now, end_time=now)
+        spans = [
+            AgentInvocationSpan(
+                span_info=info,
+                user_prompt="Hello",
+                agent_response="Hi",
+                available_tools=[ToolConfig(name="search")],
+            ),
+        ]
+        return Session(
+            session_id="sess_1",
+            traces=[Trace(trace_id="trace_1", session_id="sess_1", spans=spans)],
+        )
+
+    def test_diagnosis_disabled_when_no_diagnosis_config(self):
+        """When diagnosis_config is not set, diagnoses and recommendations should be empty."""
+        cases = [Case(name="fail", input="foo", expected_output="bar")]
+        experiment = Experiment(cases=cases, evaluators=[MockEvaluator()])
+
+        reports = experiment.run_evaluations(lambda c: c.input)
+
+        assert len(reports) == 1
+        assert reports[0].diagnoses == [None]
+        assert reports[0].recommendations == [None]
+
+    @patch("strands_evals.experiment.Experiment._run_diagnosis")
+    def test_diagnosis_config_on_failure_calls_diagnosis_for_failing_case(self, mock_run_diag):
+        """When diagnosis_config is set, diagnosis runs on failing cases."""
+        mock_run_diag.return_value = (
+            {
+                "session_id": "sess_1",
+                "failures": [{"span_id": "s1", "category": ["error"], "confidence": [0.9], "evidence": ["e"]}],
+                "root_causes": [],
+            },
+            "Add disambiguation instructions",
+        )
+
+        session = self._make_session()
+        cases = [Case(name="fail", input="foo", expected_output="bar")]
+        experiment = Experiment(
+            cases=cases,
+            evaluators=[MockEvaluator()],
+            diagnosis_config=DiagnosisConfig(),
+        )
+
+        def task_returning_session(c):
+            return {"output": c.input, "trajectory": session}
+
+        reports = experiment.run_evaluations(task_returning_session)
+
+        assert len(reports) == 1
+        assert reports[0].diagnoses[0] is not None
+        assert reports[0].diagnoses[0]["session_id"] == "sess_1"
+        assert reports[0].recommendations[0] == "Add disambiguation instructions"
+        mock_run_diag.assert_called_once()
+
+    @patch("strands_evals.experiment.Experiment._run_diagnosis")
+    def test_diagnosis_config_on_failure_skips_passing_case(self, mock_run_diag):
+        """When trigger is on_failure and case passes, diagnosis should not run."""
+        cases = [Case(name="pass", input="hello", expected_output="hello")]
+        experiment = Experiment(
+            cases=cases,
+            evaluators=[MockEvaluator()],
+            diagnosis_config=DiagnosisConfig(),
+        )
+
+        reports = experiment.run_evaluations(lambda c: c.input)
+
+        assert len(reports) == 1
+        assert reports[0].diagnoses == [None]
+        assert reports[0].recommendations == [None]
+        mock_run_diag.assert_not_called()
+
+    def test_diagnosis_config_returns_none_for_non_session_trajectory(self):
+        """Diagnosis should return None when trajectory is not a Session."""
+        cases = [Case(name="fail", input="foo", expected_output="bar")]
+        experiment = Experiment(
+            cases=cases,
+            evaluators=[MockEvaluator()],
+            diagnosis_config=DiagnosisConfig(),
+        )
+
+        def task_with_list_trajectory(c):
+            return {"output": c.input, "trajectory": ["step1", "step2"]}
+
+        reports = experiment.run_evaluations(task_with_list_trajectory)
+
+        assert len(reports) == 1
+        assert reports[0].diagnoses == [None]
+        assert reports[0].recommendations == [None]
+
+    @patch("strands_evals.experiment.Experiment._run_diagnosis")
+    def test_diagnosis_config_with_multiple_evaluators(self, mock_run_diag):
+        """Diagnosis runs once per case, result shared across evaluator reports."""
+        mock_run_diag.return_value = (
+            {"session_id": "s1", "failures": [], "root_causes": []},
+            "Fix the prompt",
+        )
+        session = self._make_session()
+
+        class AlwaysFailEvaluator(Evaluator[str, str]):
+            def evaluate(self, evaluation_case):
+                return [EvaluationOutput(score=0.0, test_pass=False, reason="fail")]
+
+        cases = [Case(name="fail", input="foo", expected_output="bar")]
+        experiment = Experiment(
+            cases=cases,
+            evaluators=[AlwaysFailEvaluator(), MockEvaluator2()],
+            diagnosis_config=DiagnosisConfig(),
+        )
+
+        def task_with_session(c):
+            return {"output": c.input, "trajectory": session}
+
+        reports = experiment.run_evaluations(task_with_session)
+
+        assert len(reports) == 2
+        # Both reports share the same diagnosis and recommendation
+        assert reports[0].diagnoses[0] == reports[1].diagnoses[0]
+        assert reports[0].recommendations[0] == reports[1].recommendations[0] == "Fix the prompt"
+        mock_run_diag.assert_called_once()
+
+    @patch("strands_evals.experiment.diagnose_session")
+    def test_diagnosis_exception_returns_none(self, mock_diagnose):
+        """If diagnosis throws, it should be caught and return None for both fields."""
+        mock_diagnose.side_effect = RuntimeError("LLM unavailable")
+        session = self._make_session()
+
+        cases = [Case(name="fail", input="foo", expected_output="bar")]
+        experiment = Experiment(
+            cases=cases,
+            evaluators=[MockEvaluator()],
+            diagnosis_config=DiagnosisConfig(),
+        )
+
+        def task_with_session(c):
+            return {"output": c.input, "trajectory": session}
+
+        reports = experiment.run_evaluations(task_with_session)
+
+        assert len(reports) == 1
+        assert reports[0].diagnoses == [None]
+        assert reports[0].recommendations == [None]

--- a/tests/strands_evals/types/test_evaluation_report.py
+++ b/tests/strands_evals/types/test_evaluation_report.py
@@ -251,6 +251,35 @@ class TestEvaluationReportFlatten:
         assert len(flattened.detailed_results) == 1
         assert flattened.detailed_results[0] == detailed
 
+    def test_flatten_preserves_diagnoses_and_recommendations(self):
+        """Test that flatten preserves diagnoses and recommendations."""
+        report1 = EvaluationReport(
+            evaluator_name="Eval1",
+            overall_score=0.0,
+            scores=[0.0],
+            cases=[{"name": "case-1"}],
+            test_passes=[False],
+            diagnoses=[{"session_id": "s1", "failures": [], "root_causes": []}],
+            recommendations=["Fix the prompt"],
+        )
+        report2 = EvaluationReport(
+            evaluator_name="Eval2",
+            overall_score=1.0,
+            scores=[1.0],
+            cases=[{"name": "case-2"}],
+            test_passes=[True],
+            diagnoses=[None],
+            recommendations=[None],
+        )
+
+        flattened = EvaluationReport.flatten([report1, report2])
+
+        assert len(flattened.diagnoses) == 2
+        assert flattened.diagnoses[0] == {"session_id": "s1", "failures": [], "root_causes": []}
+        assert flattened.diagnoses[1] is None
+        assert flattened.recommendations[0] == "Fix the prompt"
+        assert flattened.recommendations[1] is None
+
     def test_flatten_does_not_modify_original(self):
         """Test that flatten does not modify the original reports."""
         original_case = {"name": "case-1", "input": "test"}


### PR DESCRIPTION
## Summary

Integrates the detection pipeline (`detect_failures` → `analyze_root_cause`) into the `Experiment` evaluation workflow so that failing cases are automatically diagnosed and fix recommendations surface directly in the report.

### What's new

- **`diagnose_session()`** — single-call pipeline that runs failure detection followed by root cause analysis on a `Session`. Returns a `DiagnosisResult` with failures, root causes, and deduplicated recommendations.
- **`DiagnosisResult`** — Pydantic model with a `recommendations` property that extracts and deduplicates fix strings from all root causes.
- **`DiagnosisConfig`** — groups all diagnosis-related parameters into a single config object:
  - `trigger: DiagnosisTrigger = "on_failure"` — when to run diagnosis (`"on_failure"` or `"always"`)
  - `model: Model | str | None = None` — override the LLM used for diagnosis
  - `confidence_threshold: ConfidenceLevel = "medium"` — minimum confidence for failure detection
- **`Experiment` integration** — accepts an optional `diagnosis_config: DiagnosisConfig` parameter. When `None` (the default), diagnosis is disabled. When provided, diagnosis runs according to the trigger setting.
- **`EvaluationReport`** — two new fields: `diagnoses: list[dict | None]` and `recommendations: list[str | None]`, populated per-case (shared across evaluator reports).
- Diagnosis runs once per failing case (not per evaluator) to avoid duplicate LLM calls, then results are shared across all evaluator reports for that case.

### Usage

**Standalone diagnosis:**
```python
from strands_evals.detectors import diagnose_session

result = diagnose_session(session, confidence_threshold="low")

for rc in result.root_causes:
    print(f"{rc.root_cause_explanation}")
    print(f"  Fix ({rc.fix_type}): {rc.fix_recommendation}")

for rec in result.recommendations:
    print(rec)
```

**Integrated with Experiment:**
```python
from strands_evals import DiagnosisConfig, Experiment

# Diagnose on failure (default trigger)
experiment = Experiment(
    cases=test_cases,
    evaluators=[evaluator],
    diagnosis_config=DiagnosisConfig(),
)

# Always diagnose, with custom model
experiment = Experiment(
    cases=test_cases,
    evaluators=[evaluator],
    diagnosis_config=DiagnosisConfig(trigger="always", model="claude-haiku"),
)

reports = experiment.run_evaluations(task_fn)
report = reports[0]

for i in range(len(report.scores)):
    if not report.test_passes[i]:
        print(f"Recommendation: {report.recommendations[i]}")
        print(f"Diagnosis: {report.diagnoses[i]}")
```

## Testing

- 5 unit tests for `diagnose_session()` (skips RCA when no failures, passes model/threshold, serialization round-trip)
- 2 unit tests for `DiagnosisResult.recommendations` (deduplication, empty case)
- 6 unit tests for `Experiment` integration (disabled when no config, calls diagnosis for failing cases, skips passing cases, handles non-Session trajectory, shared across evaluators, exception handling)

```
pytest tests/strands_evals/detectors/test_diagnosis.py tests/strands_evals/detectors/test_types.py tests/strands_evals/test_experiment.py::TestDiagnoseOnFailure -v
```

All 13 tests pass.

## Type of Change

New feature

## Checklist
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published