### PR TITLE
feat(redteam): support async cases execution

### DIFF
--- a/src/strands_evals/experimental/redteam/__init__.py
+++ b/src/strands_evals/experimental/redteam/__init__.py
@@ -12,6 +12,8 @@ from .strategies import (
     PairStrategy,
     PromptStrategy,
     SequentialBreakStrategy,
+    StrandsAgentSession,
+    StrandsMultiAgentSession,
     TargetCheckpoint,
     TargetSession,
 )
@@ -36,6 +38,8 @@ __all__ = [
     "RedTeamExperiment",
     "RedTeamReport",
     "SequentialBreakStrategy",
+    "StrandsAgentSession",
+    "StrandsMultiAgentSession",
     "TargetCheckpoint",
     "TargetSession",
     "TargetSpec",

--- a/src/strands_evals/experimental/redteam/experiment.py
+++ b/src/strands_evals/experimental/redteam/experiment.py
@@ -11,6 +11,7 @@ from typing import Any, cast
 
 from strands import Agent
 from strands.models.model import Model
+from strands.multiagent.base import MultiAgentBase
 
 from ...case import Case
 from ...evaluation_data_store import EvaluationDataStore
@@ -29,11 +30,23 @@ from .utils import _put_model_field
 class RedTeamExperiment(Experiment[InputT, OutputT]):
     """Experiment that runs the case x strategy cross-product and returns a `RedTeamReport`.
 
+    Targets can be a single `strands.Agent`, a multi-agent system (`strands.multiagent.Graph`,
+    `strands.multiagent.Swarm`, or any `strands.multiagent.base.MultiAgentBase`), or a custom
+    `TargetSession` Protocol implementer.
+
     Example:
         ```python
+        # Single Agent target
         cases = AdversarialCaseGenerator(model=model).generate_cases(agent=agent)
         experiment = RedTeamExperiment(
             cases=cases, agent=agent, attack_strategies=[CrescendoStrategy(max_turns=10)]
+        )
+        report = experiment.run_evaluations()
+
+        # Multi-agent (Graph / Swarm) target
+        graph = Graph(...)  # or Swarm(...)
+        experiment = RedTeamExperiment(
+            cases=cases, agent=graph, attack_strategies=[CrescendoStrategy(max_turns=10)]
         )
         report = experiment.run_evaluations()
         report.display()
@@ -44,7 +57,8 @@ class RedTeamExperiment(Experiment[InputT, OutputT]):
         self,
         cases: list[Case[InputT, OutputT]] | None = None,
         *,
-        agent: Agent | TargetSession | None = None,
+        agent: Agent | MultiAgentBase | TargetSession | None = None,
+        agent_factory: Callable[[], Agent | MultiAgentBase | TargetSession] | None = None,
         attack_strategies: list[AttackStrategy] | None = None,
         evaluators: list[Evaluator[InputT, OutputT]] | None = None,
         model: Model | str | None = None,
@@ -54,6 +68,7 @@ class RedTeamExperiment(Experiment[InputT, OutputT]):
             evaluators=evaluators or [AttackSuccessEvaluator(model=model)],
         )
         self._agent = agent
+        self._agent_factory = agent_factory
         self._attack_strategies = attack_strategies or []
         self._by_label = self._build_by_label(self._attack_strategies)
         self._model = model
@@ -62,16 +77,36 @@ class RedTeamExperiment(Experiment[InputT, OutputT]):
         self._run_meta: dict[str, dict[str, Any]] = {}
 
     @property
-    def agent(self) -> Agent | TargetSession | None:
+    def agent(self) -> Agent | MultiAgentBase | TargetSession | None:
         """The target the default attacker task talks to.
 
-        Not persisted by `to_dict`; set via this setter after `from_file` / `from_dict` before `run_evaluations`.
+        Accepts a single `strands.Agent`, a `MultiAgentBase` (e.g. `Graph`, `Swarm`), or a custom
+        `TargetSession`. Not persisted by `to_dict`; set via this setter after `from_file` /
+        `from_dict` before `run_evaluations`.
         """
         return self._agent
 
     @agent.setter
-    def agent(self, value: Agent | TargetSession | None) -> None:
+    def agent(self, value: Agent | MultiAgentBase | TargetSession | None) -> None:
         self._agent = value
+
+    @property
+    def agent_factory(self) -> Callable[[], Agent | MultiAgentBase | TargetSession] | None:
+        """Zero-arg callable that returns a fresh target per case.
+
+        When set, the factory is used for every case -- sequential runs included -- and takes
+        precedence over `agent`. Required for parallel runs (`max_workers > 1`): real Strands
+        targets carry non-deepcopyable client state (the default `BedrockModel` holds an httplib
+        pool with thread locks), so the runner cannot clone `self.agent` safely; the user must
+        construct each per-case target themselves.
+
+        Not persisted by `to_dict`.
+        """
+        return self._agent_factory
+
+    @agent_factory.setter
+    def agent_factory(self, value: Callable[[], Agent | MultiAgentBase | TargetSession] | None) -> None:
+        self._agent_factory = value
 
     @property
     def attack_strategies(self) -> list[AttackStrategy]:
@@ -121,18 +156,33 @@ class RedTeamExperiment(Experiment[InputT, OutputT]):
     async def run_evaluations_async(  # type: ignore[override]
         self,
         task: Callable | None = None,
-        max_workers: int = 1,
+        max_workers: int = 5,
         evaluation_data_store: EvaluationDataStore | None = None,
     ) -> RedTeamReport:
-        # Parallel workers would interleave on the shared target Agent and on each
-        # strategy instance's per-case state, so red team runs are strictly sequential.
-        if max_workers != 1:
-            raise ValueError("RedTeamExperiment requires max_workers=1 (shared target Agent and strategy state).")
+        """Run case-strategy cross-product, in parallel when `max_workers > 1`.
+
+        Defaults to `max_workers=5`: callers reaching for the async entry point are opting into
+        concurrency, and 5 is the largest value safe across most provider tiers without user-side
+        rate-limit tuning. Bump higher for fast targets / generous TPM budgets; drop to 1 for
+        deterministic ordering or to debug a single case.
+
+        Parallel runs require each worker to have its own target so concurrent `invoke()` calls
+        cannot interleave on shared agent state. The default attacker task uses `agent_factory`
+        (called once per case to produce a fresh target). `agent` is for sequential runs only --
+        Strands targets aren't safely deepcopyable, so we don't try. A user-supplied `task`
+        callable is treated as already parallel-safe.
+
+        Strategy instances are shared across all concurrent cases; per-case state must live in
+        `run_attack` locals, not on `self`. See `AttackStrategy.run_attack` for the contract.
+        """
+        if max_workers < 1:
+            raise ValueError(f"max_workers must be >= 1, got {max_workers}")
         self._run_meta.clear()
         if task is None:
-            task = self._default_task()
-        # Swap _cases for the expanded cross-product only for the duration of the base
-        # run; safe because max_workers=1 is enforced, so nothing else reads it concurrently.
+            task = self._default_task(parallel=max_workers > 1)
+        # Swap _cases for the expanded cross-product. Each case has a unique name (case x strategy
+        # label), so parallel workers never collide on the same key in the base runner's results
+        # buffer or in `self._run_meta`.
         original_cases = self._cases
         self._cases = self._expand_cross_product()
         try:
@@ -143,10 +193,10 @@ class RedTeamExperiment(Experiment[InputT, OutputT]):
             self._cases = original_cases
         return RedTeamReport.from_evaluation_report(report, run_meta=self._run_meta)
 
-    def _default_task(self) -> Callable[[Case[InputT, OutputT]], Any]:
-        if self._agent is None:
+    def _default_task(self, *, parallel: bool = False) -> Callable[[Case[InputT, OutputT]], Any]:
+        if self._agent is None and self._agent_factory is None:
             raise ValueError(
-                "RedTeamExperiment requires either `agent` at construction "
+                "RedTeamExperiment requires either `agent` (or `agent_factory`) at construction "
                 "or an explicit `task` argument to run_evaluations()."
             )
         return cast(
@@ -154,8 +204,10 @@ class RedTeamExperiment(Experiment[InputT, OutputT]):
             _build_attacker_task(
                 self._agent,
                 self._by_label,
+                agent_factory=self._agent_factory,
                 model=self._model,
                 run_meta=self._run_meta,
+                parallel=parallel,
             ),
         )
 
@@ -174,7 +226,11 @@ class RedTeamExperiment(Experiment[InputT, OutputT]):
         custom_evaluators: list[type[Evaluator]] | None = None,
         custom_strategies: list[type[AttackStrategy]] | None = None,
     ):
-        """Load a RedTeamExperiment from JSON. The loaded experiment has no `agent` attached."""
+        """Load a RedTeamExperiment from JSON.
+
+        The loaded experiment has neither `agent` nor `agent_factory` attached -- both are
+        runtime-only and not serialized. Reattach via the setters before `run_evaluations`.
+        """
         file_path = Path(path)
         if file_path.suffix != ".json":
             raise ValueError(

--- a/src/strands_evals/experimental/redteam/strategies/base.py
+++ b/src/strands_evals/experimental/redteam/strategies/base.py
@@ -75,6 +75,13 @@ class AttackStrategy(ABC):
     ) -> AttackRunResult:
         """Run the multi-turn attack and return its result.
 
+        Parallel safety: a single strategy instance is shared across every case in an experiment,
+        including parallel ones. Implementations MUST keep per-case state in `run_attack` locals
+        (or the supplied `target_session`); writing to `self` mid-run is cross-talk between
+        concurrent cases. If a strategy needs to track state across turns within one case, use
+        local variables. If it needs to reset something on `self` between cases, do it in
+        `reset()`, not in `run_attack`.
+
         Args:
             case: The red team case carrying the attack goal.
             target_session: Session for talking to the target; use `target_session.invoke(message)`.

--- a/src/strands_evals/experimental/redteam/task.py
+++ b/src/strands_evals/experimental/redteam/task.py
@@ -20,21 +20,68 @@ MAX_ALLOWED_TURNS = 50
 
 
 def _build_attacker_task(
-    agent: Agent | MultiAgentBase | TargetSession,
+    agent: Agent | MultiAgentBase | TargetSession | None,
     by_label: dict[str, AttackStrategy],
     *,
+    agent_factory: Callable[[], Agent | MultiAgentBase | TargetSession] | None = None,
     model: Model | str | None = None,
     run_meta: dict[str, dict[str, Any]] | None = None,
+    parallel: bool = False,
 ) -> Callable[[RedTeamCase], dict]:
     """Build a `task(case) -> {"output": conversation, "trajectory": tool_uses}` callable.
 
     Looks up each case's strategy by `metadata["strategy"]` and delegates the multi-turn loop to
     `strategy.run_attack`, injecting a `TargetSession`. `MAX_ALLOWED_TURNS` is the hard ceiling. Run metadata
     is recorded into `run_meta` keyed by case name.
-    """
 
-    # Capture the clean baseline ONCE, before any case runs, so every per-case reset
-    # rolls back to the same as-constructed state rather than to case N-1's history.
+    Args:
+        agent: The shared target for sequential runs. Required when `agent_factory` is None.
+        by_label: Strategy registry keyed by `metadata["strategy"]` label.
+        agent_factory: Zero-arg callable returning a fresh target for each case. Required for parallel
+            runs (`parallel=True`); takes precedence over `agent` when both are set.
+        model: Model passed through to `strategy.run_attack` for strategy-internal LLM calls.
+        run_meta: Per-case strategy metadata sink, keyed by `case.name`.
+        parallel: When True, every case is built from `agent_factory` so concurrent cases never share
+            mutable state. When False, all cases share one target and rewind to a once-captured baseline
+            between cases.
+    """
+    if agent is None and agent_factory is None:
+        raise ValueError("must provide either `agent` or `agent_factory`.")
+
+    # Per-case construction handles both parallel runs (fresh target per worker) and the case where
+    # the user passes a factory without an `agent` to share. Snapshot-based reset only fits when the
+    # same target is reused sequentially across cases.
+    if parallel or agent_factory is not None:
+        return _build_per_case_task_fn(
+            agent=agent,
+            agent_factory=agent_factory,
+            by_label=by_label,
+            model=model,
+            run_meta=run_meta,
+        )
+
+    # Sequential path: `agent` is guaranteed non-None here -- the upfront check rejects (None,
+    # None), and `agent_factory is not None` would have routed us to the per-case builder above.
+    return _build_shared_target_task_fn(
+        agent=agent,  # type: ignore[arg-type]
+        by_label=by_label,
+        model=model,
+        run_meta=run_meta,
+    )
+
+
+def _build_shared_target_task_fn(
+    *,
+    agent: Agent | MultiAgentBase | TargetSession,
+    by_label: dict[str, AttackStrategy],
+    model: Model | str | None,
+    run_meta: dict[str, dict[str, Any]] | None,
+) -> Callable[[RedTeamCase], dict]:
+    """Build a task fn that drives one shared target across cases, rewinding to a fixed baseline.
+
+    Captures the clean baseline ONCE, before any case runs, so every per-case reset rolls back to
+    the same as-constructed state rather than to case N-1's history.
+    """
     initial_snapshot: Any
     if isinstance(agent, Agent):
         initial_snapshot = agent.take_snapshot(preset="session")
@@ -60,6 +107,67 @@ def _build_attacker_task(
         }
 
     return task_fn
+
+
+def _build_per_case_task_fn(
+    *,
+    agent: Agent | MultiAgentBase | TargetSession | None,
+    agent_factory: Callable[[], Agent | MultiAgentBase | TargetSession] | None,
+    by_label: dict[str, AttackStrategy],
+    model: Model | str | None,
+    run_meta: dict[str, dict[str, Any]] | None,
+) -> Callable[[RedTeamCase], dict]:
+    """Build a per-case task fn that constructs its own target every case.
+
+    Resolves the target source once at build time into a single zero-arg `make_target` callable so
+    the per-case path has no runtime branch. Callers (parallel runs against a custom
+    `TargetSession` with no factory) get a `TypeError` here, before any case runs.
+    """
+    make_target = _resolve_target_source(agent=agent, agent_factory=agent_factory)
+
+    def task_fn(case: RedTeamCase) -> dict:
+        strategy = _resolve_case_strategy(case, by_label)
+        strategy.reset()
+
+        # No baseline: each case starts from a freshly built target, and `session.reset()` only
+        # needs to clear the per-case trace.
+        session = _build_session(make_target(), baseline=None)
+        session.reset()
+
+        result = strategy.run_attack(case, session, max_turns=MAX_ALLOWED_TURNS, model=model)
+        if run_meta is not None and case.name is not None:
+            # CPython dict assignment for a single distinct key is atomic, and case names are unique
+            # per cross-product expansion, so concurrent writers never target the same key.
+            run_meta[case.name] = {**result.metadata, "pruned_branches": result.pruned_branches}
+        return {
+            "output": result.conversation,
+            "trajectory": list(session.trace),
+        }
+
+    return task_fn
+
+
+def _resolve_target_source(
+    *,
+    agent: Agent | MultiAgentBase | TargetSession | None,
+    agent_factory: Callable[[], Agent | MultiAgentBase | TargetSession] | None,
+) -> Callable[[], Agent | MultiAgentBase | TargetSession]:
+    """Require an `agent_factory` for the per-case path, rejecting config errors up front.
+
+    Per-case construction always goes through a user-supplied factory. The deep-copy fallback
+    against a `strands.Agent` was removed because real Strands agents are not deepcopyable -- the
+    default `BedrockModel` carries an httplib pool with thread locks that `copy.deepcopy` chokes
+    on. Surfacing the requirement at config time beats crashing mid-run with a `cannot pickle
+    '_thread.lock'` deep in `copy.py`.
+    """
+    if agent_factory is not None:
+        return agent_factory
+    raise TypeError(
+        "Parallel red team runs require `agent_factory=...`. Strands `Agent` and `MultiAgentBase` "
+        "instances cannot be deep-copied per worker (their default model client holds non-pickleable "
+        f"state); got agent={type(agent).__name__!r}, agent_factory=None. Pass a zero-arg factory "
+        "that returns a fresh target for each case."
+    )
 
 
 def _build_session(

--- a/tests/strands_evals/experimental/redteam/test_experiment.py
+++ b/tests/strands_evals/experimental/redteam/test_experiment.py
@@ -152,14 +152,103 @@ async def test_run_evaluations_async_returns_report():
         agent=_FakeSession(),
         attack_strategies=[_StubStrategy()],
     )
-    report = await exp.run_evaluations_async()
+    # Sequential -- a TargetSession can't be deep-copied, and parallel paths are covered below.
+    report = await exp.run_evaluations_async(max_workers=1)
     assert isinstance(report, RedTeamReport)
 
 
-async def test_max_workers_must_be_one():
+async def test_max_workers_must_be_positive():
     exp = RedTeamExperiment(cases=[_case()], agent=_FakeSession(), attack_strategies=[_StubStrategy()])
-    with pytest.raises(ValueError, match="max_workers=1"):
-        await exp.run_evaluations_async(max_workers=4)
+    with pytest.raises(ValueError, match="max_workers"):
+        await exp.run_evaluations_async(max_workers=0)
+
+
+async def test_parallel_requires_agent_factory():
+    """Parallel runs always require `agent_factory` -- the runner does not deepcopy targets."""
+    exp = RedTeamExperiment(cases=[_case()], agent=_FakeSession(), attack_strategies=[_StubStrategy()])
+    with pytest.raises(TypeError, match="agent_factory"):
+        await exp.run_evaluations_async(max_workers=2)
+
+
+async def test_parallel_uses_agent_factory_per_case():
+    """When parallel and `agent_factory` is set, each case gets a fresh target from the factory."""
+    factory_calls: list[_FakeSession] = []
+
+    def factory():
+        sess = _FakeSession()
+        factory_calls.append(sess)
+        return sess
+
+    exp = RedTeamExperiment(
+        cases=[_case("c0"), _case("c1"), _case("c2")],
+        agent_factory=factory,
+        attack_strategies=[_StubStrategy()],
+    )
+    report = await exp.run_evaluations_async(max_workers=3)
+    assert isinstance(report, RedTeamReport)
+    assert len(factory_calls) == 3
+
+
+async def test_parallel_report_per_case_isolation():
+    """End-to-end: under `max_workers > 1`, each case's output lands on its own report row.
+
+    Pins the property the parallel path is *for* -- that concurrent cases don't bleed each
+    other's outputs through the shared strategy / shared `_run_meta` dict.
+    """
+
+    class _EchoStrategy(AttackStrategy):
+        @property
+        def name(self) -> str:
+            return "echo"
+
+        def run_attack(self, case, target_session, *, max_turns, model=None, **kwargs) -> AttackRunResult:
+            target_session.invoke(case.input)
+            return AttackRunResult(
+                conversation=[{"role": "attacker", "content": case.input}],
+                metadata={"echoed": case.input},
+            )
+
+    def factory():
+        return _FakeSession()
+
+    cases = [_case(f"c{i}") for i in range(5)]
+    for i, case in enumerate(cases):
+        case.input = f"msg-{i}"
+
+    exp = RedTeamExperiment(
+        cases=cases,
+        agent_factory=factory,
+        attack_strategies=[_EchoStrategy()],
+    )
+    report = await exp.run_evaluations_async(max_workers=4)
+
+    by_name = {r.case_name: r for r in report.attack_results()}
+    assert set(by_name) == {"c0__echo", "c1__echo", "c2__echo", "c3__echo", "c4__echo"}
+    for i in range(5):
+        attack = by_name[f"c{i}__echo"]
+        assert attack.conversation == [{"role": "attacker", "content": f"msg-{i}"}]
+
+
+async def test_factory_wins_in_sequential_runs():
+    """`agent_factory` overrides `agent` even at `max_workers=1` -- factory is the source of truth."""
+    factory_calls: list[_FakeSession] = []
+
+    def factory():
+        sess = _FakeSession()
+        factory_calls.append(sess)
+        return sess
+
+    shared = _FakeSession()
+    exp = RedTeamExperiment(
+        cases=[_case("c0"), _case("c1")],
+        agent=shared,
+        agent_factory=factory,
+        attack_strategies=[_StubStrategy()],
+    )
+    report = await exp.run_evaluations_async(max_workers=1)
+    assert isinstance(report, RedTeamReport)
+    assert len(factory_calls) == 2
+    assert shared not in factory_calls
 
 
 def test_async_task_rejected():

--- a/tests/strands_evals/experimental/redteam/test_task.py
+++ b/tests/strands_evals/experimental/redteam/test_task.py
@@ -223,6 +223,79 @@ def test_max_allowed_turns_constant_present():
     assert MAX_ALLOWED_TURNS >= 50
 
 
+def test_parallel_task_fn_calls_factory_per_case():
+    """`parallel=True` with `agent_factory` builds a fresh target for every case."""
+    factory_calls: list[_FakeSession] = []
+
+    def factory():
+        sess = _FakeSession(lambda _msg: "ok")
+        factory_calls.append(sess)
+        return sess
+
+    task = _build_attacker_task(
+        agent=None,
+        by_label=_by_label(_StubStrategy()),
+        agent_factory=factory,
+        parallel=True,
+    )
+    task(_case("c0"))
+    task(_case("c1"))
+    task(_case("c2"))
+    assert len(factory_calls) == 3
+
+
+def test_parallel_task_fn_requires_agent_factory():
+    """Parallel runs always require an explicit `agent_factory` -- there is no deepcopy fallback.
+
+    Strands targets carry non-deepcopyable client state (the default `BedrockModel` holds an
+    httplib pool with thread locks), so the runner refuses parallel without a factory regardless
+    of whether `agent` is an `Agent`, `MultiAgentBase`, or a custom `TargetSession`. Surfacing
+    the requirement at build time beats crashing mid-run.
+    """
+    from strands import Agent
+
+    real_agent = Agent(model=None, callback_handler=None)
+    with pytest.raises(TypeError, match="agent_factory"):
+        _build_attacker_task(
+            agent=real_agent,
+            by_label=_by_label(_StubStrategy()),
+            parallel=True,
+        )
+
+    sess = _FakeSession(lambda _msg: "ok")
+    with pytest.raises(TypeError, match="agent_factory"):
+        _build_attacker_task(
+            agent=sess,
+            by_label=_by_label(_StubStrategy()),
+            parallel=True,
+        )
+
+
+def test_factory_path_skips_baseline_snapshot():
+    """When `agent_factory` is supplied, the build step never calls `take_snapshot` on the source
+    `agent` -- the factory is the source of truth for clean state."""
+    from strands import Agent
+
+    agent = MagicMock(spec=Agent)
+    agent.messages = MagicMock()
+    agent.messages.__len__.return_value = 0
+
+    def factory():
+        target = MagicMock(spec=Agent)
+        target.messages = MagicMock()
+        target.messages.__len__.return_value = 0
+        target.return_value = "ok"
+        return target
+
+    _build_attacker_task(
+        agent=agent,
+        by_label=_by_label(_StubStrategy()),
+        agent_factory=factory,
+    )
+    # the factory path neither captures a baseline nor mutates the seed agent.
+    assert agent.take_snapshot.call_count == 0
+
+
 def test_task_fn_routes_multi_agent_base_to_multi_agent_session():
     """A MultiAgentBase target is wrapped in StrandsMultiAgentSession (not
     StrandsAgentSession) and the baseline is captured once at build time."""


### PR DESCRIPTION
## Description

Lifts the `max_workers=1` restriction in `RedTeamExperiment.run_evaluations_async` so users can run case-strategy cross-products in parallel, and widens the public API to make multi-agent (`Graph`/`Swarm`) targets discoverable.

The previous code pinned `max_workers=1` because the entire experiment shared one `TargetSession` wrapping one target agent — concurrent cases would interleave on `invoke()`/`snapshot()`/`restore()` of that single agent. Built-in strategies are stateless across cases (their `reset()` is a no-op), so the strategy instances themselves are not the blocker. The fix is to give each parallel case its own target.

### Parallelism (the main change)

- New ctor arg `agent_factory: Callable[[], Agent | MultiAgentBase | TargetSession]`. Called once per case to produce a fresh, independent target. Required for parallel runs against a custom `TargetSession` (a Protocol implementer cannot be safely deep-copied).
- When `agent` is a `strands.Agent` / `MultiAgentBase` and no factory is set, parallel runs `copy.deepcopy(agent)` per case so concurrent workers never share mutable state.
- `run_evaluations_async` now accepts any `max_workers >= 1` (default still `1`, fully backward-compatible). Sequential runs keep the existing snapshot-based per-case reset against a single shared target.
- New helper `_build_per_case_task_fn` in `task.py` handles parallel + factory paths; sequential snapshot path unchanged.

Concurrent writes to `self._run_meta` are safe because the cross-product expansion guarantees unique `case.name` per work item, so each thread targets a distinct dict key.

### Multi-agent target discoverability (follow-up to #251)

`StrandsMultiAgentSession` was already wired through `task._build_session`, but the public surface of `RedTeamExperiment` didn't surface it:

- `RedTeamExperiment.__init__` and the `agent` / `agent_factory` getters/setters now type the target as `Agent | MultiAgentBase | TargetSession | None`, matching what the runtime actually accepts.
- `StrandsAgentSession` and `StrandsMultiAgentSession` are re-exported from `strands_evals.experimental.redteam` so users find them at the top-level package, not under `.strategies`.
- Class docstring shows a `Graph` / `Swarm` example alongside the single-`Agent` example.

### Usage

```python
# Sequential (unchanged)
exp = RedTeamExperiment(agent=agent, attack_strategies=[CrescendoStrategy()])
report = await exp.run_evaluations_async()

# Parallel via factory
exp = RedTeamExperiment(
    agent_factory=lambda: Agent(model=..., tools=...),
    attack_strategies=[CrescendoStrategy()],
)
report = await exp.run_evaluations_async(max_workers=8)

# Parallel via deep-copy of a single Agent / MultiAgentBase target
graph = Graph(...)
exp = RedTeamExperiment(agent=graph, attack_strategies=[CrescendoStrategy()])
report = await exp.run_evaluations_async(max_workers=4)
```

## Related Issues

N/A

## Documentation PR

N/A

## Type of Change

New feature.

## Testing

- `tests/strands_evals/experimental/redteam/test_experiment.py` — replaced `test_max_workers_must_be_one` with `test_max_workers_must_be_positive`, plus new `test_parallel_requires_clonable_agent_or_factory` and `test_parallel_uses_agent_factory_per_case`.
- `tests/strands_evals/experimental/redteam/test_task.py` — new tests covering the factory-per-case path, the deep-copy-per-case path, the unclonable `TargetSession` rejection, and that the factory path skips the build-time `take_snapshot` call.
- Full red-team suite green: `hatch test tests/strands_evals/experimental/redteam/` → 318 passed.
- `hatch fmt --linter` clean.

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.