### PR TITLE
fix: joined tool_results to prevent context lost

### DIFF
--- a/src/strands_evals/mappers/cloudwatch_session_mapper.py
+++ b/src/strands_evals/mappers/cloudwatch_session_mapper.py
@@ -17,7 +17,7 @@ from datetime import datetime, timezone
 from typing import Any
 
 from ..mappers.session_mapper import SessionMapper
-from ..mappers.utils import get_body
+from ..mappers.utils import get_body, join_tool_result_content
 from ..types.trace import (
     AgentInvocationSpan,
     AssistantMessage,
@@ -305,24 +305,15 @@ class CloudWatchSessionMapper(SessionMapper):
             for item in parsed:
                 if isinstance(item, dict) and "toolResult" in item:
                     tr_data = item["toolResult"]
-                    result_text = self._extract_tool_result_text(tr_data.get("content"))
                     tool_results.append(
                         ToolResult(
-                            content=result_text,
+                            content=join_tool_result_content(tr_data.get("content")),
                             error=tr_data.get("error"),
                             tool_call_id=tr_data.get("toolUseId"),
                         )
                     )
 
         return tool_results
-
-    def _extract_tool_result_text(self, content: Any) -> str:
-        """Extract text from tool result content."""
-        if not content:
-            return ""
-        if isinstance(content, list) and content:
-            return content[0].get("text", "")
-        return str(content)
 
     # --- Body-to-messages conversion ---
 
@@ -392,10 +383,9 @@ class CloudWatchSessionMapper(SessionMapper):
             if "toolResult" not in item:
                 continue
             tool_result = item["toolResult"]
-            result_text = self._extract_tool_result_text(tool_result.get("content"))
             result.append(
                 ToolResultContent(
-                    content=result_text,
+                    content=join_tool_result_content(tool_result.get("content")),
                     error=tool_result.get("error"),
                     tool_call_id=tool_result.get("toolUseId"),
                 )

--- a/src/strands_evals/mappers/strands_in_memory_session_mapper.py
+++ b/src/strands_evals/mappers/strands_in_memory_session_mapper.py
@@ -24,6 +24,7 @@ from ..types.trace import (
     UserMessage,
 )
 from .session_mapper import SessionMapper
+from .utils import join_tool_result_content
 
 logger = logging.getLogger(__name__)
 
@@ -194,14 +195,9 @@ class StrandsInMemorySessionMapper(SessionMapper):
                 continue
 
             tool_result = item["toolResult"]
-            result_text = ""
-            if "content" in tool_result and tool_result["content"]:
-                content = tool_result["content"]
-                result_text = content[0].get("text", "") if isinstance(content, list) else str(content)
-
             result.append(
                 ToolResultContent(
-                    content=result_text,
+                    content=join_tool_result_content(tool_result.get("content")),
                     error=tool_result.get("error"),
                     tool_call_id=tool_result.get("toolUseId"),
                 )
@@ -324,21 +320,9 @@ class StrandsInMemorySessionMapper(SessionMapper):
                     content.append(TextContent(text=part.get("content", "")))
 
                 if part_type == "tool_call_response":
-                    # Extract text from response array if present
-                    response = part.get("response", [])
-                    response_text = ""
-
-                    ## To-do: Compare the differences for multiple toolResults
-                    if isinstance(response, list) and response:
-                        response_text = (
-                            response[0].get("text", "") if isinstance(response[0], dict) else str(response[0])
-                        )
-                    elif isinstance(response, str):
-                        response_text = response
-
                     content.append(
                         ToolResultContent(
-                            content=response_text,
+                            content=join_tool_result_content(part.get("response")),
                             tool_call_id=part.get("id"),
                         )
                     )
@@ -380,15 +364,7 @@ class StrandsInMemorySessionMapper(SessionMapper):
                             if output_messages and output_messages[0].get("parts"):
                                 part = output_messages[0]["parts"][0]
                                 if part.get("type") == "tool_call_response":
-                                    response = part.get("response", [])
-                                    if isinstance(response, list) and response:
-                                        tool_result_content = (
-                                            response[0].get("text", "")
-                                            if isinstance(response[0], dict)
-                                            else str(response[0])
-                                        )
-                                    elif isinstance(response, str):
-                                        tool_result_content = response
+                                    tool_result_content = join_tool_result_content(part.get("response"))
                 except Exception as e:
                     logger.warning(f"Failed to process tool event {event.name}: {e}")
         else:

--- a/src/strands_evals/mappers/utils.py
+++ b/src/strands_evals/mappers/utils.py
@@ -2,10 +2,48 @@
 Utility functions for mapper selection and detection.
 """
 
+import json
 from typing import Any
 
 from .constants import SCOPE_LANGCHAIN_OTEL, SCOPE_OPENINFERENCE, SCOPE_STRANDS
 from .session_mapper import SessionMapper
+
+
+def serialize_tool_result_block(block: Any) -> str:
+    """Serialize a single Bedrock-style tool result content block to text.
+
+    Handles text, json, image, document, and video block types so values in
+    any block are visible to evaluators (not just block[0]).
+    """
+    if not isinstance(block, dict):
+        return str(block) if block is not None else ""
+    if "text" in block:
+        return block["text"] or ""
+    if "json" in block:
+        try:
+            return json.dumps(block["json"], default=str)
+        except (TypeError, ValueError):
+            return str(block["json"])
+    for key in ("image", "document", "video"):
+        if key in block:
+            return f"[{key} content]"
+    return ""
+
+
+def join_tool_result_content(content: Any) -> str:
+    """Join every block of a tool result's content into a single string.
+
+    Replaces the prior `content[0]`-only behavior that hid values in
+    subsequent blocks from faithfulness/correctness judges.
+    """
+    if not content:
+        return ""
+    if isinstance(content, list):
+        parts = [serialize_tool_result_block(b) for b in content]
+        return "\n".join(p for p in parts if p)
+    if isinstance(content, str):
+        return content
+    return str(content)
 
 
 def detect_otel_mapper(spans: list[Any]) -> SessionMapper:

--- a/tests/strands_evals/mappers/test_cloudwatch_session_mapper.py
+++ b/tests/strands_evals/mappers/test_cloudwatch_session_mapper.py
@@ -245,3 +245,41 @@ class TestSessionBuilding:
         session = mapper.map_to_session(records, "sess-1")
         assert len(session.traces) == 1
         assert len(session.traces[0].spans) > 0
+
+    def test_multi_block_tool_result_preserves_all_blocks(self, mapper):
+        """Regression for #235: every block of toolResult.content reaches the evaluator."""
+        multi_block_msg = {
+            "role": "tool",
+            "content": {
+                "content": json.dumps(
+                    [
+                        {
+                            "toolResult": {
+                                "content": [{"text": "summary"}, {"text": "Output: 2"}],
+                                "toolUseId": "tu-1",
+                            }
+                        }
+                    ]
+                )
+            },
+        }
+        record1 = make_log_record(
+            trace_id="t1",
+            span_id="s1",
+            input_messages=[make_user_message("run it")],
+            output_messages=[_make_assistant_tool_use_message("runner", {}, "tu-1")],
+            time_nano=1000,
+        )
+        record2 = make_log_record(
+            trace_id="t1",
+            span_id="s2",
+            input_messages=[make_user_message("run it"), multi_block_msg],
+            output_messages=[make_assistant_text_message("done")],
+            time_nano=2000,
+        )
+
+        session = mapper.map_to_session([record1, record2], "sess-1")
+        tool_spans = [s for s in session.traces[0].spans if isinstance(s, ToolExecutionSpan)]
+        assert len(tool_spans) == 1
+        assert "summary" in tool_spans[0].tool_result.content
+        assert "Output: 2" in tool_spans[0].tool_result.content

--- a/tests/strands_evals/mappers/test_strands_in_memory_mapper.py
+++ b/tests/strands_evals/mappers/test_strands_in_memory_mapper.py
@@ -573,3 +573,134 @@ def test_session_id_filtering_gen_ai_conversation_id_takes_precedence(provider):
     # Should NOT match on session.id when gen_ai.conversation.id is present
     session2 = mapper.map_to_session([span], "session-456")
     assert len(session2.traces) == 0
+
+
+# Regression tests for issue #235: multi-block toolResult.content was dropped
+
+
+def test_legacy_tool_result_preserves_all_text_blocks(provider):
+    """Legacy convention: every text block in toolResult.content is included."""
+    span = make_span(
+        provider,
+        0xAAA,
+        0xBBB,
+        0xCCC,
+        "chat",
+        {"gen_ai.operation.name": "chat"},
+        lambda s: s.add_event(
+            "gen_ai.tool.message",
+            {
+                "content": (
+                    '[{"toolResult": {"toolUseId": "t1", "content": [{"text": "summary line"},{"text": "Output: 2"}]}}]'
+                )
+            },
+        ),
+    )
+
+    session = StrandsInMemorySessionMapper().map_to_session([span], "sid")
+
+    tool_result = session.traces[0].spans[0].messages[0].content[0]
+    assert "summary line" in tool_result.content
+    assert "Output: 2" in tool_result.content
+
+
+def test_legacy_tool_result_serializes_json_block(provider):
+    """Legacy convention: json blocks are serialized so values stay visible."""
+    span = make_span(
+        provider,
+        0xAAA,
+        0xBBB,
+        0xCCC,
+        "chat",
+        {"gen_ai.operation.name": "chat"},
+        lambda s: s.add_event(
+            "gen_ai.tool.message",
+            {
+                "content": (
+                    '[{"toolResult": {"toolUseId": "t1", "content": [{"text": "see data"},{"json": {"answer": 42}}]}}]'
+                )
+            },
+        ),
+    )
+
+    session = StrandsInMemorySessionMapper().map_to_session([span], "sid")
+
+    tool_result = session.traces[0].spans[0].messages[0].content[0]
+    assert "see data" in tool_result.content
+    assert '"answer": 42' in tool_result.content
+
+
+def test_latest_convention_tool_result_preserves_all_blocks(provider):
+    """Latest convention inference span: all response blocks join into content."""
+    span = make_span(
+        provider,
+        0xAAA,
+        0xBBB,
+        0xCCC,
+        "chat",
+        {"gen_ai.operation.name": "chat", "gen_ai.provider.name": "strands-agents"},
+        lambda s: s.add_event(
+            "gen_ai.client.inference.operation.details",
+            {
+                "gen_ai.input.messages": """
+                    [
+                        {"role": "user", "parts": [
+                            {"type": "tool_call_response", "id": "t1", "response": [
+                                {"text": "summary"},
+                                {"text": "Output: 2"}
+                            ]}
+                        ]}
+                    ]
+                """,
+                "gen_ai.output.messages": """
+                    [{"role": "assistant", "parts": [
+                        {"type": "text", "content": "done"}
+                    ], "finish_reason": "stop"}]
+                """,
+            },
+        ),
+    )
+
+    session = StrandsInMemorySessionMapper().map_to_session([span], "sid")
+
+    tool_result = session.traces[0].spans[0].messages[0].content[0]
+    assert "summary" in tool_result.content
+    assert "Output: 2" in tool_result.content
+
+
+def test_latest_convention_tool_execution_span_preserves_all_blocks(provider):
+    """Latest convention tool execution span: all response blocks join into content."""
+    span = make_span(
+        provider,
+        0xAAA,
+        0xBBB,
+        0xCCC,
+        "execute_tool",
+        {
+            "gen_ai.operation.name": "execute_tool",
+            "gen_ai.provider.name": "strands-agents",
+            "gen_ai.tool.name": "calc",
+            "gen_ai.tool.call.id": "t1",
+            "gen_ai.tool.status": "success",
+        },
+        lambda s: s.add_event(
+            "gen_ai.client.inference.operation.details",
+            {
+                "gen_ai.output.messages": """[
+                    {"role": "tool", "parts": [
+                        {"type": "tool_call_response", "id": "t1", "response": [
+                            {"text": "summary"},
+                            {"text": "Output: 2"}
+                        ]}
+                    ], "finish_reason": "stop"}
+                ]"""
+            },
+        ),
+    )
+
+    session = StrandsInMemorySessionMapper().map_to_session([span], "sid")
+
+    tool = session.traces[0].spans[0]
+    assert isinstance(tool, ToolExecutionSpan)
+    assert "summary" in tool.tool_result.content
+    assert "Output: 2" in tool.tool_result.content


### PR DESCRIPTION
## Description

Fixes a bug where multi-block `toolResult.content` was silently dropped to the first block, causing `FaithfulnessEvaluator` (and other evaluators) to flag values from `content[1+]` as hallucinated.

**Root cause:** Three sites in `StrandsInMemorySessionMapper` and two in `CloudWatchSessionMapper` read `content[0]` (or `response[0]`) only:
- `StrandsInMemorySessionMapper._process_tool_results` (legacy convention)
- `StrandsInMemorySessionMapper._convert_inference_messages` (latest convention — had a `## To-do` comment)
- `StrandsInMemorySessionMapper._convert_tool_execution_span` (latest convention)
- `CloudWatchSessionMapper._extract_tool_results` / `_process_tool_results` (via `_extract_tool_result_text`)

**Fix:** Two shared helpers in `mappers/utils.py`, used by both mappers:
- `serialize_tool_result_block(block)` — serializes a single Bedrock-style content block. Handles `text`, `json` (via `json.dumps`), and `image`/`document`/`video` (placeholder marker so the judge knows non-text data exists).
- `join_tool_result_content(content)` — joins all blocks with `\n`, filtering empties.

This addresses both the reported `text`-block bug **and** the latent same-shape bug for `json` blocks (common via Strands' `@tool` decorator returning dicts).

## Related Issues

Fixes https://github.com/strands-agents/evals/issues/235

Ref: https://github.com/aws/agentcore-cli/issues/1393

## Documentation PR

N/A

## Type of Change

Bug fix

## Testing

- 4 new regression tests in `test_strands_in_memory_mapper.py` covering: legacy multi-text, legacy text+json, latest-convention multi-text inference, latest-convention multi-text tool execution span.
- 1 new regression test in `test_cloudwatch_session_mapper.py` for multi-block tool result reaching the `ToolExecutionSpan`.
- All 172 existing mapper tests pass unchanged.

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.