### PR TITLE
Add changelog-sync workflow

### DIFF
--- a/.github/workflows/changelog-sync.yml
+++ b/.github/workflows/changelog-sync.yml
@@ -1,0 +1,31 @@
+name: "Changelog: Sync"
+
+# Evals releases are surfaced on the changelog page that lives in
+# strands-agents/harness-sdk, so this workflow opens a cross-repo PR there.
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      backfill:
+        description: 'Backfill all releases'
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: strands-agents/devtools/changelog-release-pr@main
+        with:
+          source-repo: strands-agents/evals
+          mode: ${{ (github.event_name == 'workflow_dispatch' && inputs.backfill) && 'backfill' || 'single' }}
+          tag: ${{ github.event.release.tag_name }}
+          # Cross-repo: needs pull-requests:write + contents:write on harness-sdk.
+          # Reuse the org's existing cross-repo automation token; do not provision
+          # a new secret without confirming none exists.
+          github-token: ${{ secrets.CHANGELOG_PR_TOKEN }}

--- a/.github/workflows/changelog-sync.yml
+++ b/.github/workflows/changelog-sync.yml
@@ -12,6 +12,10 @@ on:
         description: 'Backfill all releases'
         type: boolean
         default: false
+      tag:
+        description: 'Single release tag to sync (ignored when backfill is checked)'
+        type: string
+        default: ''
 
 permissions:
   contents: read
@@ -24,7 +28,7 @@ jobs:
         with:
           source-repo: strands-agents/evals
           mode: ${{ (github.event_name == 'workflow_dispatch' && inputs.backfill) && 'backfill' || 'single' }}
-          tag: ${{ github.event.release.tag_name }}
+          tag: ${{ github.event.release.tag_name || inputs.tag }}
           # Cross-repo: needs pull-requests:write + contents:write on harness-sdk.
           # Reuse the org's existing cross-repo automation token; do not provision
           # a new secret without confirming none exists.

--- a/.github/workflows/changelog-sync.yml
+++ b/.github/workflows/changelog-sync.yml
@@ -11,23 +11,36 @@ on:
       tag:
         description: 'Single release tag to sync'
         type: string
-        default: ''
-
-permissions:
-  contents: read
+        required: true
 
 jobs:
   sync:
+    # Prereleases are skipped by the action too; gating here saves the run.
+    if: github.event_name != 'release' || !github.event.release.prerelease
     runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
-      - uses: strands-agents/devtools/changelog-release-pr@main
+      # Cross-repo PR needs pull-requests:write + contents:write on
+      # harness-sdk. Reuse the org's existing cross-repo automation token; do
+      # not provision a new secret without confirming none exists. Until the
+      # secret is wired, skip cleanly instead of failing every release run —
+      # the daily cron in harness-sdk backstops evals syncs (≤24h latency).
+      - name: Check token configured
+        id: token
+        env:
+          HAS_TOKEN: ${{ secrets.CHANGELOG_PR_TOKEN != '' }}
+        run: |
+          echo "available=$HAS_TOKEN" >> "$GITHUB_OUTPUT"
+          if [ "$HAS_TOKEN" != "true" ]; then
+            echo "::notice::CHANGELOG_PR_TOKEN not configured — skipping instant sync (harness-sdk daily cron will backstop this release)."
+          fi
+
+      - name: Sync release to harness-sdk changelog
+        if: steps.token.outputs.available == 'true'
+        uses: strands-agents/devtools/changelog-release-pr@main
         with:
           source-repo: strands-agents/evals
           mode: single
           tag: ${{ github.event.release.tag_name || inputs.tag }}
-          # Cross-repo: needs pull-requests:write + contents:write on harness-sdk.
-          # Reuse the org's existing cross-repo automation token; do not provision
-          # a new secret without confirming none exists.
           github-token: ${{ secrets.CHANGELOG_PR_TOKEN }}

--- a/.github/workflows/changelog-sync.yml
+++ b/.github/workflows/changelog-sync.yml
@@ -8,12 +8,8 @@ on:
     types: [published]
   workflow_dispatch:
     inputs:
-      backfill:
-        description: 'Backfill all releases'
-        type: boolean
-        default: false
       tag:
-        description: 'Single release tag to sync (ignored when backfill is checked)'
+        description: 'Single release tag to sync'
         type: string
         default: ''
 
@@ -29,7 +25,7 @@ jobs:
       - uses: strands-agents/devtools/changelog-release-pr@main
         with:
           source-repo: strands-agents/evals
-          mode: ${{ (github.event_name == 'workflow_dispatch' && inputs.backfill) && 'backfill' || 'single' }}
+          mode: single
           tag: ${{ github.event.release.tag_name || inputs.tag }}
           # Cross-repo: needs pull-requests:write + contents:write on harness-sdk.
           # Reuse the org's existing cross-repo automation token; do not provision

--- a/.github/workflows/changelog-sync.yml
+++ b/.github/workflows/changelog-sync.yml
@@ -23,6 +23,8 @@ permissions:
 jobs:
   sync:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: strands-agents/devtools/changelog-release-pr@main
         with:


### PR DESCRIPTION
## Description

Adds a `changelog-sync.yml` workflow that, on each published (non-prerelease) evals release, opens a cross-repo PR into `strands-agents/harness-sdk` to update the changelog page (which aggregates releases across the Strands SDKs and lives in harness-sdk).

It's a thin caller of the shared `strands-agents/devtools/changelog-release-pr` composite action (devtools#66) — all parsing/rendering logic lives there, deterministically, with no logic duplicated here. `workflow_dispatch` with a required `tag` input supports manual single-release syncs. Historical backfill is handled separately (harness-sdk#2761), not via this workflow.

**Token**: `secrets.CHANGELOG_PR_TOKEN` needs `pull-requests:write` + `contents:write` on harness-sdk — please point at the org's existing cross-repo automation token rather than provisioning a new one. Until it's wired, the workflow **skips cleanly with a notice** (no red runs); the daily cron in harness-sdk backstops evals syncs with ≤24h latency, so this is non-blocking.

## Related Issues

Part of the Strands changelog feature: harness-sdk#2717 (page), harness-sdk#2765 (harness workflow), harness-sdk#2761 (backfill), devtools#66 (shared action).

## Type of Change

New feature

## Testing

- Workflow YAML validated.
- The devtools action it calls has 57 passing unit tests and was validated end-to-end against the harness-sdk changelog schema, including real evals releases.

## Merge order

devtools#66 must merge first (the `uses:` path doesn't exist on devtools main until then). After it merges, pin the action ref from `@main` to the merge SHA.