### PR TITLE
fix(templates): correct doc link and clean up issue/PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,7 +1,7 @@
 name: Bug Report
 description: Report a bug in the Strands Agents Evals
 title: "[BUG] "
-labels: ["bug", "triage"]
+labels: ["triage", "python"]
 assignees: []
 body:
   - type: markdown
@@ -13,7 +13,7 @@ body:
     attributes:
       label: "Checks"
       options:
-        - label: "I have updated to the lastest minor and patch version of Strands and evals"
+        - label: "I have updated to the latest minor and patch version of Strands and evals"
           required: true
         - label: "I have checked the documentation and this is not expected behavior"
           required: true
@@ -59,7 +59,6 @@ body:
       options:
         - pip
         - git clone
-        - binary
         - other
   - type: textarea
     id: steps-to-reproduce

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,8 @@
 blank_issues_enabled: false
 contact_links:
+  - name: Strands Evals SDK Support
+    url: https://github.com/strands-agents/evals/discussions
+    about: Please ask and answer questions here
   - name: Strands Evals SDK Documentation
-    url: https://github.com/strands-agents/docs
+    url: https://strandsagents.com/docs/user-guide/evals-sdk/quickstart/
     about: Visit our documentation for help

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,7 +1,7 @@
 name: Feature Request
 description: Suggest a new feature or enhancement for Strands Evals SDK
 title: "[FEATURE] "
-labels: ["enhancement", "triage"]
+labels: ["triage", "python"]
 assignees: []
 body:
   - type: markdown

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,7 +7,7 @@
 
 ## Documentation PR
 
-<!-- Link to related associated PR in the agent-docs repo -->
+<!-- Link to any related documentation PR -->
 
 ## Type of Change
 
@@ -21,7 +21,7 @@ Other (please describe):
 
 ## Testing
 
-How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli
+How have you tested the change? Verify that the changes do not break functionality or introduce new warnings.
 
 - [ ] I ran `hatch run prepare`
 


### PR DESCRIPTION
## Summary

Fixes the broken documentation link and tidies the issue/PR templates.

## Changes

- **`config.yml`** — the documentation contact link pointed at `github.com/strands-agents/docs`. Updated to the Evals quickstart (`https://strandsagents.com/docs/user-guide/evals-sdk/quickstart/`) and added a Discussions support link (Discussions is enabled on this repo).
- **`bug_report.yml` / `feature_request.yml`** — removed the hardcoded type label (`bug` / `enhancement`). Blank issues are disabled, so users sometimes file through the wrong form, which baked in the wrong type. The issue-labeler classifies type from the issue content, so it handles this more reliably. Kept `triage` and added `python` (Evals is Python-only).
- **`bug_report.yml`** — fixed "lastest" typo and dropped the `binary` install-method option (Evals ships via pip only).
- **PR template** — removed the stale `consuming repositories: agents-docs, agents-tools, agents-cli` line (copied from another repo; not applicable here) and fixed the "agent-docs repo" reference.

## Notes

- The `triage` label did not exist on the repo and has been created (the templates referenced it but it was never present).

## Testing

- [ ] Open a new issue via each template and confirm the contact links resolve and labels apply as expected.