### PR TITLE
fix(experiment): preserve input order in run_evaluations_async

### DIFF
--- a/src/strands_evals/experiment.py
+++ b/src/strands_evals/experiment.py
@@ -456,18 +456,18 @@ class Experiment(Generic[InputT, OutputT]):
         Worker that processes cases from the queue. Run evaluation on the task.
 
         Args:
-            queue: Queue containing cases to process
+            queue: Queue containing (index, case) tuples to process
             task: Task function to run on each case
             results: List to store results
             evaluation_data_store: Optional store for loading/saving evaluation data
         """
         while True:
             try:
-                case = queue.get_nowait()
+                index, case = queue.get_nowait()
             except asyncio.QueueEmpty:
                 break
 
-            case_name = case.name or f"case_{len(results)}"
+            case_name = case.name or f"case_{index}"
             trace_id = None
 
             try:
@@ -510,14 +510,12 @@ class Experiment(Generic[InputT, OutputT]):
                                 diagnosis, recommendation = await self._run_diagnosis(evaluation_context, case_name)
 
                         # Store results
-                        results.append(
-                            {
-                                "case": evaluation_context.model_dump(),
-                                "evaluator_results": evaluator_results,
-                                "diagnosis": diagnosis,
-                                "recommendation": recommendation,
-                            }
-                        )
+                        results[index] = {
+                            "case": evaluation_context.model_dump(),
+                            "evaluator_results": evaluator_results,
+                            "diagnosis": diagnosis,
+                            "recommendation": recommendation,
+                        }
 
                     except Exception as e:
                         case_span.record_exception(e)
@@ -533,14 +531,12 @@ class Experiment(Generic[InputT, OutputT]):
                                     "detailed_results": [],
                                 }
                             )
-                        results.append(
-                            {
-                                "case": case.model_dump(),
-                                "evaluator_results": evaluator_results,
-                                "diagnosis": None,
-                                "recommendation": None,
-                            }
-                        )
+                        results[index] = {
+                            "case": case.model_dump(),
+                            "evaluator_results": evaluator_results,
+                            "diagnosis": None,
+                            "recommendation": None,
+                        }
             finally:
                 queue.task_done()
 
@@ -592,11 +588,11 @@ class Experiment(Generic[InputT, OutputT]):
         if evaluation_data_store is not None:
             self._validate_case_names()
 
-        queue: asyncio.Queue[Case[InputT, OutputT]] = asyncio.Queue()
-        results: list[Any] = []
+        queue: asyncio.Queue[tuple[int, Case[InputT, OutputT]]] = asyncio.Queue()
+        results: list[Any] = [None] * len(self._cases)
 
-        for case in self._cases:
-            queue.put_nowait(case)
+        for i, case in enumerate(self._cases):
+            queue.put_nowait((i, case))
 
         num_workers = min(max_workers, len(self._cases))
 

--- a/tests/strands_evals/test_experiment.py
+++ b/tests/strands_evals/test_experiment.py
@@ -787,6 +787,32 @@ async def test_experiment_run_evaluations_async_with_async_task():
 
 
 @pytest.mark.asyncio
+async def test_experiment_run_evaluations_async_preserves_input_order():
+    """Test that run_evaluations_async returns results in input order regardless of completion order"""
+    import random
+
+    cases = [
+        Case(name=f"case_{i}", input=f"input_{i}", expected_output=f"input_{i}")
+        for i in range(10)
+    ]
+    experiment = Experiment(cases=cases, evaluators=[MockEvaluator()])
+
+    async def variable_delay_task(c):
+        await asyncio.sleep(random.uniform(0.01, 0.1))
+        return c.input
+
+    reports = await experiment.run_evaluations_async(variable_delay_task, max_workers=5)
+
+    assert len(reports) == 1
+    report = reports[0]
+    for i, case_data in enumerate(report.cases):
+        assert case_data["name"] == f"case_{i}", (
+            f"report.cases[{i}] has name '{case_data['name']}', expected 'case_{i}'"
+        )
+        assert case_data["input"] == f"input_{i}"
+
+
+@pytest.mark.asyncio
 async def test_experiment_run_evaluations_async_with_errors():
     """Test run_evaluations_async handles errors gracefully"""
 


### PR DESCRIPTION
## Description

`run_evaluations_async` with `max_workers > 1` returned results in worker completion order rather than input order. This silently corrupted evaluation data — scores, pass/fail verdicts, and actual outputs got attributed to the wrong test cases.

The fix pre-allocates the results list and uses direct index assignment (`results[index] = ...`) so each case's result is placed at its original position regardless of when the worker completes.

## Related Issues

Closes #198

## Type of Change

Bug fix

## Testing

- Added `test_experiment_run_evaluations_async_preserves_input_order` which runs 10 cases with random delays across 5 workers and asserts `report.cases[i].name == f"case_{i}"` for all i.
- All existing tests continue to pass.

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.