### PR TITLE
fix: added pyproject classifiers

### DIFF
--- a/.github/workflows/test-lint.yml
+++ b/.github/workflows/test-lint.yml
@@ -28,6 +28,9 @@ jobs:
         - os: ubuntu-latest
           os-name: 'linux'
           python-version: "3.13"
+        - os: ubuntu-latest
+          os-name: 'linux'
+          python-version: "3.14"
         # Windows
         - os: windows-latest
           os-name: 'windows'
@@ -41,6 +44,9 @@ jobs:
         - os: windows-latest
           os-name: 'windows'
           python-version: "3.13"
+        - os: windows-latest
+          os-name: 'windows'
+          python-version: "3.14"
         # MacOS - latest only; not enough runners for macOS
         - os: macos-latest
           os-name: 'macOS'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,14 @@ license = {text = "Apache-2.0"}
 authors = [
     {name = "AWS", email = "opensource@amazon.com"},
 ]
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
+]
 
 dependencies = [
     "pydantic>=2.4.0,<3.0.0",
@@ -75,7 +83,7 @@ dependencies = [
 ]
 
 [[tool.hatch.envs.hatch-test.matrix]]
-python = ["3.13", "3.12", "3.11", "3.10"]
+python = ["3.14", "3.13", "3.12", "3.11", "3.10"]
 
 [tool.hatch.envs.default.scripts]
 list = [


### PR DESCRIPTION
## Description
- Added pyproject classifiers to recover python supported versions. 
- Evals should support 3.14, added it into the pyproject tests

## Related Issues

N/A

## Documentation PR

N/A

## Type of Change

Bug fix

## Testing

How have you tested the change? Verify that the changes do not break functionality or introduce new warnings.

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.