### PR TITLE
chore: allow importing EvaluationReport from root

### DIFF
--- a/src/strands_evals/__init__.py
+++ b/src/strands_evals/__init__.py
@@ -7,6 +7,7 @@ from .local_file_task_result_store import LocalFileTaskResultStore
 from .simulation import ActorSimulator, UserSimulator
 from .telemetry import StrandsEvalsTelemetry, get_tracer
 from .types.detector import DiagnosisConfig
+from .types.evaluation_report import EvaluationReport
 
 __all__ = [
     "DiagnosisConfig",
@@ -14,6 +15,7 @@ __all__ = [
     "Case",
     "LocalFileTaskResultStore",
     "EvaluationDataStore",
+    "EvaluationReport",
     "EvalTaskHandler",
     "TracedHandler",
     "eval_task",


### PR DESCRIPTION
## Description
Allow importing `EvaluationReport` from root

## Related Issues

N/A

## Documentation PR

N/A

## Type of Change

Bug fix
New feature
Breaking change
Documentation update
Other (please describe):

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.