### PR TITLE
chore(cli): added fetch command to pull traces from different sources

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -190,7 +190,8 @@ strands-evals/
 │   │       ├── validate.py
 │   │       ├── report.py
 │   │       ├── diagnose.py
-│   │       └── generate.py
+│   │       ├── generate.py
+│   │       └── fetch.py                      # pull Session JSON from a TraceProvider
 │   │
 │   ├── __main__.py                           # `python -m strands_evals` shim → cli.main
 │   │
@@ -235,7 +236,7 @@ strands-evals/
 ### Directory Purposes
 
 - **`src/strands_evals/`**: All production code
-- **`src/strands_evals/cli/`**: `strands-evals` console script — five subcommands (`run`, `validate`, `report`, `diagnose`, `generate`) plus the `module:attr` resolver and synthesized task wrapper used by `--agent`
+- **`src/strands_evals/cli/`**: `strands-evals` console script — six subcommands (`run`, `validate`, `report`, `diagnose`, `generate`, `fetch`) plus the `module:attr` resolver and synthesized task wrapper used by `--agent`. `fetch` has per-provider sub-subcommands (`cloudwatch`, `langfuse`, `opensearch`); langfuse / opensearch are imported lazily so they only fail when invoked without their extra installed.
 - **`tests/strands_evals/`**: Unit tests mirroring src/ structure
 - **`tests/strands_evals/cli/`**: CLI tests; fixtures live under `cli/fixtures/` and are referenced by tests via `tests.strands_evals.cli.fixtures.*:attr` specs
 - **`tests_integ/`**: Integration tests using real trace providers and model endpoints

--- a/SKILL.md
+++ b/SKILL.md
@@ -472,7 +472,7 @@ Only import from `typing` for symbols without a built-in equivalent: `Any`, `Cal
 ## Pointers
 
 - Repo conventions, contribution rules, prompt versioning, review checklist: `AGENTS.md`
-- CLI workflow (`strands-evals run` / `validate` / `diagnose` / `report` / `generate`): see the README "Command-Line Interface" section and `--help` on each subcommand
+- CLI workflow (`strands-evals run` / `validate` / `diagnose` / `report` / `generate` / `fetch`): see the README "Command-Line Interface" section and `--help` on each subcommand. `fetch` has provider-scoped sub-subcommands (`fetch cloudwatch`, `fetch langfuse`, `fetch opensearch`) that emit a Session JSON to stdout or `-o PATH`, ready to pipe into `strands-evals diagnose -`.
 - Logging style: `STYLE_GUIDE.md`
 - Human contributor guide: `CONTRIBUTING.md`
 - User docs: https://strandsagents.com/latest/documentation/docs/user-guide/evals-sdk/quickstart/

--- a/src/strands_evals/cli/commands/fetch.py
+++ b/src/strands_evals/cli/commands/fetch.py
@@ -1,0 +1,276 @@
+"""`strands-evals fetch` — pull traces from a provider and emit a Session JSON.
+
+Each provider is a separate sub-subparser under `fetch`. CloudWatch is always
+available (boto3 is a hard runtime dep); Langfuse and OpenSearch live behind
+optional extras and are imported lazily so users without those extras can still
+run the rest of the CLI.
+"""
+
+from __future__ import annotations
+
+import argparse
+
+from ...types.evaluation import TaskOutput
+from ...types.trace import Session
+from .._common import EXIT_BAD_INPUT, EXIT_OK, emit_error
+from .._io import write_text_output
+
+
+def _emit_session(task_output: TaskOutput, session_id: str, output: str | None) -> int:
+    """Pull the Session out of a provider TaskOutput and write it as JSON.
+
+    Output is always JSON — Rich rendering of a Session has no useful shape;
+    its JSON form is the canonical representation.
+    """
+    trajectory = task_output.get("trajectory")
+    if not isinstance(trajectory, Session):
+        raise RuntimeError(
+            f"provider returned no Session for session_id='{session_id}' (trajectory type: {type(trajectory).__name__})"
+        )
+    write_text_output(trajectory.model_dump_json(indent=2), output)
+    return EXIT_OK
+
+
+def _run_cloudwatch(args: argparse.Namespace) -> int:
+    # Match OpenSearch's paired-creds check style: validate client-side and
+    # exit 2 with a friendly message rather than letting CloudWatchProvider's
+    # ProviderError bubble up as a generic exit-3 runtime error.
+    if (args.log_group is None) == (args.agent_name is None):
+        emit_error("exactly one of --log-group or --agent-name is required")
+        return EXIT_BAD_INPUT
+
+    from ...providers.cloudwatch_provider import CloudWatchProvider
+
+    provider = CloudWatchProvider(
+        region=args.region,
+        log_group=args.log_group,
+        agent_name=args.agent_name,
+        lookback_days=args.lookback_days,
+    )
+    return _emit_session(provider.get_evaluation_data(args.session_id), args.session_id, args.output)
+
+
+def _run_langfuse(args: argparse.Namespace) -> int:
+    try:
+        # optional extra: langfuse
+        from ...providers.langfuse_provider import LangfuseProvider
+    except ImportError:
+        emit_error("langfuse extra not installed; install with `pip install strands-agents-evals[langfuse]`")
+        return EXIT_BAD_INPUT
+
+    provider = LangfuseProvider(host=args.host, timeout=args.timeout)
+    return _emit_session(provider.get_evaluation_data(args.session_id), args.session_id, args.output)
+
+
+def _run_opensearch(args: argparse.Namespace) -> int:
+    auth: tuple[str, str] | None = None
+    if args.username is not None or args.password is not None:
+        if args.username is None or args.password is None:
+            emit_error("--username and --password must be provided together")
+            return EXIT_BAD_INPUT
+        auth = (args.username, args.password)
+
+    # `OpenSearchProvider` lazy-imports `opensearch_genai_observability_sdk_py`
+    # inside its constructor (so the provider class itself is always importable).
+    # Wrap both the module import and the constructor call in the ImportError
+    # guard, scoped tightly so genuine inner ImportErrors aren't masked.
+    try:
+        # optional extra: opensearch
+        from ...providers.opensearch_provider import OpenSearchProvider
+
+        provider = OpenSearchProvider(
+            host=args.host,
+            index=args.index,
+            auth=auth,
+            verify_certs=args.verify_certs,
+        )
+    except ImportError:
+        emit_error("opensearch extra not installed; install with `pip install strands-agents-evals[opensearch]`")
+        return EXIT_BAD_INPUT
+
+    return _emit_session(provider.get_evaluation_data(args.session_id), args.session_id, args.output)
+
+
+def add_subparser(
+    subparsers: argparse._SubParsersAction,
+    parent: argparse.ArgumentParser,
+) -> argparse.ArgumentParser:
+    parser = subparsers.add_parser(
+        "fetch",
+        parents=[parent],
+        help="fetch traces from a provider and emit a Session JSON",
+        description=(
+            "Wraps a TraceProvider — one sub-subcommand per backend "
+            "(cloudwatch, langfuse, opensearch). The fetched Session JSON "
+            "goes to -o PATH or stdout, ready to pipe into "
+            "`strands-evals diagnose -`. Credentials come from environment "
+            "variables (AWS_REGION, LANGFUSE_PUBLIC_KEY, LANGFUSE_SECRET_KEY, "
+            "etc.); the CLI does not reimplement auth."
+        ),
+    )
+    sub = parser.add_subparsers(dest="provider", metavar="PROVIDER")
+    sub.required = True
+
+    _add_cloudwatch_parser(sub, parent)
+    _add_langfuse_parser(sub, parent)
+    _add_opensearch_parser(sub, parent)
+
+    return parser
+
+
+def _add_cloudwatch_parser(
+    sub: argparse._SubParsersAction,
+    parent: argparse.ArgumentParser,
+) -> None:
+    cw = sub.add_parser(
+        "cloudwatch",
+        parents=[parent],
+        help="fetch a session from AWS CloudWatch Logs",
+        description=(
+            "Query CloudWatch Logs Insights for OTEL spans tagged with "
+            "session.id and map them to a Session. Either --log-group or "
+            "--agent-name must be supplied (agent-name discovers the runtime "
+            "log group via describe_log_groups)."
+        ),
+    )
+    cw.add_argument(
+        "--session-id",
+        required=True,
+        metavar="ID",
+        help="session id to fetch (matches attributes.session.id)",
+    )
+    cw.add_argument(
+        "--region",
+        default=None,
+        help="AWS region (default: AWS_REGION / AWS_DEFAULT_REGION env vars, then us-east-1)",
+    )
+    cw.add_argument(
+        "--log-group",
+        default=None,
+        help="full CloudWatch log group path",
+    )
+    cw.add_argument(
+        "--agent-name",
+        default=None,
+        help="agent name used to discover the runtime log group via describe_log_groups",
+    )
+    cw.add_argument(
+        "--lookback-days",
+        type=int,
+        default=30,
+        help="how many days back to search for traces (default: 30)",
+    )
+    cw.add_argument(
+        "-o",
+        "--output",
+        metavar="PATH",
+        default=None,
+        help="write the Session JSON to PATH instead of stdout",
+    )
+    cw.set_defaults(func=_run_cloudwatch)
+
+
+def _add_langfuse_parser(
+    sub: argparse._SubParsersAction,
+    parent: argparse.ArgumentParser,
+) -> None:
+    lf = sub.add_parser(
+        "langfuse",
+        parents=[parent],
+        help="fetch a session from Langfuse",
+        description=(
+            "Fetch all traces and observations for a session via the Langfuse "
+            "SDK and map them to a Session. Requires the langfuse extra "
+            "(`pip install strands-agents-evals[langfuse]`). Credentials read "
+            "from LANGFUSE_PUBLIC_KEY / LANGFUSE_SECRET_KEY env vars."
+        ),
+    )
+    lf.add_argument(
+        "--session-id",
+        required=True,
+        metavar="ID",
+        help="session id to fetch (Langfuse trace.list session_id filter)",
+    )
+    lf.add_argument(
+        "--host",
+        default=None,
+        help="Langfuse API host (default: LANGFUSE_HOST env var, then https://us.cloud.langfuse.com)",
+    )
+    lf.add_argument(
+        "--timeout",
+        type=int,
+        default=120,
+        help="request timeout in seconds (default: 120)",
+    )
+    lf.add_argument(
+        "-o",
+        "--output",
+        metavar="PATH",
+        default=None,
+        help="write the Session JSON to PATH instead of stdout",
+    )
+    lf.set_defaults(func=_run_langfuse)
+
+
+def _add_opensearch_parser(
+    sub: argparse._SubParsersAction,
+    parent: argparse.ArgumentParser,
+) -> None:
+    os_ = sub.add_parser(
+        "opensearch",
+        parents=[parent],
+        help="fetch a session from OpenSearch",
+        description=(
+            "Fetch spans for a session via OpenSearchTraceRetriever and map "
+            "them to a Session. Requires the opensearch extra "
+            "(`pip install strands-agents-evals[opensearch]`)."
+        ),
+    )
+    os_.add_argument(
+        "--session-id",
+        required=True,
+        metavar="ID",
+        help="session id to fetch (conversation id)",
+    )
+    os_.add_argument(
+        "--host",
+        default="https://localhost:9200",
+        help="OpenSearch endpoint URL (default: https://localhost:9200)",
+    )
+    os_.add_argument(
+        "--index",
+        default="otel-v1-apm-span-*",
+        help="index pattern for span documents (default: otel-v1-apm-span-*)",
+    )
+    os_.add_argument(
+        "--username",
+        default=None,
+        help="basic auth username (paired with --password); SigV4 auth is library-only",
+    )
+    os_.add_argument(
+        "--password",
+        default=None,
+        help="basic auth password (paired with --username)",
+    )
+    verify_group = os_.add_mutually_exclusive_group()
+    verify_group.add_argument(
+        "--verify-certs",
+        dest="verify_certs",
+        action="store_true",
+        default=True,
+        help="verify TLS certificates (default)",
+    )
+    verify_group.add_argument(
+        "--no-verify-certs",
+        dest="verify_certs",
+        action="store_false",
+        help="skip TLS certificate verification (local/dev only)",
+    )
+    os_.add_argument(
+        "-o",
+        "--output",
+        metavar="PATH",
+        default=None,
+        help="write the Session JSON to PATH instead of stdout",
+    )
+    os_.set_defaults(func=_run_opensearch)

--- a/src/strands_evals/cli/main.py
+++ b/src/strands_evals/cli/main.py
@@ -7,6 +7,7 @@ import sys
 
 from . import _common
 from .commands import diagnose as diagnose_cmd
+from .commands import fetch as fetch_cmd
 from .commands import generate as generate_cmd
 from .commands import report as report_cmd
 from .commands import run as run_cmd
@@ -29,6 +30,7 @@ def _build_parser() -> argparse.ArgumentParser:
     diagnose_cmd.add_subparser(subparsers, parent)
     run_cmd.add_subparser(subparsers, parent)
     generate_cmd.add_subparser(subparsers, parent)
+    fetch_cmd.add_subparser(subparsers, parent)
 
     return parser
 

--- a/tests/strands_evals/cli/test_fetch.py
+++ b/tests/strands_evals/cli/test_fetch.py
@@ -1,0 +1,287 @@
+"""Tests for ``strands-evals fetch``."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from strands_evals.cli.main import main
+from strands_evals.providers.exceptions import SessionNotFoundError
+from strands_evals.types.evaluation import TaskOutput
+from strands_evals.types.trace import Session
+
+
+def _task_output(session: Session) -> TaskOutput:
+    return {"output": "hi", "trajectory": session}
+
+
+# --- cloudwatch ----------------------------------------------------------------
+
+
+def test_fetch_cloudwatch_writes_session_json(session_file: Path, tmp_path: Path):
+    session = Session.model_validate_json(session_file.read_text())
+    out_path = tmp_path / "out.json"
+
+    provider = MagicMock()
+    provider.get_evaluation_data.return_value = _task_output(session)
+
+    with patch(
+        "strands_evals.providers.cloudwatch_provider.CloudWatchProvider",
+        return_value=provider,
+    ) as cw_cls:
+        exit_code = main(
+            [
+                "fetch",
+                "cloudwatch",
+                "--session-id",
+                "sess_1",
+                "--log-group",
+                "/aws/foo",
+                "--region",
+                "us-west-2",
+                "--lookback-days",
+                "7",
+                "-o",
+                str(out_path),
+            ]
+        )
+
+    assert exit_code == 0
+    cw_cls.assert_called_once_with(
+        region="us-west-2",
+        log_group="/aws/foo",
+        agent_name=None,
+        lookback_days=7,
+    )
+    provider.get_evaluation_data.assert_called_once_with("sess_1")
+
+    payload = json.loads(out_path.read_text())
+    assert payload["session_id"] == "sess_1"
+
+
+def test_fetch_cloudwatch_to_stdout(session_file: Path, capsys):
+    session = Session.model_validate_json(session_file.read_text())
+
+    provider = MagicMock()
+    provider.get_evaluation_data.return_value = _task_output(session)
+
+    with patch(
+        "strands_evals.providers.cloudwatch_provider.CloudWatchProvider",
+        return_value=provider,
+    ):
+        exit_code = main(
+            [
+                "fetch",
+                "cloudwatch",
+                "--session-id",
+                "sess_1",
+                "--log-group",
+                "/aws/foo",
+            ]
+        )
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    payload = json.loads(captured.out)
+    assert payload["session_id"] == "sess_1"
+
+
+def test_fetch_cloudwatch_requires_one_target(capsys):
+    """Both --log-group and --agent-name omitted (or both set) → exit 2."""
+    exit_code = main(["fetch", "cloudwatch", "--session-id", "sess_1"])
+    captured = capsys.readouterr()
+    assert exit_code == 2
+    assert "exactly one of --log-group or --agent-name" in captured.err
+
+
+def test_fetch_cloudwatch_rejects_both_targets(capsys):
+    exit_code = main(
+        [
+            "fetch",
+            "cloudwatch",
+            "--session-id",
+            "sess_1",
+            "--log-group",
+            "/aws/foo",
+            "--agent-name",
+            "agent-x",
+        ]
+    )
+    captured = capsys.readouterr()
+    assert exit_code == 2
+    assert "exactly one of --log-group or --agent-name" in captured.err
+
+
+def test_fetch_cloudwatch_provider_error_exits_3(session_file: Path):
+    provider = MagicMock()
+    provider.get_evaluation_data.side_effect = SessionNotFoundError("nope")
+
+    with patch(
+        "strands_evals.providers.cloudwatch_provider.CloudWatchProvider",
+        return_value=provider,
+    ):
+        exit_code = main(
+            [
+                "fetch",
+                "cloudwatch",
+                "--session-id",
+                "missing",
+                "--log-group",
+                "/aws/foo",
+            ]
+        )
+
+    assert exit_code == 3
+
+
+# --- langfuse -----------------------------------------------------------------
+
+
+def test_fetch_langfuse_writes_session_json(session_file: Path, tmp_path: Path):
+    session = Session.model_validate_json(session_file.read_text())
+    out_path = tmp_path / "out.json"
+
+    provider = MagicMock()
+    provider.get_evaluation_data.return_value = _task_output(session)
+
+    with patch(
+        "strands_evals.providers.langfuse_provider.LangfuseProvider",
+        return_value=provider,
+    ) as lf_cls:
+        exit_code = main(
+            [
+                "fetch",
+                "langfuse",
+                "--session-id",
+                "sess_1",
+                "--host",
+                "https://lf.example.com",
+                "-o",
+                str(out_path),
+            ]
+        )
+
+    assert exit_code == 0
+    lf_cls.assert_called_once_with(host="https://lf.example.com", timeout=120)
+    provider.get_evaluation_data.assert_called_once_with("sess_1")
+    assert json.loads(out_path.read_text())["session_id"] == "sess_1"
+
+
+def test_fetch_langfuse_missing_extra_exits_2(monkeypatch, capsys):
+    """Setting the provider module to None makes `from ... import` raise ImportError."""
+    monkeypatch.setitem(sys.modules, "strands_evals.providers.langfuse_provider", None)
+
+    exit_code = main(["fetch", "langfuse", "--session-id", "sess_1"])
+
+    captured = capsys.readouterr()
+    assert exit_code == 2
+    assert "langfuse extra not installed" in captured.err
+
+
+# --- opensearch ---------------------------------------------------------------
+
+
+def test_fetch_opensearch_writes_session_json(session_file: Path, tmp_path: Path):
+    session = Session.model_validate_json(session_file.read_text())
+    out_path = tmp_path / "out.json"
+
+    provider = MagicMock()
+    provider.get_evaluation_data.return_value = _task_output(session)
+
+    with patch(
+        "strands_evals.providers.opensearch_provider.OpenSearchProvider",
+        return_value=provider,
+    ) as os_cls:
+        exit_code = main(
+            [
+                "fetch",
+                "opensearch",
+                "--session-id",
+                "sess_1",
+                "--host",
+                "https://os.example.com",
+                "--index",
+                "my-spans-*",
+                "--username",
+                "u",
+                "--password",
+                "p",
+                "--no-verify-certs",
+                "-o",
+                str(out_path),
+            ]
+        )
+
+    assert exit_code == 0
+    os_cls.assert_called_once_with(
+        host="https://os.example.com",
+        index="my-spans-*",
+        auth=("u", "p"),
+        verify_certs=False,
+    )
+    assert json.loads(out_path.read_text())["session_id"] == "sess_1"
+
+
+def test_fetch_opensearch_default_no_auth(session_file: Path, capsys):
+    session = Session.model_validate_json(session_file.read_text())
+    provider = MagicMock()
+    provider.get_evaluation_data.return_value = _task_output(session)
+
+    with patch(
+        "strands_evals.providers.opensearch_provider.OpenSearchProvider",
+        return_value=provider,
+    ) as os_cls:
+        exit_code = main(["fetch", "opensearch", "--session-id", "sess_1"])
+
+    assert exit_code == 0
+    os_cls.assert_called_once_with(
+        host="https://localhost:9200",
+        index="otel-v1-apm-span-*",
+        auth=None,
+        verify_certs=True,
+    )
+
+
+def test_fetch_opensearch_missing_extra_exits_2(capsys):
+    """OpenSearch's heavy dep is imported lazily inside __init__, so the
+    constructor — not the module import — raises ImportError when the extra
+    is absent. Reproduce that by patching the provider class to raise on
+    instantiation; assert exit 2 + install hint.
+    """
+    with patch(
+        "strands_evals.providers.opensearch_provider.OpenSearchProvider",
+        side_effect=ImportError("opensearch_genai_observability_sdk_py is required"),
+    ):
+        exit_code = main(["fetch", "opensearch", "--session-id", "sess_1"])
+
+    captured = capsys.readouterr()
+    assert exit_code == 2
+    assert "opensearch extra not installed" in captured.err
+
+
+def test_fetch_opensearch_partial_credentials_rejected(capsys):
+    exit_code = main(
+        [
+            "fetch",
+            "opensearch",
+            "--session-id",
+            "sess_1",
+            "--username",
+            "u",
+        ]
+    )
+    captured = capsys.readouterr()
+    assert exit_code == 2
+    assert "must be provided together" in captured.err
+
+
+# --- subcommand routing -------------------------------------------------------
+
+
+def test_fetch_requires_provider():
+    with pytest.raises(SystemExit):
+        main(["fetch"])


### PR DESCRIPTION
## Description

Adds the `strands-evals fetch` subcommand — a thin wrapper over the existing `TraceProvider` classes that pulls traces from a backend by `--session-id` and emits a `Session` JSON document, ready to pipe into `strands-evals diagnose -` or save with `-o PATH`.

Three sub-subparsers under `fetch`, one per provider:

- **`fetch cloudwatch`**: Wraps `CloudWatchProvider`.
    - `--session-id` (required)
    - `--region`. Region falls back to `AWS_REGION` / `AWS_DEFAULT_REGION` env vars.
    - `--log-group` / `--agent-name`
    - `--lookback-days`

- **`fetch langfuse`**: wraps `LangfuseProvider`.
  - Flags: `--session-id` (required),
  - `--host`,
  - `--timeout`.
  - Credentials read from `LANGFUSE_PUBLIC_KEY` / `LANGFUSE_SECRET_KEY`. Gated on the `langfuse` extra.
- **`fetch opensearch`**: wraps `OpenSearchProvider`.
  - `--session-id` (required),
  - `--host`,
  - `--index`,
  - `--username` / `--password` (basic auth, paired)
  - `--verify-certs` / `--no-verify-certs`. Gated on the `opensearch` extra.

Behavior:

- Output is always JSON (`Session.model_dump_json(indent=2)`). Or use `-o PATH` or stdout for rich rendering.
- Optional-extra providers (`langfuse`, `opensearch`) are imported lazily inside the subcommand callback. Users without the extras can still use the rest of the CLI.
  - Missing extra → exit code `2` with an install hint pointing at the right extra.
- `--username` / `--password` for OpenSearch must be supplied together; 
  - one without the other → exit code `2`. 
- Provider runtime failures (`SessionNotFoundError`, `ProviderError`) flow through `_common.run_command`'s catch-all → exit code `3`, matching the plan's exit-code rules.

## Related Issues

N/A

## Documentation PR
N/A

## Type of Change

New feature

## Testing

- New `tests/strands_evals/cli/test_fetch.py` with 9 unit tests:
  - Each provider: writes Session JSON to `-o`, falls back to stdout, calls the provider class with the expected kwargs.
  - CloudWatch `SessionNotFoundError` → exit `3`.
  - Langfuse missing-extra path → exit `2` with install hint (forced via `monkeypatch.setitem(sys.modules, ..., None)`).
  - OpenSearch: default no-auth, full basic-auth tuple, partial-credentials rejection, `--no-verify-certs` threading.
  - `fetch` with no provider → `SystemExit` (argparse-enforced).
- Full CLI suite passes: `hatch test tests/strands_evals/cli` — 110 passed.
- `hatch fmt --linter` and `hatch fmt --formatter` clean on the new files.

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.