### PR TITLE
chore(simulator): updated input to AgentInput but only supporting its…

### DIFF
--- a/src/strands_evals/simulation/actor_simulator.py
+++ b/src/strands_evals/simulation/actor_simulator.py
@@ -5,6 +5,7 @@ from typing import Any, cast
 from pydantic import BaseModel
 from strands import Agent
 from strands.agent.agent_result import AgentResult
+from strands.types.agent import AgentInput
 from strands.types.content import Message
 
 from strands_evals.case import Case
@@ -15,6 +16,23 @@ from strands_evals.simulation.tools.goal_completion import get_conversation_goal
 from strands_evals.types.simulation import ActorProfile, ActorResponse
 
 logger = logging.getLogger(__name__)
+
+
+def _require_str_initial_query(initial_query: AgentInput) -> str:
+    """Validate that an `AgentInput` initial query is a `str` for v1.
+
+    The signature is typed as `AgentInput` for forward compatibility with Strands,
+    but v1 only supports the `str` variant. Other variants (content blocks,
+    interrupt responses, prior messages) raise so callers don't silently get
+    the wrong behavior.
+    """
+    if not isinstance(initial_query, str):
+        raise TypeError(
+            f"initial_query must be a str in v1; got {type(initial_query).__name__}. "
+            "The type is annotated as AgentInput for forward compatibility, but only "
+            "str is supported today. Support for other AgentInput variants is planned."
+        )
+    return initial_query
 
 
 class ActorSimulator:
@@ -85,6 +103,7 @@ class ActorSimulator:
                 user_message = str(user_result.structured_output.message)
             ```
         """
+        _require_str_initial_query(case.input)
         actor_profile = cls._generate_profile_from_case(case)
 
         return cls(
@@ -123,7 +142,7 @@ class ActorSimulator:
     def __init__(
         self,
         actor_profile: ActorProfile,
-        initial_query: str,
+        initial_query: AgentInput,
         system_prompt_template: str | None = None,
         tools: list | None = None,
         model: str | None = None,
@@ -138,7 +157,9 @@ class ActorSimulator:
 
         Args:
             actor_profile: ActorProfile object containing traits, context, and actor_goal.
-            initial_query: The actor's first query or message.
+            initial_query: The actor's first query or message. Typed as `AgentInput` for
+                forward compatibility with Strands, but v1 only supports the `str` variant
+                — other variants raise `TypeError`.
             system_prompt_template: System prompt for the actor. Accepts two shapes:
 
                 - A template containing the `{actor_profile}` placeholder, which
@@ -192,7 +213,7 @@ class ActorSimulator:
             ```
         """
         self.actor_profile = actor_profile
-        self.initial_query = initial_query
+        self.initial_query = _require_str_initial_query(initial_query)
         self.conversation_history: list[Message] = []
         self.model_id = model
         self.stop = False

--- a/src/strands_evals/types/simulation/actor.py
+++ b/src/strands_evals/types/simulation/actor.py
@@ -1,6 +1,7 @@
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+from strands.types.content import ContentBlock
 
 
 class ActorProfile(BaseModel):
@@ -44,11 +45,26 @@ class ActorResponse(BaseModel):
         False,
         description="Set to true when the conversation goal is met or the conversation should end.",
     )
-    message: str | None = Field(
+    message: str | list[ContentBlock] | None = Field(
         None,
-        description="The actor's next message to the agent. Provide when stop=false; set to null when stop=true.",
+        description="The actor's next message to the agent. Provide when stop=false; set to null when stop=true. "
+        "Typed as `str | list[ContentBlock] | None` for forward compatibility, but v1 only supports the `str | None` "
+        "variants — `list[ContentBlock]` raises until multimodal simulator output is supported.",
     )
     stop_reason: str | None = Field(
         None,
         description='Populated by the simulator after the call. One of "goal_completed", "max_turns", or None.',
     )
+
+    @field_validator("message")
+    @classmethod
+    def _v1_only_str_message(cls, value: str | list[ContentBlock] | None) -> str | None:
+        if isinstance(value, list):
+            # Raise `ValueError` (not `TypeError`) so Pydantic wraps it into `ValidationError`,
+            # keeping the structured-output retry path intact.
+            raise ValueError(
+                "ActorResponse.message must be a str or None in v1; got list[ContentBlock]. "
+                "The annotation includes list[ContentBlock] for forward compatibility, but multimodal "
+                "simulator output is not yet supported."
+            )
+        return value

--- a/tests/strands_evals/simulation/test_actor_simulator.py
+++ b/tests/strands_evals/simulation/test_actor_simulator.py
@@ -3,7 +3,7 @@
 from unittest.mock import MagicMock, patch
 
 import pytest
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationError
 from strands.agent.agent_result import AgentResult
 
 from strands_evals import Case
@@ -501,3 +501,32 @@ def test_init_structured_output_model_validates_message_field(sample_actor_profi
             system_prompt_template="Test: {actor_profile}",
             structured_output_model=NoMessageModel,
         )
+
+
+def test_init_rejects_non_str_initial_query(sample_actor_profile):
+    """v1 only supports `str` initial_query; other AgentInput variants raise."""
+    with pytest.raises(TypeError, match="initial_query must be a str"):
+        ActorSimulator(
+            actor_profile=sample_actor_profile,
+            initial_query=[{"text": "hi"}],
+            system_prompt_template="Test: {actor_profile}",
+        )
+
+
+@patch("strands_evals.simulation.actor_simulator.Agent")
+def test_from_case_rejects_non_str_case_input(mock_agent_class):
+    """v1 only supports `str` case.input; profile generation never runs for other variants."""
+    case = Case(input=[{"text": "hi"}])
+    with pytest.raises(TypeError, match="initial_query must be a str"):
+        ActorSimulator.from_case_for_user_simulator(case=case)
+    mock_agent_class.assert_not_called()
+
+
+def test_actor_response_rejects_list_message():
+    """v1 only supports `str | None` for ActorResponse.message; list[ContentBlock] raises.
+
+    Raised as `ValidationError` (not raw `TypeError`) so Strands' structured-output
+    retry path can recover when an LLM emits a list.
+    """
+    with pytest.raises(ValidationError, match="must be a str or None in v1"):
+        ActorResponse(reasoning="r", message=[{"text": "hi"}], stop=False)


### PR DESCRIPTION
## Description

Forward-compat type alignment for the `ActorSimulator` surface ahead of v1, addressing review comments [#3210306551](https://github.com/strands-agents/evals/pull/207#discussion_r3210306551) and [#3210374421](https://github.com/strands-agents/evals/pull/207#discussion_r3210374421) on PR #207.

The annotations on the simulator's caller-facing inputs are widened to match `strands.types.agent.AgentInput` so the API documents what Strands itself accepts and inherits future content-block / interrupt extensions without another signature bump. 

Runtime behavior is unchanged in v1: **non-`str` variants raise `TypeError` with a v1-explicit message until full multimodal support lands.**

### Changes

**`src/strands_evals/simulation/actor_simulator.py`**
- Imported `AgentInput` from `strands.types.agent`.
- Added module-level `_require_str_initial_query()` helper that raises `TypeError` on anything other than `str`, calling out v1's contract.
- `ActorSimulator.__init__(initial_query: str, ...)` → `initial_query: AgentInput`. Validator runs before storing on `self.initial_query`, so the attribute remains typed-as-str at runtime.
- `from_case_for_user_simulator(case)` validates `case.input` upfront, before `_generate_profile_from_case` formats it into the prompt template.
- Updated docstring to call out the forward-compat type/runtime split.

**`src/strands_evals/types/simulation/actor.py`**
- Imported `ContentBlock` from `strands.types.content`.
- `ActorResponse.message: str | None` → `str | list[ContentBlock] | None`.
- Added a `field_validator("message")` that raises `TypeError` on `list[ContentBlock]` for v1.
- Updated the field description to spell out the forward-compat / runtime split.

### Notes
I chose to widen to `str | list[ContentBlock] | None` instead because:
- Adopting `Message` is a real schema break (nested JSON shape changes), not a forward-compat widening — every caller doing `str(user_result.structured_output.message)` would break.

`act(agent_message: str)` was deliberately **not** widened — the simulator's reaction-to-multimodal story has bigger problems than the parameter type (system prompt, profile extraction, goal-completion tool all assume text), and pre-widening doesn't save callers from those breaks.

## Related Issues

Addresses review feedback on #207.

## Documentation PR

None required. Audited every `ActorSimulator` / `ActorResponse` reference under `harness-sdk/site/`:
- All `Case(input=...)` examples (11) pass string literals — pass through cleanly.
- The single direct `ActorSimulator(initial_query=...)` example passes a string literal.
- No published example constructs `ActorResponse` with a `list[ContentBlock]` message.

## Type of Change

Other: forward-compat API widening with v1 runtime guard. Type-checker-visible signature change; runtime behavior is identical for the only variant supported today (`str` / `str | None`).

## Testing

- [x] `hatch run prepare`
- Existing `tests/strands_evals/simulation/test_actor_simulator.py` (25 tests) and `tests/strands_evals/experimental/redteam/test_strategies.py` (6 tests) and `tests/strands_evals/types` (79 tests) — all pass unchanged, since every existing call site uses `str` inputs.

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.