### PR TITLE
chore(detectors): included more fields to the RCAItem

### DIFF
--- a/src/strands_evals/detectors/root_cause_analyzer.py
+++ b/src/strands_evals/detectors/root_cause_analyzer.py
@@ -210,6 +210,8 @@ def _parse_structured_result(output: RCAStructuredOutput) -> list[RCAItem]:
                 location=rc.location,
                 causality=rc.failure_causality,
                 propagation_impact=list(rc.failure_propagation_impact),
+                failure_detection_timing=rc.failure_detection_timing,
+                completion_status=rc.completion_status,
                 root_cause_explanation=rc.root_cause_explanation,
                 fix_type=rc.fix_recommendation.fix_type,
                 fix_recommendation=rc.fix_recommendation.recommendation,

--- a/src/strands_evals/types/detector.py
+++ b/src/strands_evals/types/detector.py
@@ -61,6 +61,10 @@ class RCAItem(BaseModel):
     location: str = Field(description="Span where root cause originated")
     causality: str = Field(description="PRIMARY_FAILURE | SECONDARY_FAILURE | TERTIARY_FAILURE")
     propagation_impact: list[str] = Field(default_factory=list)
+    failure_detection_timing: str = Field(
+        description="IMMEDIATELY_AT_OCCURRENCE | SEVERAL_STEPS_LATER | ONLY_AT_TASK_END | SILENT_UNDETECTED"
+    )
+    completion_status: str = Field(description="COMPLETE_SUCCESS | PARTIAL_SUCCESS | COMPLETE_FAILURE")
     root_cause_explanation: str
     fix_type: str = Field(description="SYSTEM_PROMPT_FIX | TOOL_DESCRIPTION_FIX | OTHERS")
     fix_recommendation: str

--- a/tests/strands_evals/detectors/test_diagnosis.py
+++ b/tests/strands_evals/detectors/test_diagnosis.py
@@ -73,6 +73,8 @@ class TestDiagnoseSession:
                 location="span_1",
                 causality="PRIMARY_FAILURE",
                 propagation_impact=["QUALITY_DEGRADATION"],
+                failure_detection_timing="IMMEDIATELY_AT_OCCURRENCE",
+                completion_status="PARTIAL_SUCCESS",
                 root_cause_explanation="Bad tool output",
                 fix_type="TOOL_DESCRIPTION_FIX",
                 fix_recommendation="Improve tool description",

--- a/tests/strands_evals/detectors/test_types.py
+++ b/tests/strands_evals/detectors/test_types.py
@@ -51,12 +51,16 @@ def test_rca_item_creation():
         location="span_0",
         causality="PRIMARY_FAILURE",
         propagation_impact=["TASK_TERMINATION"],
+        failure_detection_timing="IMMEDIATELY_AT_OCCURRENCE",
+        completion_status="COMPLETE_FAILURE",
         root_cause_explanation="The tool returned ambiguous results",
         fix_type="TOOL_DESCRIPTION_FIX",
         fix_recommendation="Add disambiguation instructions",
     )
     assert item.failure_span_id == "span_1"
     assert item.causality == "PRIMARY_FAILURE"
+    assert item.failure_detection_timing == "IMMEDIATELY_AT_OCCURRENCE"
+    assert item.completion_status == "COMPLETE_FAILURE"
 
 
 def test_rca_output_empty():
@@ -174,6 +178,8 @@ def test_diagnosis_result_recommendations():
                 failure_span_id="s1",
                 location="s0",
                 causality="PRIMARY_FAILURE",
+                failure_detection_timing="IMMEDIATELY_AT_OCCURRENCE",
+                completion_status="PARTIAL_SUCCESS",
                 root_cause_explanation="Bad tool output",
                 fix_type="TOOL_DESCRIPTION_FIX",
                 fix_recommendation="Add disambiguation instructions",
@@ -182,6 +188,8 @@ def test_diagnosis_result_recommendations():
                 failure_span_id="s2",
                 location="s0",
                 causality="SECONDARY_FAILURE",
+                failure_detection_timing="SEVERAL_STEPS_LATER",
+                completion_status="PARTIAL_SUCCESS",
                 root_cause_explanation="Missing context",
                 fix_type="SYSTEM_PROMPT_FIX",
                 fix_recommendation="Add disambiguation instructions",
@@ -190,6 +198,8 @@ def test_diagnosis_result_recommendations():
                 failure_span_id="s3",
                 location="s1",
                 causality="PRIMARY_FAILURE",
+                failure_detection_timing="SILENT_UNDETECTED",
+                completion_status="COMPLETE_FAILURE",
                 root_cause_explanation="Hallucination",
                 fix_type="SYSTEM_PROMPT_FIX",
                 fix_recommendation="Add grounding examples",


### PR DESCRIPTION
## Description

Adds `failure_detection_timing` and `completion_status` fields to `RCAItem`, the public API output type for root cause analysis.

These fields were already produced by the LLM (present in `RootCauseItem` / `RCAStructuredOutput`) but were being dropped in `_parse_structured_result` when mapping to the simplified `RCAItem`. Now they flow through to callers.

**Why:**
- `failure_detection_timing` (e.g. `SILENT_UNDETECTED`) signals stealth bugs vs. obvious errors — qualitatively useful for prioritizing fixes.
- `completion_status` per root cause tells you which failures were recovered vs. which sank the task — useful when multiple root causes exist and you need to triage.

**Changes:**
- `src/strands_evals/types/detector.py` — added two fields to `RCAItem`
- `src/strands_evals/detectors/root_cause_analyzer.py` — updated `_parse_structured_result` to pass the fields through
- `tests/strands_evals/detectors/test_types.py` — updated `RCAItem` constructions with new required fields
- `tests/strands_evals/detectors/test_diagnosis.py` — same

## Type of Change

New feature (non-breaking additive fields)

## Testing

- [x] All detector unit tests pass (`pytest tests/strands_evals/detectors/ -v` — 18 passed)

## Checklist
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] My changes generate no new warnings