### PR TITLE
chore(cli): added single case evaluation command

### DIFF
--- a/src/strands_evals/cli/_entrypoint.py
+++ b/src/strands_evals/cli/_entrypoint.py
@@ -17,7 +17,46 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Literal
 
+from ..evaluators import (
+    CoherenceEvaluator,
+    ConcisenessEvaluator,
+    CorrectnessEvaluator,
+    Equals,
+    FaithfulnessEvaluator,
+    GoalSuccessRateEvaluator,
+    HarmfulnessEvaluator,
+    HelpfulnessEvaluator,
+    InstructionFollowingEvaluator,
+    RefusalEvaluator,
+    ResponseRelevanceEvaluator,
+    StereotypingEvaluator,
+    ToolParameterAccuracyEvaluator,
+    ToolSelectionAccuracyEvaluator,
+)
 from ..evaluators.evaluator import Evaluator
+
+# Built-in evaluator shortnames for `--evaluator NAME`. Only evaluators that
+# instantiate cleanly with no required arguments are listed here — anything
+# requiring config (rubrics, target values, tool names) belongs in an
+# experiment file. `equals` is included because `Equals()` falls back to the
+# case's `expected_output` when no value is supplied, which is exactly what
+# `--expected-output` provides in ad-hoc mode.
+BUILTIN_EVALUATOR_SHORTNAMES: dict[str, type[Evaluator]] = {
+    "coherence": CoherenceEvaluator,
+    "conciseness": ConcisenessEvaluator,
+    "correctness": CorrectnessEvaluator,
+    "equals": Equals,
+    "faithfulness": FaithfulnessEvaluator,
+    "goal-success-rate": GoalSuccessRateEvaluator,
+    "harmfulness": HarmfulnessEvaluator,
+    "helpfulness": HelpfulnessEvaluator,
+    "instruction-following": InstructionFollowingEvaluator,
+    "refusal": RefusalEvaluator,
+    "response-relevance": ResponseRelevanceEvaluator,
+    "stereotyping": StereotypingEvaluator,
+    "tool-parameter-accuracy": ToolParameterAccuracyEvaluator,
+    "tool-selection-accuracy": ToolSelectionAccuracyEvaluator,
+}
 
 EntryPointKind = Literal[
     "callable_no_arg",
@@ -158,8 +197,11 @@ _FACTORY_HINT = (
     "--agent must reference a factory callable, e.g. "
     "'def build_agent() -> Agent: return Agent(...)' "
     "or 'def build_agent(case: Case) -> Agent: ...'. "
-    "Each case gets a fresh Agent so concurrent runs and "
-    "shared conversation state cannot leak between cases."
+    "Each call must return a fresh agent so concurrent runs and "
+    "shared conversation state cannot leak between cases. The CLI's "
+    "per-case freshness guarantee is enforced for strands.Agent only; "
+    "non-Strands callables are accepted but cross-case isolation is the "
+    "factory's responsibility."
 )
 
 
@@ -209,9 +251,9 @@ def _callable_arity(func: Callable[..., Any]) -> int:
 def classify_agent(obj: Any, spec: str) -> ResolvedEntryPoint:
     """Classify a resolved object passed as `--agent`.
 
-    Accepts only factory callables — the CLI invokes the factory once per case
-    so each case gets a fresh `Agent` instance. This rules out the two unsafe
-    shapes that were previously accepted:
+    Accepts callables — the CLI invokes the resolved object once per case and
+    uses the return value as the agent. Two shapes are explicitly rejected
+    because they break the per-case freshness guarantee for `strands.Agent`:
 
     - **Prebuilt `strands.Agent` instance**: would share `self.messages` and
       other mutable state across cases. Under `--max-workers > 1` this races;
@@ -224,10 +266,25 @@ def classify_agent(obj: Any, spec: str) -> ResolvedEntryPoint:
       - zero-arg callable → `callable_no_arg`
       - one-arg callable (`Case`) → `callable_one_arg`
 
+    **Scope of the freshness guarantee.** The instance/subclass rejections only
+    cover `strands.Agent` (the SDK type the CLI was designed around). A
+    *non-Strands* callable instance — e.g. `class MyAgent: __call__(self, prompt): ...`
+    exposed as a module-level instance — passes the `callable(obj)` check and
+    classifies as `callable_one_arg`. The CLI will call it as `obj(case)` once
+    per case (treating it as a factory) and then call its return value with
+    `case.input`. If that misuse happens to "work" mechanically, the same
+    instance is reused across cases and any per-call state it accumulates
+    leaks between them. There is no general way to detect this without a
+    catalog of every agent framework's base class, so the contract is:
+    `--agent` accepts a *factory* that returns a fresh agent per call. Pass a
+    function, lambda, `functools.partial`, or class object — not a prebuilt
+    instance whose `__call__` carries state.
+
     Raises:
-        EntryPointError: If the object is a prebuilt instance, an `Agent`
-            subclass, a callable with the wrong arity, or not callable at all.
-            The message points users at the factory pattern.
+        EntryPointError: If the object is a prebuilt `strands.Agent` instance,
+            a `strands.Agent` subclass, a callable with the wrong arity, or
+            not callable at all. The message points users at the factory
+            pattern.
     """
     if _is_strands_agent_instance(obj):
         raise EntryPointError(
@@ -278,6 +335,51 @@ def resolve_agent(spec: str) -> ResolvedEntryPoint:
 def resolve_task(spec: str) -> ResolvedEntryPoint:
     """Convenience: `import_attr` then `classify_task`."""
     return classify_task(import_attr(spec), spec)
+
+
+def resolve_evaluator_spec(spec: str) -> Evaluator:
+    """Resolve `--evaluator SPEC` into an instantiated `Evaluator`.
+
+    Two forms are accepted:
+
+    - **Built-in shortname** (e.g. `"helpfulness"`, `"equals"`): looked up in
+      :data:`BUILTIN_EVALUATOR_SHORTNAMES` and instantiated with no arguments.
+      `Contains` is a special case — it requires a `value=` and is not in the
+      shortname registry; users who want substring matching pass
+      `--expected-output TEXT` instead, which the caller turns into
+      `Contains(value=TEXT)`.
+    - **`MODULE:CLASS`** (contains `:`): resolved via :func:`import_attr` and
+      validated as an :class:`Evaluator` subclass, then instantiated with no
+      arguments. This is the escape hatch for custom evaluators in ad-hoc
+      mode; richer construction belongs in an experiment file.
+
+    Raises:
+        EntryPointError: When the spec is unknown, the resolved object isn't
+            an `Evaluator` subclass, or instantiation fails.
+    """
+    if ":" in spec:
+        cls = import_attr(spec)
+        if not isinstance(cls, type) or not issubclass(cls, Evaluator):
+            raise EntryPointError(
+                f"--evaluator '{spec}' must reference a subclass of "
+                f"strands_evals.evaluators.Evaluator (got {type(cls).__name__})"
+            )
+    else:
+        cls = BUILTIN_EVALUATOR_SHORTNAMES.get(spec)
+        if cls is None:
+            choices = ", ".join(sorted(BUILTIN_EVALUATOR_SHORTNAMES))
+            raise EntryPointError(
+                f"--evaluator '{spec}' is not a known built-in shortname. "
+                f"Choose from: {choices}, or pass MODULE:CLASS for a custom evaluator."
+            )
+
+    try:
+        return cls()
+    except TypeError as e:
+        raise EntryPointError(
+            f"--evaluator '{spec}' could not be instantiated with no arguments: {e}. "
+            f"Configure it in an experiment file instead."
+        ) from e
 
 
 def resolve_custom_evaluators(specs: list[str]) -> list[type[Evaluator]]:

--- a/src/strands_evals/cli/commands/run.py
+++ b/src/strands_evals/cli/commands/run.py
@@ -8,19 +8,26 @@ import logging
 import sys
 from typing import Any
 
+from ...case import Case
 from ...display.display_console import CollapsibleTableReportDisplay
+from ...evaluators.deterministic import Contains, Equals
+from ...evaluators.evaluator import Evaluator
+from ...evaluators.output_evaluator import OutputEvaluator
 from ...experiment import Experiment
 from ...local_file_task_result_store import LocalFileTaskResultStore
 from ...types.detector import ConfidenceLevel, DiagnosisConfig, DiagnosisTrigger
 from ...types.evaluation_report import EvaluationReport
+from ...types.trace import EvaluationLevel
 from .._agent_task import synthesize_task_function
-from .._common import EXIT_FAILURES, EXIT_OK, resolve_format
+from .._common import EXIT_BAD_INPUT, EXIT_FAILURES, EXIT_OK, emit_error, resolve_format
 from .._entrypoint import (
+    EntryPointError,
     resolve_agent,
     resolve_custom_evaluators,
+    resolve_evaluator_spec,
     resolve_task,
 )
-from .._io import write_text_output
+from .._io import read_text_input, write_text_output
 
 logger = logging.getLogger(__name__)
 
@@ -57,6 +64,141 @@ def _build_diagnosis_config(args: argparse.Namespace) -> DiagnosisConfig | None:
         trigger=DiagnosisTrigger(args.diagnose),
         confidence_threshold=ConfidenceLevel(args.confidence),
     )
+
+
+def _ad_hoc_flags_set(args: argparse.Namespace) -> list[str]:
+    """Return the names of ad-hoc flags the user actually provided.
+
+    Used by `_validate_args` to enforce mutual exclusion with EXPERIMENT_FILE
+    and to format helpful error messages naming the conflicting flag.
+    """
+    set_flags: list[str] = []
+    if args.input is not None:
+        set_flags.append("--input")
+    if args.input_file is not None:
+        set_flags.append("--input-file")
+    if args.name is not None:
+        set_flags.append("--name")
+    if args.expected_output is not None:
+        set_flags.append("--expected-output")
+    if args.rubric is not None:
+        set_flags.append("--rubric")
+    if args.evaluator:
+        set_flags.append("--evaluator")
+    return set_flags
+
+
+def _read_input(args: argparse.Namespace) -> str:
+    """Resolve the case input text from `--input` or `--input-file`.
+
+    `--input-file -` reads stdin, mirroring `diagnose`/`report`. The two flags
+    are mutually exclusive; argparse enforces that via a group.
+    """
+    if args.input is not None:
+        return args.input
+    return read_text_input(args.input_file)
+
+
+def _build_ad_hoc_evaluators(args: argparse.Namespace) -> list[Evaluator]:
+    """Resolve `--evaluator` specs and apply auto-wiring rules.
+
+    Auto-wire convenience evaluators only when `--evaluator` is omitted, so an
+    explicit list is never silently extended. `--expected-output` → `Contains`
+    and `--rubric` → `OutputEvaluator` compose: passing both yields both checks.
+    """
+    evaluators: list[Evaluator] = [resolve_evaluator_spec(spec) for spec in (args.evaluator or [])]
+    if not evaluators:
+        if args.expected_output is not None:
+            evaluators.append(Contains(value=args.expected_output))
+        if args.rubric is not None:
+            evaluators.append(OutputEvaluator(rubric=args.rubric))
+    return evaluators
+
+
+def _build_ad_hoc_experiment(
+    args: argparse.Namespace,
+    evaluators: list[Evaluator],
+    diagnosis_config: DiagnosisConfig | None,
+) -> Experiment:
+    """Synthesize an in-memory Experiment from ad-hoc CLI flags.
+
+    Shape:
+      - one `Case` built from `--input`/`--input-file` + optional
+        `--name`/`--expected-output`
+      - evaluators are pre-resolved by `_build_ad_hoc_evaluators` so that
+        `_validate_args` can introspect them before construction.
+    """
+    case = Case[str, str](
+        name=args.name or "ad_hoc",
+        input=_read_input(args),
+        expected_output=args.expected_output,
+    )
+    return Experiment(cases=[case], evaluators=evaluators, diagnosis_config=diagnosis_config)
+
+
+_TRACE_DEPENDENT_LEVELS = {
+    EvaluationLevel.SESSION_LEVEL,
+    EvaluationLevel.TRACE_LEVEL,
+    EvaluationLevel.TOOL_LEVEL,
+}
+
+
+def _check_ad_hoc_evaluator_compat(args: argparse.Namespace, evaluators: list[Evaluator]) -> str | None:
+    """Reject ad-hoc evaluator/flag combinations that would always misfire.
+
+    Two checks:
+      1. Trace/Session/Tool-level evaluators need a `Session` trajectory, which
+         only `--agent` produces. With `--task` they raise inside `_run_evaluator`
+         and surface as a cryptic per-case `score=0`. Fail fast instead.
+      2. `Equals()` without `--expected-output` falls back to `case.expected_output`
+         which is `None` in ad-hoc mode, so the comparison can never pass.
+    """
+    if args.task is not None:
+        offenders = sorted({type(e).__name__ for e in evaluators if e.evaluation_level in _TRACE_DEPENDENT_LEVELS})
+        if offenders:
+            return (
+                f"--evaluator {', '.join(offenders)} requires a Session trajectory; "
+                f"use --agent instead of --task in ad-hoc mode."
+            )
+
+    if args.expected_output is None:
+        equals_offenders = [e for e in evaluators if isinstance(e, Equals) and e.value is None]
+        if equals_offenders:
+            return (
+                "--evaluator equals requires --expected-output in ad-hoc mode "
+                "(otherwise the comparison is against None)."
+            )
+
+    return None
+
+
+def _validate_args(args: argparse.Namespace) -> str | None:
+    """Return an error string if argument combinations are invalid, else None.
+
+    Three rules:
+      1. EXPERIMENT_FILE and any ad-hoc flag are mutually exclusive — pick a
+         mode.
+      2. Without EXPERIMENT_FILE the user must supply `--input` or
+         `--input-file`; otherwise there is nothing to evaluate.
+      3. In ad-hoc mode at least one evaluator must be derivable: an explicit
+         `--evaluator` or an `--expected-output` (which defaults to `Contains`).
+    """
+    ad_hoc = _ad_hoc_flags_set(args)
+    if args.experiment_file is not None and ad_hoc:
+        joined = ", ".join(ad_hoc)
+        return (
+            f"EXPERIMENT_FILE and ad-hoc flags ({joined}) are mutually exclusive; "
+            f"either pass an experiment file or use --input + --evaluator/--expected-output."
+        )
+    if args.experiment_file is None:
+        if args.input is None and args.input_file is None:
+            return "EXPERIMENT_FILE or --input/--input-file is required."
+        if not args.evaluator and args.expected_output is None and args.rubric is None:
+            return (
+                "ad-hoc mode requires --evaluator, --expected-output (auto-wires Contains), "
+                "or --rubric (auto-wires OutputEvaluator)."
+            )
+    return None
 
 
 def _decide_exit_code(report: EvaluationReport, fail_on: tuple[str, float | None]) -> int:
@@ -150,18 +292,39 @@ def _display_expanded(
 
 
 def _run(args: argparse.Namespace) -> int:
-    custom_evaluators = resolve_custom_evaluators(args.custom_evaluator or [])
-    loaded = Experiment.from_file(args.experiment_file, custom_evaluators=custom_evaluators)
+    error = _validate_args(args)
+    if error is not None:
+        emit_error(error)
+        return EXIT_BAD_INPUT
 
     diagnosis_config = _build_diagnosis_config(args)
-    # Experiment.from_file does not accept diagnosis_config; rebuild via the
-    # public constructor so we don't poke private attrs. Cases are deep-copied
-    # by the property accessor, which is fine for a one-shot CLI run.
-    experiment = Experiment(
-        cases=loaded.cases,
-        evaluators=loaded.evaluators,
-        diagnosis_config=diagnosis_config,
-    )
+
+    if args.experiment_file is not None:
+        custom_evaluators = resolve_custom_evaluators(args.custom_evaluator or [])
+        loaded = Experiment.from_file(args.experiment_file, custom_evaluators=custom_evaluators)
+        # Experiment.from_file does not accept diagnosis_config; rebuild via the
+        # public constructor so we don't poke private attrs. Cases are deep-copied
+        # by the property accessor, which is fine for a one-shot CLI run.
+        experiment = Experiment(
+            cases=loaded.cases,
+            evaluators=loaded.evaluators,
+            diagnosis_config=diagnosis_config,
+        )
+    else:
+        if args.custom_evaluator:
+            logger.warning(
+                "--custom-evaluator is ignored in ad-hoc mode; pass MODULE:CLASS directly to --evaluator instead"
+            )
+        try:
+            evaluators = _build_ad_hoc_evaluators(args)
+        except EntryPointError as e:
+            emit_error(str(e))
+            return EXIT_BAD_INPUT
+        compat_error = _check_ad_hoc_evaluator_compat(args, evaluators)
+        if compat_error is not None:
+            emit_error(compat_error)
+            return EXIT_BAD_INPUT
+        experiment = _build_ad_hoc_experiment(args, evaluators, diagnosis_config)
 
     if args.agent is not None:
         entry = resolve_agent(args.agent)
@@ -227,13 +390,76 @@ def add_subparser(
             "Load an Experiment, resolve --agent or --task, execute "
             "run_evaluations_async, and write a flattened EvaluationReport. "
             "--agent synthesizes the standard task wrapper (telemetry → invoke "
-            "→ Session mapping); --task is the escape hatch for custom shapes."
+            "→ Session mapping); --task is the escape hatch for custom shapes. "
+            "Pass EXPERIMENT_FILE to run a serialized experiment, or omit it "
+            "and supply --input + --evaluator/--expected-output for an ad-hoc "
+            "single-case run without authoring an experiment file."
         ),
     )
     parser.add_argument(
         "experiment_file",
         metavar="EXPERIMENT_FILE",
-        help="path to a serialized Experiment JSON file",
+        nargs="?",
+        default=None,
+        help=(
+            "path to a serialized Experiment JSON file. Omit to run in ad-hoc "
+            "single-case mode using --input + --evaluator/--expected-output."
+        ),
+    )
+
+    ad_hoc = parser.add_argument_group("ad-hoc case (no experiment file)")
+    ad_hoc_input = ad_hoc.add_mutually_exclusive_group()
+    ad_hoc_input.add_argument(
+        "--input",
+        metavar="TEXT",
+        default=None,
+        help="case input text (ad-hoc mode); pair with --evaluator or --expected-output",
+    )
+    ad_hoc_input.add_argument(
+        "--input-file",
+        metavar="PATH",
+        default=None,
+        help="read case input from PATH (or '-' for stdin); mutually exclusive with --input",
+    )
+    ad_hoc.add_argument(
+        "--name",
+        metavar="STR",
+        default=None,
+        help="case name in ad-hoc mode (default: 'ad_hoc')",
+    )
+    ad_hoc.add_argument(
+        "--expected-output",
+        metavar="TEXT",
+        default=None,
+        help=(
+            "expected output for the ad-hoc case. When --evaluator is omitted, "
+            "this also defaults to Contains(value=TEXT) so the run is a complete "
+            "one-liner."
+        ),
+    )
+    ad_hoc.add_argument(
+        "--rubric",
+        metavar="TEXT",
+        default=None,
+        help=(
+            "rubric for an LLM-as-judge OutputEvaluator. When --evaluator is "
+            "omitted, this auto-wires OutputEvaluator(rubric=TEXT). Composes "
+            "with --expected-output (both auto-evaluators are appended). For "
+            "richer config (model, system_prompt) use an experiment file."
+        ),
+    )
+    ad_hoc.add_argument(
+        "--evaluator",
+        metavar="SPEC",
+        action="append",
+        default=None,
+        help=(
+            "evaluator for the ad-hoc case (repeatable). SPEC is either a "
+            "built-in shortname (helpfulness, equals, faithfulness, ...) or "
+            "MODULE:CLASS for a custom Evaluator subclass. Built-in shortnames "
+            "instantiate with no arguments; richer config belongs in an "
+            "experiment file."
+        ),
     )
 
     target = parser.add_mutually_exclusive_group(required=True)
@@ -244,7 +470,11 @@ def add_subparser(
             "entry point for a factory callable that returns a strands.Agent. "
             "Zero-arg ('def build_agent() -> Agent: ...') or one-arg "
             "('def build_agent(case: Case) -> Agent: ...'). The factory is "
-            "invoked once per case so each case runs against a fresh Agent."
+            "invoked once per case so each case runs against a fresh Agent. "
+            "Per-case freshness is enforced for strands.Agent only — other "
+            "callables (custom agent classes, partials, instances with __call__) "
+            "are accepted but cross-case isolation becomes the factory's "
+            "responsibility. For non-standard task shapes use --task instead."
         ),
     )
     target.add_argument(

--- a/tests/strands_evals/cli/test_run.py
+++ b/tests/strands_evals/cli/test_run.py
@@ -334,6 +334,394 @@ def test_run_exit_zero_overrides_fail_on(experiment_file: Path, tmp_path: Path):
     assert exit_code == 0
 
 
+def test_run_ad_hoc_with_expected_output_passes(capsys, tmp_path: Path):
+    """Ad-hoc mode: --input + --expected-output defaults to Contains and passes."""
+    out_path = tmp_path / "reports.json"
+    exit_code = main(
+        [
+            "--json",
+            "run",
+            "--task",
+            "tests.strands_evals.cli.fixtures.tasks:answer_string",
+            "--input",
+            "hi",
+            "--expected-output",
+            "answered: hi",
+            "-o",
+            str(out_path),
+        ]
+    )
+
+    assert exit_code == 0
+    payload = json.loads(out_path.read_text())
+    assert len(payload["cases"]) == 1
+    assert payload["cases"][0]["name"] == "ad_hoc"
+    assert payload["cases"][0]["input"] == "hi"
+    assert payload["cases"][0]["evaluator"] == "Contains"
+    assert payload["test_passes"] == [True]
+
+
+def test_run_ad_hoc_explicit_evaluator_shortname(tmp_path: Path):
+    """Ad-hoc mode: --evaluator equals (shortname) wires up Equals against expected_output."""
+    out_path = tmp_path / "reports.json"
+    exit_code = main(
+        [
+            "--json",
+            "run",
+            "--task",
+            "tests.strands_evals.cli.fixtures.tasks:answer_string",
+            "--input",
+            "hi",
+            "--expected-output",
+            "answered: hi",
+            "--evaluator",
+            "equals",
+            "-o",
+            str(out_path),
+        ]
+    )
+    assert exit_code == 0
+    payload = json.loads(out_path.read_text())
+    assert payload["cases"][0]["evaluator"] == "Equals"
+    assert payload["test_passes"] == [True]
+
+
+def test_run_ad_hoc_custom_evaluator_via_module_class(tmp_path: Path):
+    """Ad-hoc mode: --evaluator MODULE:CLASS resolves a custom Evaluator subclass."""
+    out_path = tmp_path / "reports.json"
+    exit_code = main(
+        [
+            "--json",
+            "run",
+            "--task",
+            "tests.strands_evals.cli.fixtures.tasks:answer_string",
+            "--input",
+            "hi",
+            "--evaluator",
+            "tests.strands_evals.cli.fixtures.evaluators:AlwaysPasses",
+            "-o",
+            str(out_path),
+        ]
+    )
+    assert exit_code == 0
+    payload = json.loads(out_path.read_text())
+    assert payload["cases"][0]["evaluator"] == "AlwaysPasses"
+    assert payload["test_passes"] == [True]
+
+
+def test_run_ad_hoc_input_file_from_stdin(monkeypatch, tmp_path: Path):
+    """Ad-hoc mode: --input-file - reads case input from stdin."""
+    import io
+
+    monkeypatch.setattr("sys.stdin", io.StringIO("hi"))
+    out_path = tmp_path / "reports.json"
+    exit_code = main(
+        [
+            "--json",
+            "run",
+            "--task",
+            "tests.strands_evals.cli.fixtures.tasks:answer_string",
+            "--input-file",
+            "-",
+            "--expected-output",
+            "answered: hi",
+            "-o",
+            str(out_path),
+        ]
+    )
+    assert exit_code == 0
+    payload = json.loads(out_path.read_text())
+    assert payload["cases"][0]["input"] == "hi"
+
+
+def test_run_ad_hoc_name_override(tmp_path: Path):
+    """Ad-hoc mode: --name overrides the default 'ad_hoc' case name."""
+    out_path = tmp_path / "reports.json"
+    exit_code = main(
+        [
+            "--json",
+            "run",
+            "--task",
+            "tests.strands_evals.cli.fixtures.tasks:answer_string",
+            "--input",
+            "hi",
+            "--expected-output",
+            "answered: hi",
+            "--name",
+            "smoke",
+            "-o",
+            str(out_path),
+        ]
+    )
+    assert exit_code == 0
+    payload = json.loads(out_path.read_text())
+    assert payload["cases"][0]["name"] == "smoke"
+
+
+def test_run_experiment_file_and_ad_hoc_flags_conflict(experiment_file: Path, capsys):
+    """EXPERIMENT_FILE and ad-hoc flags are mutually exclusive — exit 2 with a clear error."""
+    exit_code = main(
+        [
+            "run",
+            str(experiment_file),
+            "--task",
+            "tests.strands_evals.cli.fixtures.tasks:answer_string",
+            "--input",
+            "hi",
+        ]
+    )
+    captured = capsys.readouterr()
+    assert exit_code == 2
+    assert "mutually exclusive" in captured.err
+    assert "--input" in captured.err
+
+
+def test_run_no_experiment_file_and_no_input_errors(capsys):
+    """Without EXPERIMENT_FILE or --input, the run has nothing to execute — exit 2."""
+    exit_code = main(
+        [
+            "run",
+            "--task",
+            "tests.strands_evals.cli.fixtures.tasks:answer_string",
+        ]
+    )
+    captured = capsys.readouterr()
+    assert exit_code == 2
+    assert "EXPERIMENT_FILE or --input" in captured.err
+
+
+def test_run_ad_hoc_input_without_evaluator_errors(capsys):
+    """--input alone (no --evaluator, --expected-output, or --rubric) is invalid — exit 2."""
+    exit_code = main(
+        [
+            "run",
+            "--task",
+            "tests.strands_evals.cli.fixtures.tasks:answer_string",
+            "--input",
+            "hi",
+        ]
+    )
+    captured = capsys.readouterr()
+    assert exit_code == 2
+    assert "--evaluator" in captured.err
+    assert "--expected-output" in captured.err
+    assert "--rubric" in captured.err
+
+
+def test_run_ad_hoc_rubric_auto_wires_output_evaluator(monkeypatch, tmp_path: Path):
+    """--rubric TEXT alone is enough; auto-wires OutputEvaluator(rubric=TEXT)."""
+    from strands_evals.cli.commands import run as run_module
+    from strands_evals.evaluators.output_evaluator import OutputEvaluator
+    from strands_evals.types.evaluation import EvaluationOutput
+
+    captured: dict = {}
+
+    async def _fake_evaluate(self, evaluation_case):
+        captured["rubric"] = self.rubric
+        return [EvaluationOutput(score=1.0, test_pass=True, reason="ok")]
+
+    monkeypatch.setattr(OutputEvaluator, "evaluate_async", _fake_evaluate)
+    monkeypatch.setattr(run_module.OutputEvaluator, "evaluate_async", _fake_evaluate)
+
+    out_path = tmp_path / "reports.json"
+    exit_code = main(
+        [
+            "--json",
+            "run",
+            "--task",
+            "tests.strands_evals.cli.fixtures.tasks:answer_string",
+            "--input",
+            "hi",
+            "--rubric",
+            "Output should be cheerful.",
+            "-o",
+            str(out_path),
+        ]
+    )
+    assert exit_code == 0
+    assert captured["rubric"] == "Output should be cheerful."
+    payload = json.loads(out_path.read_text())
+    assert payload["cases"][0]["evaluator"] == "OutputEvaluator"
+    assert payload["test_passes"] == [True]
+
+
+def test_run_ad_hoc_rubric_and_expected_output_compose(monkeypatch, tmp_path: Path):
+    """--rubric + --expected-output (no --evaluator) auto-wires BOTH evaluators."""
+    from strands_evals.cli.commands import run as run_module
+    from strands_evals.evaluators.output_evaluator import OutputEvaluator
+    from strands_evals.types.evaluation import EvaluationOutput
+
+    async def _fake_evaluate(self, evaluation_case):
+        return [EvaluationOutput(score=1.0, test_pass=True, reason="ok")]
+
+    monkeypatch.setattr(OutputEvaluator, "evaluate_async", _fake_evaluate)
+    monkeypatch.setattr(run_module.OutputEvaluator, "evaluate_async", _fake_evaluate)
+
+    out_path = tmp_path / "reports.json"
+    exit_code = main(
+        [
+            "--json",
+            "run",
+            "--task",
+            "tests.strands_evals.cli.fixtures.tasks:answer_string",
+            "--input",
+            "hi",
+            "--expected-output",
+            "answered: hi",
+            "--rubric",
+            "Output should mirror the input.",
+            "-o",
+            str(out_path),
+        ]
+    )
+    assert exit_code == 0
+    payload = json.loads(out_path.read_text())
+    evaluators = sorted(c["evaluator"] for c in payload["cases"])
+    assert evaluators == ["Contains", "OutputEvaluator"]
+
+
+def test_run_ad_hoc_explicit_evaluator_suppresses_rubric_auto_wire(tmp_path: Path):
+    """--evaluator wins over --rubric: the explicit list is never silently extended."""
+    out_path = tmp_path / "reports.json"
+    exit_code = main(
+        [
+            "--json",
+            "run",
+            "--task",
+            "tests.strands_evals.cli.fixtures.tasks:answer_string",
+            "--input",
+            "hi",
+            "--rubric",
+            "ignored",
+            "--evaluator",
+            "tests.strands_evals.cli.fixtures.evaluators:AlwaysPasses",
+            "-o",
+            str(out_path),
+        ]
+    )
+    assert exit_code == 0
+    payload = json.loads(out_path.read_text())
+    evaluators = [c["evaluator"] for c in payload["cases"]]
+    assert evaluators == ["AlwaysPasses"]
+
+
+def test_run_ad_hoc_unknown_evaluator_shortname_exits_bad_input(capsys):
+    """Unknown shortname surfaces an EntryPointError message and exit 2."""
+    exit_code = main(
+        [
+            "run",
+            "--task",
+            "tests.strands_evals.cli.fixtures.tasks:answer_string",
+            "--input",
+            "hi",
+            "--evaluator",
+            "not-a-real-evaluator",
+        ]
+    )
+    captured = capsys.readouterr()
+    assert exit_code == 2
+    assert "not a known built-in shortname" in captured.err
+
+
+def test_run_input_and_input_file_mutually_exclusive(experiment_file: Path):
+    """argparse enforces --input vs --input-file mutual exclusion (exits via SystemExit)."""
+    with pytest.raises(SystemExit):
+        main(
+            [
+                "run",
+                "--task",
+                "tests.strands_evals.cli.fixtures.tasks:answer_string",
+                "--input",
+                "hi",
+                "--input-file",
+                "-",
+                "--expected-output",
+                "x",
+            ]
+        )
+
+
+def test_run_ad_hoc_trace_level_evaluator_with_task_errors(capsys):
+    """Trace-level shortnames (faithfulness, helpfulness, ...) need --agent's Session — fail fast under --task."""
+    exit_code = main(
+        [
+            "run",
+            "--task",
+            "tests.strands_evals.cli.fixtures.tasks:answer_string",
+            "--input",
+            "hi",
+            "--evaluator",
+            "faithfulness",
+        ]
+    )
+    captured = capsys.readouterr()
+    assert exit_code == 2
+    assert "FaithfulnessEvaluator" in captured.err
+    assert "--agent" in captured.err
+
+
+def test_run_ad_hoc_tool_level_evaluator_with_task_errors(capsys):
+    """Tool-level shortnames also need a Session — fail fast under --task."""
+    exit_code = main(
+        [
+            "run",
+            "--task",
+            "tests.strands_evals.cli.fixtures.tasks:answer_string",
+            "--input",
+            "hi",
+            "--evaluator",
+            "tool-selection-accuracy",
+        ]
+    )
+    captured = capsys.readouterr()
+    assert exit_code == 2
+    assert "ToolSelectionAccuracyEvaluator" in captured.err
+
+
+def test_run_ad_hoc_equals_without_expected_output_errors(capsys):
+    """`--evaluator equals` without `--expected-output` would compare against None — reject up front."""
+    exit_code = main(
+        [
+            "run",
+            "--task",
+            "tests.strands_evals.cli.fixtures.tasks:answer_string",
+            "--input",
+            "hi",
+            "--evaluator",
+            "equals",
+            "--rubric",
+            "anything",
+        ]
+    )
+    captured = capsys.readouterr()
+    assert exit_code == 2
+    assert "--expected-output" in captured.err
+
+
+def test_run_ad_hoc_equals_with_expected_output_passes(tmp_path: Path):
+    """`equals` paired with `--expected-output` is the supported one-liner shape."""
+    out_path = tmp_path / "reports.json"
+    exit_code = main(
+        [
+            "--json",
+            "run",
+            "--task",
+            "tests.strands_evals.cli.fixtures.tasks:answer_string",
+            "--input",
+            "hi",
+            "--evaluator",
+            "equals",
+            "--expected-output",
+            "answered: hi",
+            "-o",
+            str(out_path),
+        ]
+    )
+    assert exit_code == 0
+    payload = json.loads(out_path.read_text())
+    assert payload["test_passes"] == [True]
+
+
 def test_run_custom_evaluator_threading(experiment_file: Path, tmp_path: Path):
     """--custom-evaluator lets from_file resolve user-defined evaluator types."""
     # Author a tweaked experiment that references the AlwaysPasses evaluator.


### PR DESCRIPTION
## Description

Adds an **ad-hoc single-case mode** to `strands-evals run` so users can evaluate one input against an agent without authoring an experiment JSON file. `EXPERIMENT_FILE` becomes optional; when omitted, ad-hoc flags synthesize a one-`Case` `Experiment` in memory and route through the same `run_evaluations_async` path — output, exit codes, and report shape are identical to file mode.

```bash
# the new one-liner
strands-evals run \
  --agent agent:build_agent \
  --input "What is the capital of France?" \
  --rubric "Output should answer correctly in one or two short sentences."
```

Real case:
- Trace-based evaluator:
```bash
strands-evals run \
    --agent /Users/pschen/Developers/workplace/strands/evals/examples-strands-evals/evals_cli/demo/agent:build_agent \
    --name france-capital-helpful \
    --input "What is the capital of France?" \
    --evaluator helpfulness \
    --evaluator goal-success-rate \
    --fail-on none \
    --display -i
```
- OutputEvaluator

```bash
strands-evals run \
  --agent /Users/pschen/Developers/workplace/strands/evals/examples-strands-evals/evals_cli/demo/agent:build_agent \
  --name france-capital-output-evaluator \
  --input "What is the capital of France?" \
  --rubric "Output should answer correctly in one or two short sentences." \
  --display -i
```

### What's new (Detailed)

- `EXPERIMENT_FILE` is now optional to support single case evaluation. New ad-hoc argparse group:
  - `--input TEXT` / `--input-file PATH` (mutually exclusive, `-` reads stdin)
  - `--name STR` (defaults to `"ad_hoc"`)
  - `--expected-output TEXT`:  auto-wires `Contains(value=TEXT)` when `--evaluator` is omitted
  - `--rubric TEXT`: auto-wires `OutputEvaluator(rubric=TEXT)` when `--evaluator` is omitted; composes with `--expected-output`
  - `--evaluator SPEC` (repeatable): accepts a built-in shortname (`helpfulness`, `equals`, `faithfulness`, `goal-success-rate`, `tool-selection-accuracy`, ...) or `MODULE:CLASS` for a custom `Evaluator` subclass
- `cli/_entrypoint.py`:
  - New `BUILTIN_EVALUATOR_SHORTNAMES` registry — only no-arg-instantiable evaluators are listed; `OutputEvaluator` is intentionally excluded since its `rubric` belongs in an experiment file (or behind `--rubric`)
  - New `resolve_evaluator_spec(spec)` helper resolves shortnames and `MODULE:CLASS`
  - `classify_agent` docstring + `_FACTORY_HINT` updated to document that the per-case freshness guarantee covers `strands.Agent` only — addresses the scoping concern from #243's review (jjbuck)
- Validation rules in `_run`:
  1. `EXPERIMENT_FILE` and ad-hoc flags are mutually exclusive
  2. Without `EXPERIMENT_FILE` the user must supply `--input` or `--input-file`
  3. Ad-hoc mode requires at least one evaluator (explicit `--evaluator`, or auto-wired via `--expected-output`/`--rubric`)
  Failures return `EXIT_BAD_INPUT` (2) with a clear stderr message.
- Explicit `--evaluator` suppresses both auto-wires — the explicit list is never silently extended.
- `--custom-evaluator` is ignored in ad-hoc mode (warned), since users pass `MODULE:CLASS` directly to `--evaluator`.

### Out of scope (would push toward an experiment file)

`expected_trajectory`, `expected_interactions`, `expected_environment_state`, per-case `metadata`, multiple ad-hoc cases. The boundary is intentional: anything beyond `(input, expected_output, rubric)` signals you want an experiment file.

## Type of Change

New feature

## Testing
- 12 new unit tests in `tests/strands_evals/cli/test_run.py`:
  - happy paths: `--expected-output` auto-`Contains`, `--evaluator equals` shortname, `--evaluator MODULE:CLASS`, `--input-file -` stdin, `--name` override, `--rubric` auto-`OutputEvaluator`, `--rubric` + `--expected-output` compose
  - error paths: file + ad-hoc conflict, missing input, missing evaluator, unknown shortname, `--input` / `--input-file` mutex, explicit `--evaluator` suppresses `--rubric` auto-wire
- All 80 CLI tests pass (`pytest tests/strands_evals/cli/`)
- Smoke-tested end-to-end against `examples-strands-evals/evals_cli/demo`:
  ```
  strands-evals run | OutputEvaluator: 1/1 passed (1.00) | overall: 1.00
  ```

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.