### PR TITLE
ci: add aggregate CI Gate status check

### DIFF
--- a/.github/workflows/pr-and-push.yml
+++ b/.github/workflows/pr-and-push.yml
@@ -17,3 +17,27 @@ jobs:
       contents: read
     with:
       ref: ${{ github.event.pull_request.head.sha }}
+
+  # Single required status check. Branch protection can require just this one
+  # context ("CI Gate") instead of every matrix leg, whose names change
+  # whenever the matrix changes. This job fails if any needed job failed or
+  # was cancelled, so it is a faithful aggregate gate.
+  ci-gate:
+    name: CI Gate
+    if: always()
+    needs: [call-test-lint]
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - name: Verify all required jobs succeeded
+        env:
+          RESULTS: ${{ join(needs.*.result, ' ') }}
+        run: |
+          echo "Needed job results: $RESULTS"
+          for result in $RESULTS; do
+            if [ "$result" != "success" ]; then
+              echo "::error::A required CI job did not succeed (result: $result)."
+              exit 1
+            fi
+          done
+          echo "All required CI jobs succeeded."


### PR DESCRIPTION
Adds a `ci-gate` job to `pr-and-push.yml` that aggregates all needed CI jobs into a single "CI Gate" status context.

Branch protection can then require just this one context instead of every matrix leg (whose names change whenever the Python/OS matrix changes). The job runs `if: always()` and fails if any needed job failed or was cancelled, so it is a faithful aggregate gate.

This matches the pattern already used in harness-sdk and shell, as part of aligning branch protections across the org's repos. Once merged, the "CI Gate" context will be added as a required status check on `main`.