### PR TITLE
chore(redteam): added strategies round-trips

### DIFF
--- a/src/strands_evals/experimental/redteam/experiment.py
+++ b/src/strands_evals/experimental/redteam/experiment.py
@@ -23,7 +23,7 @@ from .report import RedTeamReport
 from .strategies import AttackStrategy
 from .strategies.target_session import TargetSession
 from .task import _build_attacker_task
-from .utils import _serialize_model
+from .utils import _put_model_field
 
 
 class RedTeamExperiment(Experiment[InputT, OutputT]):
@@ -207,9 +207,7 @@ class RedTeamExperiment(Experiment[InputT, OutputT]):
         out = super().to_dict()
         out["attack_strategies"] = [strategy.to_dict() for strategy in self._attack_strategies]
         # Coerce via the strategy helper for consistency with how strategies serialize their own model field.
-        model_id = _serialize_model(self._model)
-        if model_id is not None:
-            out["model"] = model_id
+        _put_model_field(out, self._model)
         return out
 
     @classmethod

--- a/src/strands_evals/experimental/redteam/strategies/bad_likert_judge/__init__.py
+++ b/src/strands_evals/experimental/redteam/strategies/bad_likert_judge/__init__.py
@@ -35,6 +35,7 @@ from pydantic import BaseModel, Field
 from strands import Agent
 from strands.models.model import Model
 
+from ...utils import _put_model_field
 from ..base import AttackRunResult, AttackStrategy
 from . import bad_likert_judge_v0 as blj_v0
 
@@ -162,6 +163,15 @@ class BadLikertJudgeStrategy(AttackStrategy):
     @property
     def name(self) -> str:
         return "bad_likert_judge"
+
+    def to_dict(self) -> dict[str, Any]:
+        out = super().to_dict()
+        out.update(
+            refine_rounds=self._refine_rounds,
+            success_threshold=self._success_threshold,
+        )
+        _put_model_field(out, self._model)
+        return out
 
     def run_attack(
         self,

--- a/src/strands_evals/experimental/redteam/strategies/base.py
+++ b/src/strands_evals/experimental/redteam/strategies/base.py
@@ -153,11 +153,22 @@ class AttackStrategy(ABC):
         """
         # Lazy import: subclasses inherit from AttackStrategy, so importing them at module top
         # would cycle (base -> strategies/__init__ -> crescendo -> base).
-        from . import CrescendoStrategy, PromptStrategy
+        from . import (
+            BadLikertJudgeStrategy,
+            CrescendoStrategy,
+            GoatStrategy,
+            PairStrategy,
+            PromptStrategy,
+            SequentialBreakStrategy,
+        )
 
         registry: dict[str, type[AttackStrategy]] = {
+            BadLikertJudgeStrategy.__name__: BadLikertJudgeStrategy,
             CrescendoStrategy.__name__: CrescendoStrategy,
+            GoatStrategy.__name__: GoatStrategy,
+            PairStrategy.__name__: PairStrategy,
             PromptStrategy.__name__: PromptStrategy,
+            SequentialBreakStrategy.__name__: SequentialBreakStrategy,
         }
         for custom in custom_strategies or []:
             registry[custom.__name__] = custom

--- a/src/strands_evals/experimental/redteam/strategies/crescendo/__init__.py
+++ b/src/strands_evals/experimental/redteam/strategies/crescendo/__init__.py
@@ -34,7 +34,7 @@ from pydantic import BaseModel, Field
 from strands import Agent
 from strands.models.model import Model
 
-from ...utils import _serialize_model
+from ...utils import _put_model_field
 from ..base import AttackRunResult, AttackStrategy
 from . import crescendo_v0
 
@@ -336,9 +336,7 @@ class CrescendoStrategy(AttackStrategy):
             max_backtracks=self._max_backtracks,
             success_threshold=self._success_threshold,
         )
-        model_id = _serialize_model(self._model)
-        if model_id is not None:
-            out["model"] = model_id
+        _put_model_field(out, self._model)
         return out
 
     def _build_judge(self, model: Model | str | None) -> Agent:

--- a/src/strands_evals/experimental/redteam/strategies/goat/__init__.py
+++ b/src/strands_evals/experimental/redteam/strategies/goat/__init__.py
@@ -24,6 +24,7 @@ from pydantic import BaseModel, Field
 from strands import Agent
 from strands.models.model import Model
 
+from ...utils import _put_model_field
 from ..base import AttackRunResult, AttackStrategy
 from . import goat_v0
 
@@ -180,6 +181,16 @@ class GoatStrategy(AttackStrategy):
     @property
     def name(self) -> str:
         return "goat"
+
+    def to_dict(self) -> dict[str, Any]:
+        out = super().to_dict()
+        out.update(
+            max_turns=self._max_turns,
+            success_threshold=self._success_threshold,
+            store_reasoning=self._store_reasoning,
+        )
+        _put_model_field(out, self._model)
+        return out
 
     def run_attack(
         self,

--- a/src/strands_evals/experimental/redteam/strategies/pair/__init__.py
+++ b/src/strands_evals/experimental/redteam/strategies/pair/__init__.py
@@ -37,6 +37,7 @@ from pydantic import BaseModel, Field
 from strands import Agent
 from strands.models.model import Model
 
+from ...utils import _put_model_field
 from ..base import AttackRunResult, AttackStrategy
 from . import pair_v0
 
@@ -212,6 +213,15 @@ class PairStrategy(AttackStrategy):
     @property
     def name(self) -> str:
         return "pair"
+
+    def to_dict(self) -> dict[str, Any]:
+        out = super().to_dict()
+        out.update(
+            max_turns=self._max_turns,
+            success_threshold=self._success_threshold,
+        )
+        _put_model_field(out, self._model)
+        return out
 
     def run_attack(
         self,

--- a/src/strands_evals/experimental/redteam/strategies/sequentialbreak/__init__.py
+++ b/src/strands_evals/experimental/redteam/strategies/sequentialbreak/__init__.py
@@ -52,6 +52,7 @@ from pydantic import BaseModel, Field
 from strands import Agent
 from strands.models.model import Model
 
+from ...utils import _put_model_field
 from ..base import AttackRunResult, AttackStrategy
 from . import sequentialbreak_v0
 
@@ -214,6 +215,16 @@ class SequentialBreakStrategy(AttackStrategy):
     @property
     def name(self) -> str:
         return "sequentialbreak"
+
+    def to_dict(self) -> dict[str, Any]:
+        out = super().to_dict()
+        out.update(
+            variants=list(self._variants),
+            max_turns=self._max_turns,
+            success_threshold=self._success_threshold,
+        )
+        _put_model_field(out, self._model)
+        return out
 
     def run_attack(
         self,

--- a/src/strands_evals/experimental/redteam/utils.py
+++ b/src/strands_evals/experimental/redteam/utils.py
@@ -37,3 +37,15 @@ def _serialize_model(model: Model | str | None) -> str | None:
         type(model).__name__,
     )
     return None
+
+
+def _put_model_field(out: dict, model: Model | str | None) -> None:
+    """Coerce `model` via `_serialize_model` and write it onto `out["model"]` if non-None.
+
+    Centralizes the `to_dict` idiom shared by the experiment and every model-aware
+    strategy: when `_serialize_model` drops the field (None / non-coercible Model),
+    the key stays absent so reload falls back to the experiment-level model.
+    """
+    model_id = _serialize_model(model)
+    if model_id is not None:
+        out["model"] = model_id

--- a/tests/strands_evals/experimental/redteam/test_experiment.py
+++ b/tests/strands_evals/experimental/redteam/test_experiment.py
@@ -7,7 +7,14 @@ from strands_evals.experimental.redteam.case import RedTeamCase
 from strands_evals.experimental.redteam.evaluators import AttackSuccessEvaluator
 from strands_evals.experimental.redteam.experiment import RedTeamExperiment
 from strands_evals.experimental.redteam.report import RedTeamReport
-from strands_evals.experimental.redteam.strategies import CrescendoStrategy, PromptStrategy
+from strands_evals.experimental.redteam.strategies import (
+    BadLikertJudgeStrategy,
+    CrescendoStrategy,
+    GoatStrategy,
+    PairStrategy,
+    PromptStrategy,
+    SequentialBreakStrategy,
+)
 from strands_evals.experimental.redteam.strategies.base import AttackRunResult, AttackStrategy
 from strands_evals.experimental.redteam.types import AttackGoal, RedTeamConfig
 
@@ -199,6 +206,106 @@ def test_to_dict_persists_strategies_and_model():
         "system_prompt_template": "TPL",
         "max_turns": 4,
     }
+
+
+def test_to_dict_persists_bad_likert_judge_strategy():
+    exp = RedTeamExperiment(
+        cases=[_case()],
+        attack_strategies=[
+            BadLikertJudgeStrategy(refine_rounds=1, success_threshold=0.6, model="claude-stub", label="blj-fast"),
+        ],
+    )
+    out = exp.to_dict()
+    assert out["attack_strategies"][0] == {
+        "strategy_type": "BadLikertJudgeStrategy",
+        "label": "blj-fast",
+        "refine_rounds": 1,
+        "success_threshold": 0.6,
+        "model": "claude-stub",
+    }
+
+
+def test_to_dict_persists_goat_strategy():
+    exp = RedTeamExperiment(
+        cases=[_case()],
+        attack_strategies=[
+            GoatStrategy(max_turns=4, success_threshold=0.6, model="claude-stub", store_reasoning=True, label="g"),
+        ],
+    )
+    out = exp.to_dict()
+    assert out["attack_strategies"][0] == {
+        "strategy_type": "GoatStrategy",
+        "label": "g",
+        "max_turns": 4,
+        "success_threshold": 0.6,
+        "store_reasoning": True,
+        "model": "claude-stub",
+    }
+
+
+def test_to_dict_persists_pair_strategy():
+    exp = RedTeamExperiment(
+        cases=[_case()],
+        attack_strategies=[
+            PairStrategy(max_turns=3, success_threshold=0.9, model="claude-stub", label="p"),
+        ],
+    )
+    out = exp.to_dict()
+    assert out["attack_strategies"][0] == {
+        "strategy_type": "PairStrategy",
+        "label": "p",
+        "max_turns": 3,
+        "success_threshold": 0.9,
+        "model": "claude-stub",
+    }
+
+
+def test_to_dict_persists_sequentialbreak_strategy():
+    exp = RedTeamExperiment(
+        cases=[_case()],
+        attack_strategies=[
+            SequentialBreakStrategy(
+                variants=["dc_t1"], max_turns=1, success_threshold=0.6, model="claude-stub", label="sb"
+            ),
+        ],
+    )
+    out = exp.to_dict()
+    assert out["attack_strategies"][0] == {
+        "strategy_type": "SequentialBreakStrategy",
+        "label": "sb",
+        "variants": ["dc_t1"],
+        "max_turns": 1,
+        "success_threshold": 0.6,
+        "model": "claude-stub",
+    }
+
+
+def test_round_trip_preserves_all_builtin_strategies(tmp_path):
+    """All built-ins resolve through the registry and survive a to_file/from_file cycle."""
+    exp = RedTeamExperiment(
+        cases=[_case()],
+        attack_strategies=[
+            CrescendoStrategy(label="cre"),
+            PromptStrategy("gradual_escalation", "TPL", label="prompt"),
+            BadLikertJudgeStrategy(label="blj"),
+            GoatStrategy(label="goat"),
+            PairStrategy(label="pair"),
+            SequentialBreakStrategy(label="sb"),
+        ],
+    )
+    p = tmp_path / "rt.json"
+    exp.to_file(str(p))
+    loaded = RedTeamExperiment.from_file(str(p))
+
+    assert [type(s).__name__ for s in loaded.attack_strategies] == [
+        "CrescendoStrategy",
+        "PromptStrategy",
+        "BadLikertJudgeStrategy",
+        "GoatStrategy",
+        "PairStrategy",
+        "SequentialBreakStrategy",
+    ]
+    assert [s.label for s in loaded.attack_strategies] == ["cre", "prompt", "blj", "goat", "pair", "sb"]
 
 
 def test_from_dict_round_trip_runs_after_setting_agent(tmp_path):


### PR DESCRIPTION
## Description

1. Adds `to_dict` / `from_dict` round-trip support for the four built-in attack strategies that were previously only persisted with `strategy_type` + `label`: `BadLikertJudgeStrategy`, `GoatStrategy`, `PairStrategy`, and `SequentialBreakStrategy`. 

  - Each now serializes its fields (`max_turns`, `success_threshold`, strategy-specific params) and its `model` so a saved experiment reloads with the same configuration.

2. Light cleanup along the way: updated the function and renamed `_serialize_model` to `_put_model_field`. Behavior is unchanged.


## Notes
`AttackStrategy.from_dict` already centralized the registry lookup; the four classes are added there alongside `CrescendoStrategy` / `PromptStrategy` so reload resolves them without `custom_strategies=`.

## Related Issues

N/A

## Documentation PR

N/A

## Type of Change

New feature

## Testing

- Added per-strategy `to_dict` assertions for BLJ / Goat / Pair / SequentialBreak.
- Added `test_round_trip_preserves_all_builtin_strategies`: builds an experiment with all six built-ins, writes via `to_file`, reloads via `from_file`, and asserts type and label preservation.
- Existing `test_from_dict_round_trip_runs_after_setting_agent` continues to pass.
- `tests/strands_evals/experimental/redteam/` — 312 passed.
- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.