### PR TITLE
fix(evaluators): update default judge model to Claude Sonnet 4.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ from strands_evals.evaluators import OutputEvaluator
 evaluator = OutputEvaluator(
     rubric="Score 1.0 for accurate, complete responses. Score 0.5 for partial answers. Score 0.0 for incorrect or unhelpful responses.",
     include_inputs=True,  # Include context in evaluation
-    model="us.anthropic.claude-sonnet-4-20250514-v1:0"  # Custom judge model
+    model="global.anthropic.claude-sonnet-4-6"  # Custom judge model
 )
 ```
 

--- a/src/strands_evals/evaluators/evaluator.py
+++ b/src/strands_evals/evaluators/evaluator.py
@@ -21,7 +21,7 @@ from ..types.trace import (
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_BEDROCK_MODEL_ID = "us.anthropic.claude-sonnet-4-20250514-v1:0"
+DEFAULT_BEDROCK_MODEL_ID = "global.anthropic.claude-sonnet-4-6"
 
 
 class Evaluator(Generic[InputT, OutputT]):


### PR DESCRIPTION
## Description

Claude Sonnet 4 (us.anthropic.claude-sonnet-4-20250514-v1:0) is now in legacy mode on Amazon Bedrock and will eventually be retired. When that happens, all 10 LLM-based evaluators that rely on the default model would silently fail since Experiment._run_evaluator() catches exceptions and records them as score: 0 results.

Update DEFAULT_BEDROCK_MODEL_ID to global.anthropic.claude-sonnet-4-6, matching the default used in the main Strands agents SDK (sdk-python/src/strands/models/bedrock.py). Also update the README example to reference the new model ID.



## Related Issues

Closes #200

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

Bug fix
Breaking change

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [ ] I ran `hatch run prepare`

## Checklist
- [ ] I have read the CONTRIBUTING document
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.