### PR TITLE
test(redteam): cover RedTeamCase metadata sync and _build_system_prompt assembly

### DIFF
--- a/tests/strands_evals/experimental/redteam/test_case.py
+++ b/tests/strands_evals/experimental/redteam/test_case.py
@@ -1,0 +1,59 @@
+"""Tests for RedTeamCase metadata sync behavior."""
+
+from strands_evals.experimental.redteam.case import RedTeamCase
+from strands_evals.experimental.redteam.types import AttackGoal, RedTeamConfig
+
+
+def _config(**attack_goal_kwargs) -> RedTeamConfig:
+    kwargs = {"risk_category": "guideline_bypass", "actor_goal": "goal"}
+    kwargs.update(attack_goal_kwargs)
+    return RedTeamConfig(attack_goal=AttackGoal(**kwargs))
+
+
+def test_metadata_none_is_populated_from_attack_goal():
+    """A case with no metadata gets the full attack_goal dump as its metadata."""
+    case = RedTeamCase(name="c0", input="hello", config=_config())
+
+    assert case.metadata == case.config.attack_goal.model_dump()
+    assert case.metadata["risk_category"] == "guideline_bypass"
+    assert case.metadata["actor_goal"] == "goal"
+    assert case.metadata["severity"] == "medium"
+
+
+def test_existing_metadata_keys_are_preserved_not_overwritten():
+    """Caller-provided metadata wins over the attack_goal dump for overlapping keys."""
+    case = RedTeamCase(
+        name="c0",
+        input="hello",
+        config=_config(severity="critical"),
+        metadata={"severity": "low", "custom": "value"},
+    )
+
+    # setdefault semantics: caller's "severity" survives, config's does not override it.
+    assert case.metadata["severity"] == "low"
+    # Caller-only keys are untouched.
+    assert case.metadata["custom"] == "value"
+    # Keys absent from caller metadata are still filled in from attack_goal.
+    assert case.metadata["risk_category"] == "guideline_bypass"
+    assert case.metadata["actor_goal"] == "goal"
+
+
+def test_partial_metadata_is_filled_in_from_attack_goal():
+    """Keys the caller didn't set are backfilled from attack_goal without touching the rest."""
+    case = RedTeamCase(
+        name="c0",
+        input="hello",
+        config=_config(context="ctx", success_criteria="criteria"),
+        metadata={"unrelated": "kept"},
+    )
+
+    assert case.metadata["unrelated"] == "kept"
+    assert case.metadata["context"] == "ctx"
+    assert case.metadata["success_criteria"] == "criteria"
+
+
+def test_empty_dict_metadata_is_filled_in_from_attack_goal():
+    """An explicit empty dict (falsy but not None) still gets backfilled, exercising the else branch."""
+    case = RedTeamCase(name="c0", input="hello", config=_config(), metadata={})
+
+    assert case.metadata == case.config.attack_goal.model_dump()

--- a/tests/strands_evals/experimental/redteam/test_common.py
+++ b/tests/strands_evals/experimental/redteam/test_common.py
@@ -1,0 +1,47 @@
+"""Tests for shared prompt-block assembly in strategies/_common.py."""
+
+from strands_evals.experimental.redteam.strategies._common import (
+    EXIT_BLOCK,
+    FORMAT_BLOCK,
+    PROFILE_BLOCK,
+    ROLE_BLOCK,
+    RULES_BLOCK,
+    _build_system_prompt,
+)
+
+
+def test_build_system_prompt_includes_all_common_blocks():
+    prompt = _build_system_prompt("PLAYBOOK CONTENT")
+
+    assert ROLE_BLOCK in prompt
+    assert PROFILE_BLOCK in prompt
+    assert "PLAYBOOK CONTENT" in prompt
+    assert RULES_BLOCK in prompt
+    assert EXIT_BLOCK in prompt
+    assert FORMAT_BLOCK in prompt
+
+
+def test_build_system_prompt_orders_blocks_role_profile_playbook_rules_exit_format():
+    """Downstream .format() calls fill {actor_goal}/{max_turns} placeholders positionally
+    within this fixed layout, so the block order is load-bearing, not incidental."""
+    prompt = _build_system_prompt("PLAYBOOK")
+
+    positions = [
+        prompt.index(ROLE_BLOCK),
+        prompt.index(PROFILE_BLOCK),
+        prompt.index("PLAYBOOK"),
+        prompt.index(RULES_BLOCK),
+        prompt.index(EXIT_BLOCK),
+        prompt.index(FORMAT_BLOCK),
+    ]
+
+    assert positions == sorted(positions)
+
+
+def test_profile_and_exit_blocks_retain_format_placeholders():
+    """These blocks are filled in later via str.format(actor_profile=..., max_turns=...);
+    _build_system_prompt itself must not consume those placeholders."""
+    prompt = _build_system_prompt("PLAYBOOK")
+
+    assert "{actor_profile}" in prompt
+    assert "{max_turns}" in prompt


### PR DESCRIPTION
## Description

Two small pieces of `experimental/redteam` logic had no direct unit tests — only incidental exercise as fixture setup inside other strategy test files, which never asserted their actual behavior:

- `RedTeamCase._sync_metadata_from_config` (`case.py`): the `model_validator` that merges `AttackGoal` fields into `metadata`. Untested branches: `metadata=None` gets fully populated from `attack_goal`; caller-provided keys are preserved (`setdefault` semantics — config never overwrites an existing key); partial metadata is backfilled for missing keys only; and an explicit empty dict (falsy but not `None`) still takes the "existing metadata" branch rather than the "populate" branch.
- `_build_system_prompt` (`strategies/_common.py`): the helper that assembles the six shared prompt blocks (`ROLE_BLOCK`, `PROFILE_BLOCK`, playbook, `RULES_BLOCK`, `EXIT_BLOCK`, `FORMAT_BLOCK`) used by every prompt-based strategy. Untested: that all blocks are present, in the correct order (block order is load-bearing for the `{actor_profile}`/`{max_turns}` placeholders filled in later via `.format()`), joined with a blank line, and that those placeholders survive assembly unconsumed.

This is a test-only PR — no production code changes. Adds `tests/strands_evals/experimental/redteam/test_case.py` and `tests/strands_evals/experimental/redteam/test_common.py`.

## Related Issues

None — found via a review of test coverage gaps in `experimental/redteam/`, not filed as an issue first since it's test-only and additive.

## Documentation PR

N/A

## Type of Change

Tests only

## Testing

- [x] Ran `python -m pytest tests/strands_evals/experimental/redteam/` — 326 passed (previously 319; +7 new)
- [x] `ruff format --check` and `ruff check` clean on the new files
- [x] `mypy` clean on the new files

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
