### PR TITLE
fix(ci): sha-pin third-party GitHub Actions

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -12,7 +12,7 @@ jobs:
       pull-requests: read
     steps:
       - name: Check PR title follows conventional commits
-        uses: amannn/action-semantic-pull-request@v6
+        uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -422,4 +422,4 @@ jobs:
           path: dist
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1


### PR DESCRIPTION
Pin all third-party actions to their current commit SHA to reduce supply chain risk. Mutable tags are kept as trailing comments for readability and Dependabot version tracking.

| Action | Tag | SHA | Workflow |
|--------|-----|-----|----------|
| amannn/action-semantic-pull-request | v6 | 48f25628 | pr-title.yml |
| pypa/gh-action-pypi-publish | release/v1 | cef22109 | release.yml |

First-party actions (`actions/*`, `aws-actions/*`, `strands-agents/devtools/*`) are intentionally left on tags.