### PR TITLE
ci: add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*  @strands-agents/codeowners


### PR DESCRIPTION
## Description
Adds a CODEOWNERS file matching harness-sdk's (`* @strands-agents/codeowners`).

The main branch ruleset requires code-owner review, but without a CODEOWNERS file that requirement does not bind and any reviewer with write access satisfies it. This makes the existing rule effective.

## Type of Change
CI/config

## Testing
Config-only change; no code paths affected.