### PR TITLE
chore(detectors): update import to include DiagnosisTrigger

### DIFF
--- a/src/strands_evals/detectors/__init__.py
+++ b/src/strands_evals/detectors/__init__.py
@@ -9,6 +9,7 @@ from ..types.detector import (
     ConfidenceLevel,
     DiagnosisConfig,
     DiagnosisResult,
+    DiagnosisTrigger,
     FailureDetectionStructuredOutput,
     FailureItem,
     FailureOutput,
@@ -28,6 +29,7 @@ __all__ = [
     "diagnose_session",
     "DiagnosisConfig",
     "DiagnosisResult",
+    "DiagnosisTrigger",
     # Types
     "ConfidenceLevel",
     "FailureOutput",


### PR DESCRIPTION
## Description
Instead of `from strands_evals.types.detector import DiagnosisTrigger`, use `from strands_evals.detectors import DiagnosisTrigger`

## Related Issues
N/A

## Documentation PR

N/A

## Type of Change

Chore update

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [ ] I ran `hatch run prepare`

## Checklist
- [ ] I have read the CONTRIBUTING document
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.