### PR TITLE
fix: add GenericGenAISessionMapper for dict spans with unrecognized scope

### DIFF
--- a/src/strands_evals/mappers/__init__.py
+++ b/src/strands_evals/mappers/__init__.py
@@ -3,6 +3,7 @@
 from .adk_otel_session_mapper import ADKOtelSessionMapper
 from .cloudwatch_parser import CloudWatchLogsParser, parse_cloudwatch_logs
 from .cloudwatch_session_mapper import CloudWatchSessionMapper
+from .generic_gen_ai_session_mapper import GenericGenAISessionMapper
 from .langchain_otel_session_mapper import LangChainOtelSessionMapper
 from .openinference_session_mapper import OpenInferenceSessionMapper
 from .opensearch_session_mapper import OpenSearchSessionMapper
@@ -20,6 +21,7 @@ __all__ = [
     "CloudWatchLogsParser",
     "CloudWatchSessionMapper",
     "GenAIConventionVersion",
+    "GenericGenAISessionMapper",
     "LangChainOtelSessionMapper",
     "OpenInferenceSessionMapper",
     "OpenSearchSessionMapper",

--- a/src/strands_evals/mappers/generic_gen_ai_session_mapper.py
+++ b/src/strands_evals/mappers/generic_gen_ai_session_mapper.py
@@ -11,7 +11,7 @@ This is the fallback mapper for spans that don't match any known instrumentor sc
 import json
 import logging
 from collections import defaultdict
-from datetime import datetime, timezone
+from datetime import datetime
 from typing import Any
 
 from ..types.trace import (
@@ -31,6 +31,7 @@ from ..types.trace import (
     UserMessage,
 )
 from .session_mapper import SessionMapper
+from .utils import join_tool_result_content
 
 logger = logging.getLogger(__name__)
 
@@ -62,39 +63,37 @@ class GenericGenAISessionMapper(SessionMapper):
 
         spans = self._normalize_to_flat_spans(data)
 
-        # Group by trace_id, optionally filtering by session.id
-        traces_by_id: dict[str, list[dict]] = defaultdict(list)
+        # Group by trace_id, optionally filtering by session.id.
+        # Single pass: bucket spans by trace and track which traces match session_id.
+        all_traces: dict[str, list[dict]] = defaultdict(list)
+        traces_with_session: set[str] = set()
+        any_span_has_session_id = False
 
-        any_span_has_session_id = any(
-            "session.id" in span.get("attributes", {}) or "gen_ai.conversation.id" in span.get("attributes", {})
-            for span in spans
-        )
-
-        if not any_span_has_session_id:
-            # No spans have session IDs — include all spans
-            for span in spans:
-                trace_id = span.get("trace_id", "unknown")
-                traces_by_id[trace_id].append(span)
-        else:
-            # Some spans have session IDs — use trace-level filtering.
-            # First, identify which trace_ids contain at least one span matching session_id.
-            all_traces: dict[str, list[dict]] = defaultdict(list)
-            traces_with_session: set[str] = set()
-
-            for span in spans:
-                trace_id = span.get("trace_id", "unknown")
-                all_traces[trace_id].append(span)
-                attrs = span.get("attributes", {})
-                span_session_id = attrs.get("gen_ai.conversation.id") or attrs.get("session.id")
-                if span_session_id and str(span_session_id) == session_id:
+        for span in spans:
+            trace_id = span.get("trace_id", "unknown")
+            all_traces[trace_id].append(span)
+            attrs = span.get("attributes", {})
+            span_session_id = attrs.get("gen_ai.conversation.id") or attrs.get("session.id")
+            if span_session_id:
+                any_span_has_session_id = True
+                if str(span_session_id) == session_id:
                     traces_with_session.add(trace_id)
 
-            # Include all spans from traces that contain at least one matching span.
-            # Exclude entire traces where no span matches the session_id (even if some
-            # spans in that trace have no session_id tag).
+        traces_by_id: dict[str, list[dict]] = defaultdict(list)
+        if not any_span_has_session_id:
+            # No spans carry session tags — include everything.
+            traces_by_id = all_traces
+        else:
+            # Include spans from matching traces; own tag wins over inheritance.
             for trace_id, trace_spans in all_traces.items():
-                if trace_id in traces_with_session:
-                    traces_by_id[trace_id] = trace_spans
+                if trace_id not in traces_with_session:
+                    continue
+                for span in trace_spans:
+                    attrs = span.get("attributes", {})
+                    own = attrs.get("gen_ai.conversation.id") or attrs.get("session.id")
+                    if own and str(own) != session_id:
+                        continue
+                    traces_by_id[trace_id].append(span)
 
         traces: list[Trace] = []
         for trace_id, trace_spans in traces_by_id.items():
@@ -147,20 +146,11 @@ class GenericGenAISessionMapper(SessionMapper):
     def _parse_timestamp(self, value: Any) -> datetime:
         """Parse timestamp from various formats.
 
-        readable_spans_to_dicts() preserves OTel's nanosecond epoch timestamps.
-        Values > 1e12 are assumed nanoseconds and divided by 1e9.
+        Delegates to SessionMapper.parse_timestamp, which additionally handles
+        ISO-8601 and string-encoded nanosecond epochs (the OTLP/JSON encoding
+        for int64 fields, as produced on the CloudWatch/ADOT path).
         """
-        if value is None:
-            return datetime.now(timezone.utc)
-        if isinstance(value, datetime):
-            return value
-        if isinstance(value, (int, float)):
-            # OTel timestamps from ReadableSpan are nanoseconds (> 1e18).
-            # Seconds-based timestamps are < 1e10. Threshold at 1e12 to distinguish.
-            if value > 1e12:
-                value = value / 1e9
-            return datetime.fromtimestamp(value, tz=timezone.utc)
-        return datetime.now(timezone.utc)
+        return self.parse_timestamp(value)
 
     def _parse_json_attr(self, attributes: Any, key: str, default: str = "[]") -> Any:
         """Parse a JSON-encoded attribute value."""
@@ -668,9 +658,7 @@ class GenericGenAISessionMapper(SessionMapper):
                 tool_result = item["toolResult"]
                 result_text = tool_result.get("content", "")
                 if isinstance(result_text, list):
-                    result_text = "\n".join(
-                        block.get("text", "") for block in result_text if isinstance(block, dict) and "text" in block
-                    )
+                    result_text = join_tool_result_content(result_text)
                 result.append(
                     ToolResultContent(
                         content=str(result_text),

--- a/src/strands_evals/mappers/generic_gen_ai_session_mapper.py
+++ b/src/strands_evals/mappers/generic_gen_ai_session_mapper.py
@@ -70,18 +70,31 @@ class GenericGenAISessionMapper(SessionMapper):
             for span in spans
         )
 
-        for span in spans:
-            attrs = span.get("attributes", {})
-
-            if not any_span_has_session_id:
-                should_include = True
-            else:
-                span_session_id = attrs.get("gen_ai.conversation.id") or attrs.get("session.id")
-                should_include = str(span_session_id) == session_id if span_session_id else True
-
-            if should_include:
+        if not any_span_has_session_id:
+            # No spans have session IDs — include all spans
+            for span in spans:
                 trace_id = span.get("trace_id", "unknown")
                 traces_by_id[trace_id].append(span)
+        else:
+            # Some spans have session IDs — use trace-level filtering.
+            # First, identify which trace_ids contain at least one span matching session_id.
+            all_traces: dict[str, list[dict]] = defaultdict(list)
+            traces_with_session: set[str] = set()
+
+            for span in spans:
+                trace_id = span.get("trace_id", "unknown")
+                all_traces[trace_id].append(span)
+                attrs = span.get("attributes", {})
+                span_session_id = attrs.get("gen_ai.conversation.id") or attrs.get("session.id")
+                if span_session_id and str(span_session_id) == session_id:
+                    traces_with_session.add(trace_id)
+
+            # Include all spans from traces that contain at least one matching span.
+            # Exclude entire traces where no span matches the session_id (even if some
+            # spans in that trace have no session_id tag).
+            for trace_id, trace_spans in all_traces.items():
+                if trace_id in traces_with_session:
+                    traces_by_id[trace_id] = trace_spans
 
         traces: list[Trace] = []
         for trace_id, trace_spans in traces_by_id.items():
@@ -124,7 +137,9 @@ class GenericGenAISessionMapper(SessionMapper):
             except (KeyError, TypeError, ValueError, json.JSONDecodeError) as e:
                 logger.warning(
                     "trace_id=%s span_id=%s | Failed to convert span: %s",
-                    span.get("trace_id", "?"), span.get("span_id", "?"), e,
+                    span.get("trace_id", "?"),
+                    span.get("span_id", "?"),
+                    e,
                 )
 
         return Trace(spans=converted_spans, trace_id=trace_id, session_id=session_id)
@@ -194,10 +209,19 @@ class GenericGenAISessionMapper(SessionMapper):
                     assistant_content = self._process_assistant_content(message_list)
                     if assistant_content:
                         messages.append(AssistantMessage(content=assistant_content))
+
+                elif event_name == "gen_ai.client.inference.operation.details":
+                    # Current OTel GenAI convention: single event with input/output messages
+                    # https://github.com/open-telemetry/semantic-conventions-genai/blob/main/docs/gen-ai/gen-ai-events.md
+                    details_messages = self._parse_operation_details_event(event_attrs)
+                    messages.extend(details_messages)
+
             except (KeyError, TypeError, ValueError, json.JSONDecodeError) as e:
                 logger.warning(
                     "span_id=%s event=%s | Failed to process event: %s",
-                    span.get("span_id", "?"), event.get("event_name", "?"), e,
+                    span.get("span_id", "?"),
+                    event.get("event_name", "?"),
+                    e,
                 )
 
         # Fallback: gen_ai.input.messages / gen_ai.output.messages as span attributes
@@ -214,8 +238,25 @@ class GenericGenAISessionMapper(SessionMapper):
 
         tool_name = str(attrs.get("gen_ai.tool.name", ""))
         tool_call_id = str(attrs.get("gen_ai.tool.call.id", ""))
+
+        # Prefer error.type (current OTel GenAI convention for failed operations),
+        # fall back to gen_ai.tool.status / tool.status for legacy compatibility.
+        # https://github.com/open-telemetry/semantic-conventions-genai/blob/main/model/gen-ai/spans.yaml#L522-L562
+        error_type = attrs.get("error.type", "")
+        span_status = span.get("status", {}).get("code", "")
         tool_status = attrs.get("gen_ai.tool.status", attrs.get("tool.status", ""))
-        tool_error = None if tool_status == "success" else (str(tool_status) if tool_status else None)
+
+        if error_type:
+            # OTel convention: error.type indicates the error class (e.g., "TimeoutError")
+            tool_error = str(error_type)
+        elif span_status == "ERROR":
+            # Span status set to ERROR without error.type — still a failure
+            tool_error = "ERROR"
+        elif tool_status and tool_status != "success":
+            # Legacy fallback: gen_ai.tool.status or tool.status
+            tool_error = str(tool_status)
+        else:
+            tool_error = None
 
         tool_arguments: dict = {}
         tool_result_content: str = ""
@@ -234,7 +275,8 @@ class GenericGenAISessionMapper(SessionMapper):
             except (KeyError, TypeError, ValueError, json.JSONDecodeError) as e:
                 logger.warning(
                     "span_id=%s | Failed to process tool event: %s",
-                    span.get("span_id", "?"), e,
+                    span.get("span_id", "?"),
+                    e,
                 )
 
         # Fallback: gen_ai.tool.input/output attributes (manual instrumentation)
@@ -296,7 +338,8 @@ class GenericGenAISessionMapper(SessionMapper):
             except (KeyError, TypeError, ValueError, json.JSONDecodeError) as e:
                 logger.warning(
                     "span_id=%s | Failed to process agent event: %s",
-                    span.get("span_id", "?"), e,
+                    span.get("span_id", "?"),
+                    e,
                 )
 
         # Fallback: extract from attributes (PydanticAI / native gen_ai format)
@@ -320,6 +363,29 @@ class GenericGenAISessionMapper(SessionMapper):
                     pass
 
         if not agent_response:
+            # Try gen_ai.output.messages (current OTel GenAI convention for invoke_agent)
+            # https://github.com/open-telemetry/semantic-conventions-genai/blob/main/docs/gen-ai/gen-ai-agent-spans.md
+            output_msgs_raw = attrs.get("gen_ai.output.messages", "")
+            if output_msgs_raw:
+                try:
+                    output_msgs = json.loads(output_msgs_raw) if isinstance(output_msgs_raw, str) else output_msgs_raw
+                    if isinstance(output_msgs, list):
+                        for msg in output_msgs:
+                            if msg.get("role") == "assistant":
+                                parts = msg.get("parts", [])
+                                for part in parts:
+                                    if part.get("type") == "text" and part.get("content"):
+                                        agent_response = part["content"]
+                                        break
+                                # Also handle flat content string
+                                if not agent_response and msg.get("content"):
+                                    agent_response = str(msg["content"])
+                            if agent_response:
+                                break
+                except (json.JSONDecodeError, TypeError):
+                    pass
+
+        if not agent_response:
             agent_response = str(attrs.get("final_result", ""))
 
         return AgentInvocationSpan(
@@ -338,8 +404,9 @@ class GenericGenAISessionMapper(SessionMapper):
         """Parse gen_ai.input.messages / gen_ai.output.messages from span attributes.
 
         PydanticAI and other native gen_ai semconv frameworks store messages as
-        JSON arrays in span attributes rather than span_events. Format:
-            [{"role": "user", "parts": [{"type": "text", "content": "..."}]}, ...]
+        JSON arrays in span attributes rather than span_events. Supports:
+        - PydanticAI format: [{"role": "user", "parts": [{"type": "text", "content": "..."}]}]
+        - OTel GenAI convention: role "tool" with response field for tool results
         """
         messages: list[UserMessage | AssistantMessage] = []
 
@@ -367,6 +434,54 @@ class GenericGenAISessionMapper(SessionMapper):
                                     )
                             if user_content:
                                 messages.append(UserMessage(content=user_content))
+                        elif role == "tool":
+                            # OTel GenAI convention: role "tool" carries tool results.
+                            # Two formats:
+                            #   1. parts: [{"type": "tool_call_response", "id": "...", "response": "..."}]
+                            #   2. flat: {"role": "tool", "id": "...", "response": "..."}
+                            # https://github.com/open-telemetry/semantic-conventions-genai/blob/main/docs/registry/attributes/gen-ai.md
+                            if parts:
+                                for part in parts:
+                                    if isinstance(part, dict) and part.get("type") == "tool_call_response":
+                                        tc_id = part.get("id") or part.get("tool_call_id")
+                                        resp = part.get("response", "")
+                                        if isinstance(resp, dict):
+                                            resp = json.dumps(resp)
+                                        messages.append(
+                                            UserMessage(
+                                                content=[
+                                                    ToolResultContent(
+                                                        content=str(resp) if resp else "",
+                                                        error=None,
+                                                        tool_call_id=tc_id,
+                                                    )
+                                                ]
+                                            )
+                                        )
+                            else:
+                                tool_call_id = msg.get("id") or msg.get("tool_call_id")
+                                response = msg.get("response", msg.get("content", ""))
+                                if isinstance(response, dict):
+                                    response = json.dumps(response)
+                                elif isinstance(response, list):
+                                    parts_text = []
+                                    for block in response:
+                                        if isinstance(block, dict) and block.get("text"):
+                                            parts_text.append(block["text"])
+                                        elif isinstance(block, str):
+                                            parts_text.append(block)
+                                    response = "\n".join(parts_text) if parts_text else str(response)
+                                messages.append(
+                                    UserMessage(
+                                        content=[
+                                            ToolResultContent(
+                                                content=str(response) if response else "",
+                                                error=None,
+                                                tool_call_id=tool_call_id,
+                                            )
+                                        ]
+                                    )
+                                )
                         elif role == "assistant":
                             assistant_content: list[TextContent | ToolCallContent] = []
                             for part in parts:
@@ -411,6 +526,118 @@ class GenericGenAISessionMapper(SessionMapper):
                                 messages.append(AssistantMessage(content=assistant_content))
             except (json.JSONDecodeError, TypeError, KeyError):
                 pass
+
+        return messages
+
+    def _parse_operation_details_event(self, event_attrs: dict) -> list[UserMessage | AssistantMessage]:
+        """Parse gen_ai.client.inference.operation.details event (current OTel GenAI convention).
+
+        This event carries gen_ai.input.messages and gen_ai.output.messages as structured
+        lists or JSON-encoded strings within a single span event.
+        https://github.com/open-telemetry/semantic-conventions-genai/blob/main/docs/gen-ai/gen-ai-events.md
+        """
+        messages: list[UserMessage | AssistantMessage] = []
+
+        for key in ("gen_ai.input.messages", "gen_ai.output.messages"):
+            raw = event_attrs.get(key, "")
+            if not raw:
+                continue
+            try:
+                msg_list = json.loads(raw) if isinstance(raw, str) else raw
+            except (json.JSONDecodeError, TypeError):
+                continue
+
+            if not isinstance(msg_list, list):
+                continue
+
+            for msg in msg_list:
+                role = msg.get("role", "")
+                parts = msg.get("parts", [])
+
+                if role == "user":
+                    user_content: list[TextContent | ToolResultContent] = []
+                    for part in parts:
+                        if isinstance(part, dict):
+                            if part.get("type") == "text" and part.get("content"):
+                                user_content.append(TextContent(text=part["content"]))
+                            elif part.get("type") == "tool_call_response":
+                                user_content.append(
+                                    ToolResultContent(
+                                        content=str(part.get("result", "")),
+                                        error=None,
+                                        tool_call_id=part.get("id"),
+                                    )
+                                )
+                    if user_content:
+                        messages.append(UserMessage(content=user_content))
+
+                elif role == "tool":
+                    # OTel convention: role "tool" carries tool results.
+                    # Two formats:
+                    #   1. parts: [{"type": "tool_call_response", "id": "...", "response": "..."}]
+                    #   2. flat: {"role": "tool", "id": "...", "response": "..."}
+                    if parts:
+                        for part in parts:
+                            if isinstance(part, dict) and part.get("type") == "tool_call_response":
+                                tc_id = part.get("id") or part.get("tool_call_id")
+                                resp = part.get("response", "")
+                                if isinstance(resp, dict):
+                                    resp = json.dumps(resp)
+                                messages.append(
+                                    UserMessage(
+                                        content=[
+                                            ToolResultContent(
+                                                content=str(resp) if resp else "",
+                                                error=None,
+                                                tool_call_id=tc_id,
+                                            )
+                                        ]
+                                    )
+                                )
+                    else:
+                        tool_call_id = msg.get("id") or msg.get("tool_call_id")
+                        response = msg.get("response", msg.get("content", ""))
+                        if isinstance(response, dict):
+                            response = json.dumps(response)
+                        elif isinstance(response, list):
+                            parts_text = []
+                            for block in response:
+                                if isinstance(block, dict) and block.get("text"):
+                                    parts_text.append(block["text"])
+                                elif isinstance(block, str):
+                                    parts_text.append(block)
+                            response = "\n".join(parts_text) if parts_text else str(response)
+                        messages.append(
+                            UserMessage(
+                                content=[
+                                    ToolResultContent(
+                                        content=str(response) if response else "",
+                                        error=None,
+                                        tool_call_id=tool_call_id,
+                                    )
+                                ]
+                            )
+                        )
+
+                elif role == "assistant":
+                    assistant_content: list[TextContent | ToolCallContent] = []
+                    for part in parts:
+                        if isinstance(part, dict):
+                            if part.get("type") == "text" and part.get("content"):
+                                assistant_content.append(TextContent(text=part["content"]))
+                            elif part.get("type") == "tool_call":
+                                assistant_content.append(
+                                    ToolCallContent(
+                                        name=part.get("name", ""),
+                                        arguments=part.get("arguments", {}),
+                                        tool_call_id=part.get("id"),
+                                    )
+                                )
+                    # Also handle flat content string (no parts)
+                    if not assistant_content and msg.get("content"):
+                        assistant_content.append(TextContent(text=str(msg["content"])))
+                    if assistant_content:
+                        messages.append(AssistantMessage(content=assistant_content))
 
         return messages
 

--- a/src/strands_evals/mappers/generic_gen_ai_session_mapper.py
+++ b/src/strands_evals/mappers/generic_gen_ai_session_mapper.py
@@ -1,0 +1,340 @@
+"""
+GenericGenAISessionMapper - Maps dict-format spans with gen_ai.* attributes to Session format.
+
+Handles spans from any framework that uses OpenTelemetry GenAI semantic conventions
+(gen_ai.operation.name, gen_ai.tool.name, etc.) but has an unrecognized scope name.
+
+This is the fallback mapper for spans that don't match any known instrumentor scope
+(Strands, OpenInference, LangChain) but still carry structured gen_ai.* attributes.
+"""
+
+import json
+import logging
+from collections import defaultdict
+from datetime import datetime, timezone
+from typing import Any
+
+from ..types.trace import (
+    AgentInvocationSpan,
+    AssistantMessage,
+    InferenceSpan,
+    Session,
+    SpanInfo,
+    TextContent,
+    ToolCall,
+    ToolCallContent,
+    ToolConfig,
+    ToolExecutionSpan,
+    ToolResult,
+    ToolResultContent,
+    Trace,
+    UserMessage,
+)
+from .session_mapper import SessionMapper
+
+logger = logging.getLogger(__name__)
+
+
+class GenericGenAISessionMapper(SessionMapper):
+    """Maps dict-format spans with gen_ai.* attributes to Session format.
+
+    Classifies spans by gen_ai.operation.name:
+    - "chat" → InferenceSpan
+    - "execute_tool" → ToolExecutionSpan
+    - "invoke_agent" → AgentInvocationSpan
+
+    Extracts data from both span attributes (gen_ai.tool.input, gen_ai.tool.output)
+    and span_events (gen_ai.user.message, gen_ai.choice, etc.).
+    """
+
+    def map_to_session(self, data: Any, session_id: str) -> Session:
+        """Map dict-format spans to Session.
+
+        Args:
+            data: List of span dicts (from readable_spans_to_dicts or similar)
+            session_id: Session identifier for filtering
+
+        Returns:
+            Session object ready for evaluation
+        """
+        if not data:
+            return Session(traces=[], session_id=session_id)
+
+        spans = self._normalize_to_flat_spans(data)
+
+        # Group by trace_id, optionally filtering by session.id
+        traces_by_id: dict[str, list[dict]] = defaultdict(list)
+
+        any_span_has_session_id = any(
+            "session.id" in span.get("attributes", {}) or "gen_ai.conversation.id" in span.get("attributes", {})
+            for span in spans
+        )
+
+        for span in spans:
+            attrs = span.get("attributes", {})
+
+            if not any_span_has_session_id:
+                should_include = True
+            else:
+                span_session_id = attrs.get("gen_ai.conversation.id") or attrs.get("session.id")
+                should_include = str(span_session_id) == session_id if span_session_id else True
+
+            if should_include:
+                trace_id = span.get("trace_id", "unknown")
+                traces_by_id[trace_id].append(span)
+
+        traces: list[Trace] = []
+        for trace_id, trace_spans in traces_by_id.items():
+            trace = self._convert_trace(trace_id, trace_spans, session_id)
+            if trace.spans:
+                traces.append(trace)
+
+        return Session(traces=traces, session_id=session_id)
+
+    def _convert_trace(self, trace_id: str, spans: list[dict], session_id: str) -> Trace:
+        """Convert a list of dict spans (same trace_id) to a Trace."""
+        converted_spans: list[InferenceSpan | ToolExecutionSpan | AgentInvocationSpan] = []
+
+        for span in spans:
+            try:
+                attrs = span.get("attributes", {})
+                operation_name = attrs.get("gen_ai.operation.name", "")
+
+                span_info = SpanInfo(
+                    trace_id=span.get("trace_id"),
+                    span_id=span.get("span_id"),
+                    session_id=session_id,
+                    parent_span_id=span.get("parent_span_id"),
+                    start_time=self._parse_timestamp(span.get("start_time")),
+                    end_time=self._parse_timestamp(span.get("end_time")),
+                )
+
+                if operation_name == "chat":
+                    inference_span = self._convert_inference_span(span, span_info)
+                    if inference_span and inference_span.messages:
+                        converted_spans.append(inference_span)
+                elif operation_name == "execute_tool":
+                    tool_span = self._convert_tool_execution_span(span, span_info)
+                    if tool_span:
+                        converted_spans.append(tool_span)
+                elif operation_name == "invoke_agent":
+                    agent_span = self._convert_agent_invocation_span(span, span_info)
+                    if agent_span:
+                        converted_spans.append(agent_span)
+            except (KeyError, TypeError, ValueError, json.JSONDecodeError) as e:
+                logger.warning(
+                    "trace_id=%s span_id=%s | Failed to convert span: %s",
+                    span.get("trace_id", "?"), span.get("span_id", "?"), e,
+                )
+
+        return Trace(spans=converted_spans, trace_id=trace_id, session_id=session_id)
+
+    def _parse_timestamp(self, value: Any) -> datetime:
+        """Parse timestamp from various formats.
+
+        readable_spans_to_dicts() preserves OTel's nanosecond epoch timestamps.
+        Values > 1e12 are assumed nanoseconds and divided by 1e9.
+        """
+        if value is None:
+            return datetime.now(timezone.utc)
+        if isinstance(value, datetime):
+            return value
+        if isinstance(value, (int, float)):
+            # OTel timestamps from ReadableSpan are nanoseconds (> 1e18).
+            # Seconds-based timestamps are < 1e10. Threshold at 1e12 to distinguish.
+            if value > 1e12:
+                value = value / 1e9
+            return datetime.fromtimestamp(value, tz=timezone.utc)
+        return datetime.now(timezone.utc)
+
+    def _parse_json_attr(self, attributes: Any, key: str, default: str = "[]") -> Any:
+        """Parse a JSON-encoded attribute value."""
+        try:
+            value = attributes.get(key, default)
+            return json.loads(str(value))
+        except (AttributeError, TypeError, json.JSONDecodeError):
+            return json.loads(default)
+
+    # =========================================================================
+    # Span Conversion
+    # =========================================================================
+
+    def _convert_inference_span(self, span: dict, span_info: SpanInfo) -> InferenceSpan | None:
+        """Convert a span with gen_ai.operation.name='chat' to InferenceSpan."""
+        messages: list[UserMessage | AssistantMessage] = []
+
+        for event in span.get("span_events", []):
+            try:
+                event_name = event.get("event_name", "")
+                event_attrs = event.get("attributes", {})
+
+                if event_name == "gen_ai.user.message":
+                    content_list = self._parse_json_attr(event_attrs, "content")
+                    user_content: list[TextContent | ToolResultContent] = [
+                        TextContent(text=item["text"]) for item in content_list if "text" in item
+                    ]
+                    if user_content:
+                        messages.append(UserMessage(content=user_content))
+
+                elif event_name == "gen_ai.assistant.message":
+                    content_list = self._parse_json_attr(event_attrs, "content")
+                    assistant_content = self._process_assistant_content(content_list)
+                    if assistant_content:
+                        messages.append(AssistantMessage(content=assistant_content))
+
+                elif event_name == "gen_ai.tool.message":
+                    content_list = self._parse_json_attr(event_attrs, "content")
+                    tool_results = self._process_tool_results(content_list)
+                    if tool_results:
+                        messages.append(UserMessage(content=tool_results))
+
+                elif event_name == "gen_ai.choice":
+                    message_list = self._parse_json_attr(event_attrs, "message")
+                    assistant_content = self._process_assistant_content(message_list)
+                    if assistant_content:
+                        messages.append(AssistantMessage(content=assistant_content))
+            except (KeyError, TypeError, ValueError, json.JSONDecodeError) as e:
+                logger.warning(
+                    "span_id=%s event=%s | Failed to process event: %s",
+                    span.get("span_id", "?"), event.get("event_name", "?"), e,
+                )
+
+        return InferenceSpan(span_info=span_info, messages=messages, metadata={})
+
+    def _convert_tool_execution_span(self, span: dict, span_info: SpanInfo) -> ToolExecutionSpan | None:
+        """Convert a span with gen_ai.operation.name='execute_tool' to ToolExecutionSpan."""
+        attrs = span.get("attributes", {})
+
+        tool_name = str(attrs.get("gen_ai.tool.name", ""))
+        tool_call_id = str(attrs.get("gen_ai.tool.call.id", ""))
+        tool_status = attrs.get("gen_ai.tool.status", attrs.get("tool.status", ""))
+        tool_error = None if tool_status == "success" else (str(tool_status) if tool_status else None)
+
+        tool_arguments: dict = {}
+        tool_result_content: str = ""
+
+        # Try span_events first (Strands telemetry format)
+        for event in span.get("span_events", []):
+            try:
+                event_name = event.get("event_name", "")
+                event_attrs = event.get("attributes", {})
+
+                if event_name == "gen_ai.tool.message":
+                    tool_arguments = self._parse_json_attr(event_attrs, "content", "{}")
+                elif event_name == "gen_ai.choice":
+                    message_list = self._parse_json_attr(event_attrs, "message")
+                    tool_result_content = message_list[0].get("text", "") if message_list else ""
+            except (KeyError, TypeError, ValueError, json.JSONDecodeError) as e:
+                logger.warning(
+                    "span_id=%s | Failed to process tool event: %s",
+                    span.get("span_id", "?"), e,
+                )
+
+        # Fallback: gen_ai.tool.input/output attributes (manual instrumentation)
+        if not tool_arguments:
+            tool_input = attrs.get("gen_ai.tool.input", "")
+            if tool_input:
+                try:
+                    parsed = json.loads(tool_input) if isinstance(tool_input, str) else tool_input
+                    tool_arguments = parsed if isinstance(parsed, dict) else {}
+                except (json.JSONDecodeError, TypeError):
+                    tool_arguments = {}
+
+        if not tool_result_content:
+            tool_output = attrs.get("gen_ai.tool.output", "")
+            if tool_output:
+                tool_result_content = str(tool_output)
+
+        if not tool_name:
+            return None
+
+        tool_call = ToolCall(name=tool_name, arguments=tool_arguments, tool_call_id=tool_call_id)
+        tool_result = ToolResult(content=tool_result_content, error=tool_error, tool_call_id=tool_call_id)
+
+        return ToolExecutionSpan(span_info=span_info, tool_call=tool_call, tool_result=tool_result, metadata={})
+
+    def _convert_agent_invocation_span(self, span: dict, span_info: SpanInfo) -> AgentInvocationSpan | None:
+        """Convert a span with gen_ai.operation.name='invoke_agent' to AgentInvocationSpan."""
+        attrs = span.get("attributes", {})
+
+        user_prompt = ""
+        agent_response = ""
+        available_tools: list[ToolConfig] = []
+
+        # Parse available tools
+        try:
+            tools_json = attrs.get("gen_ai.agent.tools", "[]")
+            tool_names = json.loads(str(tools_json)) if isinstance(tools_json, str) else tools_json
+            if isinstance(tool_names, list):
+                available_tools = [ToolConfig(name=name) for name in tool_names]
+        except (json.JSONDecodeError, TypeError):
+            pass
+
+        # Extract from span_events
+        for event in span.get("span_events", []):
+            try:
+                event_name = event.get("event_name", "")
+                event_attrs = event.get("attributes", {})
+
+                if event_name == "gen_ai.user.message":
+                    content_list = self._parse_json_attr(event_attrs, "content")
+                    user_prompt = content_list[0].get("text", "") if content_list else ""
+                elif event_name == "gen_ai.choice":
+                    msg = event_attrs.get("message", "")
+                    agent_response = str(msg)
+            except (KeyError, TypeError, ValueError, json.JSONDecodeError) as e:
+                logger.warning(
+                    "span_id=%s | Failed to process agent event: %s",
+                    span.get("span_id", "?"), e,
+                )
+
+        return AgentInvocationSpan(
+            span_info=span_info,
+            user_prompt=user_prompt,
+            agent_response=agent_response,
+            available_tools=available_tools,
+            metadata={},
+        )
+
+    # =========================================================================
+    # Content Processing Helpers
+    # =========================================================================
+
+    @staticmethod
+    def _process_assistant_content(content_list: list[dict]) -> list[TextContent | ToolCallContent]:
+        """Process assistant message content blocks."""
+        result: list[TextContent | ToolCallContent] = []
+        for item in content_list:
+            if "text" in item:
+                result.append(TextContent(text=item["text"]))
+            elif "toolUse" in item:
+                tool_use = item["toolUse"]
+                result.append(
+                    ToolCallContent(
+                        name=tool_use["name"],
+                        arguments=tool_use.get("input", {}),
+                        tool_call_id=tool_use.get("toolUseId"),
+                    )
+                )
+        return result
+
+    @staticmethod
+    def _process_tool_results(content_list: list[dict]) -> list[TextContent | ToolResultContent]:
+        """Process tool result content blocks."""
+        result: list[TextContent | ToolResultContent] = []
+        for item in content_list:
+            if "toolResult" in item:
+                tool_result = item["toolResult"]
+                result_text = tool_result.get("content", "")
+                if isinstance(result_text, list):
+                    result_text = "\n".join(
+                        block.get("text", "") for block in result_text if isinstance(block, dict) and "text" in block
+                    )
+                result.append(
+                    ToolResultContent(
+                        content=str(result_text),
+                        error=tool_result.get("error"),
+                        tool_call_id=tool_result.get("toolUseId"),
+                    )
+                )
+        return result

--- a/src/strands_evals/mappers/generic_gen_ai_session_mapper.py
+++ b/src/strands_evals/mappers/generic_gen_ai_session_mapper.py
@@ -11,7 +11,6 @@ This is the fallback mapper for spans that don't match any known instrumentor sc
 import json
 import logging
 from collections import defaultdict
-from datetime import datetime
 from typing import Any
 
 from ..types.trace import (
@@ -44,8 +43,18 @@ class GenericGenAISessionMapper(SessionMapper):
     - "execute_tool" → ToolExecutionSpan
     - "invoke_agent" → AgentInvocationSpan
 
-    Extracts data from both span attributes (gen_ai.tool.input, gen_ai.tool.output)
-    and span_events (gen_ai.user.message, gen_ai.choice, etc.).
+    Supports both the legacy event convention (gen_ai.user.message, gen_ai.choice,
+    gen_ai.tool.message) and the current unified convention
+    (gen_ai.client.inference.operation.details with gen_ai.input.messages /
+    gen_ai.output.messages), including producers running under
+    OTEL_SEMCONV_STABILITY_OPT_IN=gen_ai_latest_experimental.
+
+    Session filtering policy:
+        Trace-level inclusion with span-level exclusion. A trace is included if at
+        least one span matches the requested session_id (via gen_ai.conversation.id or
+        session.id). Within an included trace, spans explicitly tagged with a *different*
+        session are excluded; untagged spans inherit membership from the trace match.
+        When no spans carry any session tag, all spans are included unconditionally.
     """
 
     def map_to_session(self, data: Any, session_id: str) -> Session:
@@ -117,8 +126,8 @@ class GenericGenAISessionMapper(SessionMapper):
                     span_id=span.get("span_id"),
                     session_id=session_id,
                     parent_span_id=span.get("parent_span_id"),
-                    start_time=self._parse_timestamp(span.get("start_time")),
-                    end_time=self._parse_timestamp(span.get("end_time")),
+                    start_time=self.parse_timestamp(span.get("start_time")),
+                    end_time=self.parse_timestamp(span.get("end_time")),
                 )
 
                 if operation_name == "chat":
@@ -142,15 +151,6 @@ class GenericGenAISessionMapper(SessionMapper):
                 )
 
         return Trace(spans=converted_spans, trace_id=trace_id, session_id=session_id)
-
-    def _parse_timestamp(self, value: Any) -> datetime:
-        """Parse timestamp from various formats.
-
-        Delegates to SessionMapper.parse_timestamp, which additionally handles
-        ISO-8601 and string-encoded nanosecond epochs (the OTLP/JSON encoding
-        for int64 fields, as produced on the CloudWatch/ADOT path).
-        """
-        return self.parse_timestamp(value)
 
     def _parse_json_attr(self, attributes: Any, key: str, default: str = "[]") -> Any:
         """Parse a JSON-encoded attribute value."""
@@ -233,7 +233,8 @@ class GenericGenAISessionMapper(SessionMapper):
         # fall back to gen_ai.tool.status / tool.status for legacy compatibility.
         # https://github.com/open-telemetry/semantic-conventions-genai/blob/main/model/gen-ai/spans.yaml#L522-L562
         error_type = attrs.get("error.type", "")
-        span_status = span.get("status", {}).get("code", "")
+        status_obj = span.get("status") or {}
+        span_status = status_obj.get("code", "") if isinstance(status_obj, dict) else ""
         tool_status = attrs.get("gen_ai.tool.status", attrs.get("tool.status", ""))
 
         if error_type:
@@ -425,9 +426,9 @@ class GenericGenAISessionMapper(SessionMapper):
     # Content Processing Helpers
     # =========================================================================
 
-    def _convert_message_list_from_event(self, event_attrs: dict) -> list:
+    def _convert_message_list_from_event(self, event_attrs: dict) -> list[UserMessage | AssistantMessage]:
         """Parse operation.details event attrs and return typed messages via _convert_message_list."""
-        messages = []
+        messages: list[UserMessage | AssistantMessage] = []
         for key in ("gen_ai.input.messages", "gen_ai.output.messages"):
             raw = event_attrs.get(key, "")
             if not raw:

--- a/src/strands_evals/mappers/generic_gen_ai_session_mapper.py
+++ b/src/strands_evals/mappers/generic_gen_ai_session_mapper.py
@@ -203,7 +203,7 @@ class GenericGenAISessionMapper(SessionMapper):
                 elif event_name == "gen_ai.client.inference.operation.details":
                     # Current OTel GenAI convention: single event with input/output messages
                     # https://github.com/open-telemetry/semantic-conventions-genai/blob/main/docs/gen-ai/gen-ai-events.md
-                    details_messages = self._parse_operation_details_event(event_attrs)
+                    details_messages = self._convert_message_list_from_event(event_attrs)
                     messages.extend(details_messages)
 
             except (KeyError, TypeError, ValueError, json.JSONDecodeError) as e:
@@ -262,6 +262,26 @@ class GenericGenAISessionMapper(SessionMapper):
                 elif event_name == "gen_ai.choice":
                     message_list = self._parse_json_attr(event_attrs, "message")
                     tool_result_content = message_list[0].get("text", "") if message_list else ""
+                elif event_name == "gen_ai.client.inference.operation.details":
+                    # Current OTel GenAI convention: unified event with input/output messages.
+                    # Extract tool arguments from input and tool result from output.
+                    messages = self._convert_message_list_from_event(event_attrs)
+                    for msg in messages:
+                        if msg.role.value == "user":
+                            for c in msg.content:
+                                if hasattr(c, "text") and c.text and not tool_arguments:
+                                    try:
+                                        parsed = json.loads(c.text)
+                                        if isinstance(parsed, dict):
+                                            tool_arguments = parsed
+                                    except (json.JSONDecodeError, TypeError):
+                                        pass
+                                elif hasattr(c, "content") and c.content and not tool_result_content:
+                                    tool_result_content = c.content
+                        elif msg.role.value == "assistant":
+                            for c in msg.content:
+                                if hasattr(c, "text") and c.text and not tool_result_content:
+                                    tool_result_content = c.text
             except (KeyError, TypeError, ValueError, json.JSONDecodeError) as e:
                 logger.warning(
                     "span_id=%s | Failed to process tool event: %s",
@@ -325,6 +345,21 @@ class GenericGenAISessionMapper(SessionMapper):
                 elif event_name == "gen_ai.choice":
                     msg = event_attrs.get("message", "")
                     agent_response = str(msg)
+                elif event_name == "gen_ai.client.inference.operation.details":
+                    # Current OTel GenAI convention: unified event with input/output messages.
+                    # Extract user prompt from input messages and agent response from output.
+                    messages = self._convert_message_list_from_event(event_attrs)
+                    for msg in messages:
+                        if msg.role.value == "user" and not user_prompt:
+                            for c in msg.content:
+                                if hasattr(c, "text") and c.text:
+                                    user_prompt = c.text
+                                    break
+                        elif msg.role.value == "assistant" and not agent_response:
+                            for c in msg.content:
+                                if hasattr(c, "text") and c.text:
+                                    agent_response = c.text
+                                    break
             except (KeyError, TypeError, ValueError, json.JSONDecodeError) as e:
                 logger.warning(
                     "span_id=%s | Failed to process agent event: %s",
@@ -390,6 +425,127 @@ class GenericGenAISessionMapper(SessionMapper):
     # Content Processing Helpers
     # =========================================================================
 
+    def _convert_message_list_from_event(self, event_attrs: dict) -> list:
+        """Parse operation.details event attrs and return typed messages via _convert_message_list."""
+        messages = []
+        for key in ("gen_ai.input.messages", "gen_ai.output.messages"):
+            raw = event_attrs.get(key, "")
+            if not raw:
+                continue
+            try:
+                msg_list = json.loads(raw) if isinstance(raw, str) else raw
+            except (json.JSONDecodeError, TypeError):
+                continue
+            if isinstance(msg_list, list):
+                messages.extend(self._convert_message_list(msg_list))
+        return messages
+
+    def _convert_message_list(self, msg_list: list[dict]) -> list[UserMessage | AssistantMessage]:
+        """Convert a list of role-tagged message dicts to typed UserMessage/AssistantMessage.
+
+        Shared logic for both span-attribute messages (gen_ai.input.messages /
+        gen_ai.output.messages) and operation.details event payloads.
+
+        Supports:
+        - role "user": text parts and tool_call_response parts
+        - role "tool": OTel GenAI convention tool results (parts-based or flat)
+        - role "assistant": text parts, tool_call parts, or flat content string
+        """
+        messages: list[UserMessage | AssistantMessage] = []
+
+        for msg in msg_list:
+            role = msg.get("role", "")
+            parts = msg.get("parts", [])
+
+            if role == "user":
+                user_content: list[TextContent | ToolResultContent] = []
+                for part in parts:
+                    if not isinstance(part, dict):
+                        continue
+                    if part.get("type") == "text" and part.get("content"):
+                        user_content.append(TextContent(text=part["content"]))
+                    elif part.get("type") == "tool_call_response":
+                        user_content.append(
+                            ToolResultContent(
+                                content=str(part.get("result", "")),
+                                error=None,
+                                tool_call_id=part.get("id"),
+                            )
+                        )
+                if user_content:
+                    messages.append(UserMessage(content=user_content))
+
+            elif role == "tool":
+                # OTel GenAI convention: role "tool" carries tool results.
+                # Two formats:
+                #   1. parts: [{"type": "tool_call_response", "id": "...", "response": "..."}]
+                #   2. flat: {"role": "tool", "id": "...", "response": "..."}
+                if parts:
+                    for part in parts:
+                        if isinstance(part, dict) and part.get("type") == "tool_call_response":
+                            tc_id = part.get("id") or part.get("tool_call_id")
+                            resp = part.get("response", "")
+                            if isinstance(resp, dict):
+                                resp = json.dumps(resp)
+                            messages.append(
+                                UserMessage(
+                                    content=[
+                                        ToolResultContent(
+                                            content=str(resp) if resp else "",
+                                            error=None,
+                                            tool_call_id=tc_id,
+                                        )
+                                    ]
+                                )
+                            )
+                else:
+                    tool_call_id = msg.get("id") or msg.get("tool_call_id")
+                    response = msg.get("response", msg.get("content", ""))
+                    if isinstance(response, dict):
+                        response = json.dumps(response)
+                    elif isinstance(response, list):
+                        parts_text = []
+                        for block in response:
+                            if isinstance(block, dict) and block.get("text"):
+                                parts_text.append(block["text"])
+                            elif isinstance(block, str):
+                                parts_text.append(block)
+                        response = "\n".join(parts_text) if parts_text else str(response)
+                    messages.append(
+                        UserMessage(
+                            content=[
+                                ToolResultContent(
+                                    content=str(response) if response else "",
+                                    error=None,
+                                    tool_call_id=tool_call_id,
+                                )
+                            ]
+                        )
+                    )
+
+            elif role == "assistant":
+                assistant_content: list[TextContent | ToolCallContent] = []
+                for part in parts:
+                    if not isinstance(part, dict):
+                        continue
+                    if part.get("type") == "text" and part.get("content"):
+                        assistant_content.append(TextContent(text=part["content"]))
+                    elif part.get("type") == "tool_call":
+                        assistant_content.append(
+                            ToolCallContent(
+                                name=part.get("name", ""),
+                                arguments=part.get("arguments", {}),
+                                tool_call_id=part.get("id"),
+                            )
+                        )
+                # Also handle flat content string (no parts)
+                if not assistant_content and msg.get("content"):
+                    assistant_content.append(TextContent(text=str(msg["content"])))
+                if assistant_content:
+                    messages.append(AssistantMessage(content=assistant_content))
+
+        return messages
+
     def _parse_attribute_messages(self, attrs: dict) -> list[UserMessage | AssistantMessage]:
         """Parse gen_ai.input.messages / gen_ai.output.messages from span attributes.
 
@@ -400,234 +556,16 @@ class GenericGenAISessionMapper(SessionMapper):
         """
         messages: list[UserMessage | AssistantMessage] = []
 
-        # Parse input messages
-        input_msgs_raw = attrs.get("gen_ai.input.messages", "")
-        if input_msgs_raw:
-            try:
-                input_msgs = json.loads(input_msgs_raw) if isinstance(input_msgs_raw, str) else input_msgs_raw
-                if isinstance(input_msgs, list):
-                    for msg in input_msgs:
-                        role = msg.get("role", "")
-                        parts = msg.get("parts", [])
-                        if role == "user":
-                            user_content: list[TextContent | ToolResultContent] = []
-                            for part in parts:
-                                if part.get("type") == "text" and part.get("content"):
-                                    user_content.append(TextContent(text=part["content"]))
-                                elif part.get("type") == "tool_call_response":
-                                    user_content.append(
-                                        ToolResultContent(
-                                            content=str(part.get("result", "")),
-                                            error=None,
-                                            tool_call_id=part.get("id"),
-                                        )
-                                    )
-                            if user_content:
-                                messages.append(UserMessage(content=user_content))
-                        elif role == "tool":
-                            # OTel GenAI convention: role "tool" carries tool results.
-                            # Two formats:
-                            #   1. parts: [{"type": "tool_call_response", "id": "...", "response": "..."}]
-                            #   2. flat: {"role": "tool", "id": "...", "response": "..."}
-                            # https://github.com/open-telemetry/semantic-conventions-genai/blob/main/docs/registry/attributes/gen-ai.md
-                            if parts:
-                                for part in parts:
-                                    if isinstance(part, dict) and part.get("type") == "tool_call_response":
-                                        tc_id = part.get("id") or part.get("tool_call_id")
-                                        resp = part.get("response", "")
-                                        if isinstance(resp, dict):
-                                            resp = json.dumps(resp)
-                                        messages.append(
-                                            UserMessage(
-                                                content=[
-                                                    ToolResultContent(
-                                                        content=str(resp) if resp else "",
-                                                        error=None,
-                                                        tool_call_id=tc_id,
-                                                    )
-                                                ]
-                                            )
-                                        )
-                            else:
-                                tool_call_id = msg.get("id") or msg.get("tool_call_id")
-                                response = msg.get("response", msg.get("content", ""))
-                                if isinstance(response, dict):
-                                    response = json.dumps(response)
-                                elif isinstance(response, list):
-                                    parts_text = []
-                                    for block in response:
-                                        if isinstance(block, dict) and block.get("text"):
-                                            parts_text.append(block["text"])
-                                        elif isinstance(block, str):
-                                            parts_text.append(block)
-                                    response = "\n".join(parts_text) if parts_text else str(response)
-                                messages.append(
-                                    UserMessage(
-                                        content=[
-                                            ToolResultContent(
-                                                content=str(response) if response else "",
-                                                error=None,
-                                                tool_call_id=tool_call_id,
-                                            )
-                                        ]
-                                    )
-                                )
-                        elif role == "assistant":
-                            assistant_content: list[TextContent | ToolCallContent] = []
-                            for part in parts:
-                                if part.get("type") == "text" and part.get("content"):
-                                    assistant_content.append(TextContent(text=part["content"]))
-                                elif part.get("type") == "tool_call":
-                                    assistant_content.append(
-                                        ToolCallContent(
-                                            name=part.get("name", ""),
-                                            arguments=part.get("arguments", {}),
-                                            tool_call_id=part.get("id"),
-                                        )
-                                    )
-                            if assistant_content:
-                                messages.append(AssistantMessage(content=assistant_content))
-            except (json.JSONDecodeError, TypeError, KeyError):
-                pass
-
-        # Parse output messages
-        output_msgs_raw = attrs.get("gen_ai.output.messages", "")
-        if output_msgs_raw:
-            try:
-                output_msgs = json.loads(output_msgs_raw) if isinstance(output_msgs_raw, str) else output_msgs_raw
-                if isinstance(output_msgs, list):
-                    for msg in output_msgs:
-                        role = msg.get("role", "")
-                        parts = msg.get("parts", [])
-                        if role == "assistant":
-                            assistant_content = []
-                            for part in parts:
-                                if part.get("type") == "text" and part.get("content"):
-                                    assistant_content.append(TextContent(text=part["content"]))
-                                elif part.get("type") == "tool_call":
-                                    assistant_content.append(
-                                        ToolCallContent(
-                                            name=part.get("name", ""),
-                                            arguments=part.get("arguments", {}),
-                                            tool_call_id=part.get("id"),
-                                        )
-                                    )
-                            if assistant_content:
-                                messages.append(AssistantMessage(content=assistant_content))
-            except (json.JSONDecodeError, TypeError, KeyError):
-                pass
-
-        return messages
-
-    def _parse_operation_details_event(self, event_attrs: dict) -> list[UserMessage | AssistantMessage]:
-        """Parse gen_ai.client.inference.operation.details event (current OTel GenAI convention).
-
-        This event carries gen_ai.input.messages and gen_ai.output.messages as structured
-        lists or JSON-encoded strings within a single span event.
-        https://github.com/open-telemetry/semantic-conventions-genai/blob/main/docs/gen-ai/gen-ai-events.md
-        """
-        messages: list[UserMessage | AssistantMessage] = []
-
         for key in ("gen_ai.input.messages", "gen_ai.output.messages"):
-            raw = event_attrs.get(key, "")
+            raw = attrs.get(key, "")
             if not raw:
                 continue
             try:
                 msg_list = json.loads(raw) if isinstance(raw, str) else raw
             except (json.JSONDecodeError, TypeError):
                 continue
-
-            if not isinstance(msg_list, list):
-                continue
-
-            for msg in msg_list:
-                role = msg.get("role", "")
-                parts = msg.get("parts", [])
-
-                if role == "user":
-                    user_content: list[TextContent | ToolResultContent] = []
-                    for part in parts:
-                        if isinstance(part, dict):
-                            if part.get("type") == "text" and part.get("content"):
-                                user_content.append(TextContent(text=part["content"]))
-                            elif part.get("type") == "tool_call_response":
-                                user_content.append(
-                                    ToolResultContent(
-                                        content=str(part.get("result", "")),
-                                        error=None,
-                                        tool_call_id=part.get("id"),
-                                    )
-                                )
-                    if user_content:
-                        messages.append(UserMessage(content=user_content))
-
-                elif role == "tool":
-                    # OTel convention: role "tool" carries tool results.
-                    # Two formats:
-                    #   1. parts: [{"type": "tool_call_response", "id": "...", "response": "..."}]
-                    #   2. flat: {"role": "tool", "id": "...", "response": "..."}
-                    if parts:
-                        for part in parts:
-                            if isinstance(part, dict) and part.get("type") == "tool_call_response":
-                                tc_id = part.get("id") or part.get("tool_call_id")
-                                resp = part.get("response", "")
-                                if isinstance(resp, dict):
-                                    resp = json.dumps(resp)
-                                messages.append(
-                                    UserMessage(
-                                        content=[
-                                            ToolResultContent(
-                                                content=str(resp) if resp else "",
-                                                error=None,
-                                                tool_call_id=tc_id,
-                                            )
-                                        ]
-                                    )
-                                )
-                    else:
-                        tool_call_id = msg.get("id") or msg.get("tool_call_id")
-                        response = msg.get("response", msg.get("content", ""))
-                        if isinstance(response, dict):
-                            response = json.dumps(response)
-                        elif isinstance(response, list):
-                            parts_text = []
-                            for block in response:
-                                if isinstance(block, dict) and block.get("text"):
-                                    parts_text.append(block["text"])
-                                elif isinstance(block, str):
-                                    parts_text.append(block)
-                            response = "\n".join(parts_text) if parts_text else str(response)
-                        messages.append(
-                            UserMessage(
-                                content=[
-                                    ToolResultContent(
-                                        content=str(response) if response else "",
-                                        error=None,
-                                        tool_call_id=tool_call_id,
-                                    )
-                                ]
-                            )
-                        )
-
-                elif role == "assistant":
-                    assistant_content: list[TextContent | ToolCallContent] = []
-                    for part in parts:
-                        if isinstance(part, dict):
-                            if part.get("type") == "text" and part.get("content"):
-                                assistant_content.append(TextContent(text=part["content"]))
-                            elif part.get("type") == "tool_call":
-                                assistant_content.append(
-                                    ToolCallContent(
-                                        name=part.get("name", ""),
-                                        arguments=part.get("arguments", {}),
-                                        tool_call_id=part.get("id"),
-                                    )
-                                )
-                    # Also handle flat content string (no parts)
-                    if not assistant_content and msg.get("content"):
-                        assistant_content.append(TextContent(text=str(msg["content"])))
-                    if assistant_content:
-                        messages.append(AssistantMessage(content=assistant_content))
+            if isinstance(msg_list, list):
+                messages.extend(self._convert_message_list(msg_list))
 
         return messages
 

--- a/src/strands_evals/mappers/generic_gen_ai_session_mapper.py
+++ b/src/strands_evals/mappers/generic_gen_ai_session_mapper.py
@@ -163,6 +163,7 @@ class GenericGenAISessionMapper(SessionMapper):
         """Convert a span with gen_ai.operation.name='chat' to InferenceSpan."""
         messages: list[UserMessage | AssistantMessage] = []
 
+        # Try span_events first (Strands telemetry / manual instrumentation format)
         for event in span.get("span_events", []):
             try:
                 event_name = event.get("event_name", "")
@@ -199,6 +200,12 @@ class GenericGenAISessionMapper(SessionMapper):
                     span.get("span_id", "?"), event.get("event_name", "?"), e,
                 )
 
+        # Fallback: gen_ai.input.messages / gen_ai.output.messages as span attributes
+        # (PydanticAI, AutoGen, and other native gen_ai semconv frameworks)
+        if not messages:
+            attrs = span.get("attributes", {})
+            messages = self._parse_attribute_messages(attrs)
+
         return InferenceSpan(span_info=span_info, messages=messages, metadata={})
 
     def _convert_tool_execution_span(self, span: dict, span_info: SpanInfo) -> ToolExecutionSpan | None:
@@ -232,7 +239,7 @@ class GenericGenAISessionMapper(SessionMapper):
 
         # Fallback: gen_ai.tool.input/output attributes (manual instrumentation)
         if not tool_arguments:
-            tool_input = attrs.get("gen_ai.tool.input", "")
+            tool_input = attrs.get("gen_ai.tool.input", "") or attrs.get("gen_ai.tool.call.arguments", "")
             if tool_input:
                 try:
                     parsed = json.loads(tool_input) if isinstance(tool_input, str) else tool_input
@@ -241,7 +248,7 @@ class GenericGenAISessionMapper(SessionMapper):
                     tool_arguments = {}
 
         if not tool_result_content:
-            tool_output = attrs.get("gen_ai.tool.output", "")
+            tool_output = attrs.get("gen_ai.tool.output", "") or attrs.get("gen_ai.tool.call.result", "")
             if tool_output:
                 tool_result_content = str(tool_output)
 
@@ -261,16 +268,20 @@ class GenericGenAISessionMapper(SessionMapper):
         agent_response = ""
         available_tools: list[ToolConfig] = []
 
-        # Parse available tools
+        # Parse available tools from gen_ai.agent.tools or gen_ai.tool.definitions
         try:
-            tools_json = attrs.get("gen_ai.agent.tools", "[]")
-            tool_names = json.loads(str(tools_json)) if isinstance(tools_json, str) else tools_json
-            if isinstance(tool_names, list):
-                available_tools = [ToolConfig(name=name) for name in tool_names]
+            tools_json = attrs.get("gen_ai.agent.tools", "") or attrs.get("gen_ai.tool.definitions", "[]")
+            tool_list = json.loads(str(tools_json)) if isinstance(tools_json, str) else tools_json
+            if isinstance(tool_list, list):
+                for item in tool_list:
+                    if isinstance(item, str):
+                        available_tools.append(ToolConfig(name=item))
+                    elif isinstance(item, dict):
+                        available_tools.append(ToolConfig(name=item.get("name", "")))
         except (json.JSONDecodeError, TypeError):
             pass
 
-        # Extract from span_events
+        # Extract from span_events (manual instrumentation format)
         for event in span.get("span_events", []):
             try:
                 event_name = event.get("event_name", "")
@@ -288,6 +299,29 @@ class GenericGenAISessionMapper(SessionMapper):
                     span.get("span_id", "?"), e,
                 )
 
+        # Fallback: extract from attributes (PydanticAI / native gen_ai format)
+        if not user_prompt:
+            # Try pydantic_ai.all_messages or gen_ai.input.messages
+            all_msgs_raw = attrs.get("pydantic_ai.all_messages", "") or attrs.get("gen_ai.input.messages", "")
+            if all_msgs_raw:
+                try:
+                    all_msgs = json.loads(all_msgs_raw) if isinstance(all_msgs_raw, str) else all_msgs_raw
+                    if isinstance(all_msgs, list):
+                        for msg in all_msgs:
+                            if msg.get("role") == "user":
+                                parts = msg.get("parts", [])
+                                for part in parts:
+                                    if part.get("type") == "text" and part.get("content"):
+                                        user_prompt = part["content"]
+                                        break
+                            if user_prompt:
+                                break
+                except (json.JSONDecodeError, TypeError):
+                    pass
+
+        if not agent_response:
+            agent_response = str(attrs.get("final_result", ""))
+
         return AgentInvocationSpan(
             span_info=span_info,
             user_prompt=user_prompt,
@@ -299,6 +333,86 @@ class GenericGenAISessionMapper(SessionMapper):
     # =========================================================================
     # Content Processing Helpers
     # =========================================================================
+
+    def _parse_attribute_messages(self, attrs: dict) -> list[UserMessage | AssistantMessage]:
+        """Parse gen_ai.input.messages / gen_ai.output.messages from span attributes.
+
+        PydanticAI and other native gen_ai semconv frameworks store messages as
+        JSON arrays in span attributes rather than span_events. Format:
+            [{"role": "user", "parts": [{"type": "text", "content": "..."}]}, ...]
+        """
+        messages: list[UserMessage | AssistantMessage] = []
+
+        # Parse input messages
+        input_msgs_raw = attrs.get("gen_ai.input.messages", "")
+        if input_msgs_raw:
+            try:
+                input_msgs = json.loads(input_msgs_raw) if isinstance(input_msgs_raw, str) else input_msgs_raw
+                if isinstance(input_msgs, list):
+                    for msg in input_msgs:
+                        role = msg.get("role", "")
+                        parts = msg.get("parts", [])
+                        if role == "user":
+                            user_content: list[TextContent | ToolResultContent] = []
+                            for part in parts:
+                                if part.get("type") == "text" and part.get("content"):
+                                    user_content.append(TextContent(text=part["content"]))
+                                elif part.get("type") == "tool_call_response":
+                                    user_content.append(
+                                        ToolResultContent(
+                                            content=str(part.get("result", "")),
+                                            error=None,
+                                            tool_call_id=part.get("id"),
+                                        )
+                                    )
+                            if user_content:
+                                messages.append(UserMessage(content=user_content))
+                        elif role == "assistant":
+                            assistant_content: list[TextContent | ToolCallContent] = []
+                            for part in parts:
+                                if part.get("type") == "text" and part.get("content"):
+                                    assistant_content.append(TextContent(text=part["content"]))
+                                elif part.get("type") == "tool_call":
+                                    assistant_content.append(
+                                        ToolCallContent(
+                                            name=part.get("name", ""),
+                                            arguments=part.get("arguments", {}),
+                                            tool_call_id=part.get("id"),
+                                        )
+                                    )
+                            if assistant_content:
+                                messages.append(AssistantMessage(content=assistant_content))
+            except (json.JSONDecodeError, TypeError, KeyError):
+                pass
+
+        # Parse output messages
+        output_msgs_raw = attrs.get("gen_ai.output.messages", "")
+        if output_msgs_raw:
+            try:
+                output_msgs = json.loads(output_msgs_raw) if isinstance(output_msgs_raw, str) else output_msgs_raw
+                if isinstance(output_msgs, list):
+                    for msg in output_msgs:
+                        role = msg.get("role", "")
+                        parts = msg.get("parts", [])
+                        if role == "assistant":
+                            assistant_content = []
+                            for part in parts:
+                                if part.get("type") == "text" and part.get("content"):
+                                    assistant_content.append(TextContent(text=part["content"]))
+                                elif part.get("type") == "tool_call":
+                                    assistant_content.append(
+                                        ToolCallContent(
+                                            name=part.get("name", ""),
+                                            arguments=part.get("arguments", {}),
+                                            tool_call_id=part.get("id"),
+                                        )
+                                    )
+                            if assistant_content:
+                                messages.append(AssistantMessage(content=assistant_content))
+            except (json.JSONDecodeError, TypeError, KeyError):
+                pass
+
+        return messages
 
     @staticmethod
     def _process_assistant_content(content_list: list[dict]) -> list[TextContent | ToolCallContent]:

--- a/src/strands_evals/mappers/generic_gen_ai_session_mapper.py
+++ b/src/strands_evals/mappers/generic_gen_ai_session_mapper.py
@@ -218,7 +218,7 @@ class GenericGenAISessionMapper(SessionMapper):
         # (PydanticAI, AutoGen, and other native gen_ai semconv frameworks)
         if not messages:
             attrs = span.get("attributes", {})
-            messages = self._parse_attribute_messages(attrs)
+            messages = self._convert_message_list_from_event(attrs)
 
         return InferenceSpan(span_info=span_info, messages=messages, metadata={})
 
@@ -455,6 +455,8 @@ class GenericGenAISessionMapper(SessionMapper):
         messages: list[UserMessage | AssistantMessage] = []
 
         for msg in msg_list:
+            if not isinstance(msg, dict):
+                continue
             role = msg.get("role", "")
             parts = msg.get("parts", [])
 
@@ -466,9 +468,14 @@ class GenericGenAISessionMapper(SessionMapper):
                     if part.get("type") == "text" and part.get("content"):
                         user_content.append(TextContent(text=part["content"]))
                     elif part.get("type") == "tool_call_response":
+                        _r = part.get("response", part.get("result", ""))
+                        if isinstance(_r, list):
+                            _r = join_tool_result_content(_r)
+                        elif isinstance(_r, dict):
+                            _r = json.dumps(_r)
                         user_content.append(
                             ToolResultContent(
-                                content=str(part.get("result", "")),
+                                content=str(_r) if _r else "",
                                 error=None,
                                 tool_call_id=part.get("id"),
                             )
@@ -485,9 +492,11 @@ class GenericGenAISessionMapper(SessionMapper):
                     for part in parts:
                         if isinstance(part, dict) and part.get("type") == "tool_call_response":
                             tc_id = part.get("id") or part.get("tool_call_id")
-                            resp = part.get("response", "")
+                            resp = part.get("response", part.get("result", ""))
                             if isinstance(resp, dict):
                                 resp = json.dumps(resp)
+                            elif isinstance(resp, list):
+                                resp = join_tool_result_content(resp)
                             messages.append(
                                 UserMessage(
                                     content=[
@@ -505,13 +514,7 @@ class GenericGenAISessionMapper(SessionMapper):
                     if isinstance(response, dict):
                         response = json.dumps(response)
                     elif isinstance(response, list):
-                        parts_text = []
-                        for block in response:
-                            if isinstance(block, dict) and block.get("text"):
-                                parts_text.append(block["text"])
-                            elif isinstance(block, str):
-                                parts_text.append(block)
-                        response = "\n".join(parts_text) if parts_text else str(response)
+                        response = join_tool_result_content(response)
                     messages.append(
                         UserMessage(
                             content=[
@@ -544,29 +547,6 @@ class GenericGenAISessionMapper(SessionMapper):
                     assistant_content.append(TextContent(text=str(msg["content"])))
                 if assistant_content:
                     messages.append(AssistantMessage(content=assistant_content))
-
-        return messages
-
-    def _parse_attribute_messages(self, attrs: dict) -> list[UserMessage | AssistantMessage]:
-        """Parse gen_ai.input.messages / gen_ai.output.messages from span attributes.
-
-        PydanticAI and other native gen_ai semconv frameworks store messages as
-        JSON arrays in span attributes rather than span_events. Supports:
-        - PydanticAI format: [{"role": "user", "parts": [{"type": "text", "content": "..."}]}]
-        - OTel GenAI convention: role "tool" with response field for tool results
-        """
-        messages: list[UserMessage | AssistantMessage] = []
-
-        for key in ("gen_ai.input.messages", "gen_ai.output.messages"):
-            raw = attrs.get(key, "")
-            if not raw:
-                continue
-            try:
-                msg_list = json.loads(raw) if isinstance(raw, str) else raw
-            except (json.JSONDecodeError, TypeError):
-                continue
-            if isinstance(msg_list, list):
-                messages.extend(self._convert_message_list(msg_list))
 
         return messages
 

--- a/src/strands_evals/mappers/utils.py
+++ b/src/strands_evals/mappers/utils.py
@@ -96,7 +96,7 @@ def detect_otel_mapper(spans: list[Any]) -> SessionMapper:
     - InMemory format: gen_ai.* attributes
 
     Args:
-        spans: List of span dictionaries (normalized or raw), or ReadableSpan objects
+        spans: List of span dictionaries (normalized or raw)
 
     Returns:
         Appropriate SessionMapper instance

--- a/src/strands_evals/mappers/utils.py
+++ b/src/strands_evals/mappers/utils.py
@@ -123,13 +123,6 @@ def detect_otel_mapper(spans: list[Any]) -> SessionMapper:
     if not spans:
         return StrandsInMemorySessionMapper()
 
-    # Check if input is raw ReadableSpan objects (not dicts).
-    # If so, route directly to StrandsInMemorySessionMapper which handles them natively.
-    if not isinstance(spans[0], dict):
-        return StrandsInMemorySessionMapper()
-
-    # From here, spans are dicts (from readable_spans_to_dicts or CloudWatch parsing)
-
     # Detect scope and format from first relevant span
     for span in spans:
         scope_name = get_scope_name(span)
@@ -149,19 +142,26 @@ def detect_otel_mapper(spans: list[Any]) -> SessionMapper:
             # body-scan below determine CloudWatch vs InMemory.
             break
 
-    # Fallback: check if spans use the CloudWatch body format
+    # Fallback: check if spans use the CloudWatch body format (no scope.name
+    # but have body.input/output structure). This handles raw CloudWatch
+    # log records that haven't been normalized by CloudWatchLogsParser.
     for span in spans:
         if get_body(span) is not None:
             return CloudWatchSessionMapper()
 
-    # Fallback for dict spans with gen_ai.* attributes but unrecognized scope
+    # Fallback for dict spans with gen_ai.* attributes but unrecognized scope.
+    # Only route to GenericGenAISessionMapper if the span has an unrecognized
+    # (or missing) scope — Strands-scoped spans already fell through above.
+    known_scopes = {SCOPE_STRANDS, SCOPE_LANGCHAIN_OTEL, SCOPE_ADK} | SCOPES_OPENINFERENCE_FAMILY
     for span in spans:
-        attrs = span.get("attributes", {})
-        if isinstance(attrs, dict) and "gen_ai.operation.name" in attrs:
-            return GenericGenAISessionMapper()
+        scope_name = get_scope_name(span)
+        if scope_name not in known_scopes:
+            attrs = span.get("attributes", {})
+            if isinstance(attrs, dict) and "gen_ai.operation.name" in attrs:
+                return GenericGenAISessionMapper()
 
-    # Final default for truly unrecognized spans
-    return GenericGenAISessionMapper()
+    # Default to StrandsInMemorySessionMapper
+    return StrandsInMemorySessionMapper()
 
 
 def get_body(span: dict) -> dict | None:

--- a/src/strands_evals/mappers/utils.py
+++ b/src/strands_evals/mappers/utils.py
@@ -96,7 +96,7 @@ def detect_otel_mapper(spans: list[Any]) -> SessionMapper:
     - InMemory format: gen_ai.* attributes
 
     Args:
-        spans: List of span dictionaries (normalized or raw)
+        spans: List of span dictionaries (normalized or raw), or ReadableSpan objects
 
     Returns:
         Appropriate SessionMapper instance
@@ -115,12 +115,20 @@ def detect_otel_mapper(spans: list[Any]) -> SessionMapper:
     # Import here to avoid circular imports
     from .adk_otel_session_mapper import ADKOtelSessionMapper
     from .cloudwatch_session_mapper import CloudWatchSessionMapper
+    from .generic_gen_ai_session_mapper import GenericGenAISessionMapper
     from .langchain_otel_session_mapper import LangChainOtelSessionMapper
     from .openinference_session_mapper import OpenInferenceSessionMapper
     from .strands_in_memory_session_mapper import StrandsInMemorySessionMapper
 
     if not spans:
         return StrandsInMemorySessionMapper()
+
+    # Check if input is raw ReadableSpan objects (not dicts).
+    # If so, route directly to StrandsInMemorySessionMapper which handles them natively.
+    if not isinstance(spans[0], dict):
+        return StrandsInMemorySessionMapper()
+
+    # From here, spans are dicts (from readable_spans_to_dicts or CloudWatch parsing)
 
     # Detect scope and format from first relevant span
     for span in spans:
@@ -141,15 +149,19 @@ def detect_otel_mapper(spans: list[Any]) -> SessionMapper:
             # body-scan below determine CloudWatch vs InMemory.
             break
 
-    # Fallback: check if spans use the CloudWatch body format (no scope.name
-    # but have body.input/output structure). This handles raw CloudWatch
-    # log records that haven't been normalized by CloudWatchLogsParser.
+    # Fallback: check if spans use the CloudWatch body format
     for span in spans:
         if get_body(span) is not None:
             return CloudWatchSessionMapper()
 
-    # Default to StrandsInMemorySessionMapper
-    return StrandsInMemorySessionMapper()
+    # Fallback for dict spans with gen_ai.* attributes but unrecognized scope
+    for span in spans:
+        attrs = span.get("attributes", {})
+        if isinstance(attrs, dict) and "gen_ai.operation.name" in attrs:
+            return GenericGenAISessionMapper()
+
+    # Final default for truly unrecognized spans
+    return GenericGenAISessionMapper()
 
 
 def get_body(span: dict) -> dict | None:

--- a/tests/strands_evals/mappers/fixtures/autogen_live_spans.json
+++ b/tests/strands_evals/mappers/fixtures/autogen_live_spans.json
@@ -1,0 +1,69 @@
+[
+  {
+    "trace_id": "0295b55e1b7a83fe709fba9715e803d4",
+    "span_id": "64eafd28de20ab52",
+    "parent_span_id": null,
+    "name": "create_agent math_assistant",
+    "start_time": 1784744881427958982,
+    "end_time": 1784744881427982483,
+    "attributes": {
+      "gen_ai.operation.name": "create_agent",
+      "gen_ai.system": "autogen",
+      "gen_ai.agent.name": "math_assistant",
+      "gen_ai.agent.description": "An agent that provides assistance with ability to use tools."
+    },
+    "scope": {
+      "name": "autogen-core",
+      "version": ""
+    },
+    "status": {
+      "code": "UNSET"
+    },
+    "span_events": []
+  },
+  {
+    "trace_id": "29940edc28dc48eca72e6d60de6e689f",
+    "span_id": "0ec9116f30a58399",
+    "parent_span_id": "2bc1f36601ddf69e",
+    "name": "execute_tool calculate",
+    "start_time": 1784744883555970242,
+    "end_time": 1784744883556256909,
+    "attributes": {
+      "gen_ai.operation.name": "execute_tool",
+      "gen_ai.system": "autogen",
+      "gen_ai.tool.name": "calculate",
+      "gen_ai.tool.description": "Evaluate a mathematical expression",
+      "gen_ai.tool.call.id": "toolu_bdrk_011nDreLrC9nv8NZs6iGrx6d"
+    },
+    "scope": {
+      "name": "autogen-core",
+      "version": ""
+    },
+    "status": {
+      "code": "UNSET"
+    },
+    "span_events": []
+  },
+  {
+    "trace_id": "29940edc28dc48eca72e6d60de6e689f",
+    "span_id": "2bc1f36601ddf69e",
+    "parent_span_id": null,
+    "name": "invoke_agent math_assistant",
+    "start_time": 1784744881428191698,
+    "end_time": 1784744883556710660,
+    "attributes": {
+      "gen_ai.operation.name": "invoke_agent",
+      "gen_ai.system": "autogen",
+      "gen_ai.agent.name": "math_assistant",
+      "gen_ai.agent.description": "An agent that provides assistance with ability to use tools."
+    },
+    "scope": {
+      "name": "autogen-core",
+      "version": ""
+    },
+    "status": {
+      "code": "UNSET"
+    },
+    "span_events": []
+  }
+]

--- a/tests/strands_evals/mappers/fixtures/otel_genai_convention_spans.json
+++ b/tests/strands_evals/mappers/fixtures/otel_genai_convention_spans.json
@@ -1,0 +1,150 @@
+[
+  {
+    "trace_id": "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4",
+    "span_id": "1000000000000001",
+    "parent_span_id": null,
+    "name": "invoke_agent WeatherAssistant",
+    "start_time": 1700000000000000000,
+    "end_time": 1700000006000000000,
+    "attributes": {
+      "gen_ai.operation.name": "invoke_agent",
+      "gen_ai.agent.name": "WeatherAssistant",
+      "gen_ai.provider.name": "openai",
+      "gen_ai.request.model": "gpt-4o",
+      "gen_ai.conversation.id": "conv_otel_test_001",
+      "gen_ai.input.messages": "[{\"role\": \"user\", \"parts\": [{\"type\": \"text\", \"content\": \"What's the weather in Paris and London?\"}]}]",
+      "gen_ai.output.messages": "[{\"role\": \"assistant\", \"parts\": [{\"type\": \"text\", \"content\": \"The weather in Paris is rainy at 57\\u00b0F. I was unable to retrieve London's weather due to a service timeout.\"}], \"finish_reason\": \"stop\"}]",
+      "gen_ai.tool.definitions": "[{\"type\": \"function\", \"name\": \"get_weather\", \"description\": \"Get current weather for a location\", \"parameters\": {\"type\": \"object\", \"properties\": {\"location\": {\"type\": \"string\", \"description\": \"City name\"}}, \"required\": [\"location\"]}}]",
+      "gen_ai.usage.input_tokens": 150,
+      "gen_ai.usage.output_tokens": 42
+    },
+    "scope": {"name": "my-weather-app", "version": "1.0.0"},
+    "status": {"code": "OK"},
+    "span_events": []
+  },
+  {
+    "trace_id": "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4",
+    "span_id": "1000000000000002",
+    "parent_span_id": "1000000000000001",
+    "name": "chat gpt-4o",
+    "start_time": 1700000001000000000,
+    "end_time": 1700000002000000000,
+    "attributes": {
+      "gen_ai.operation.name": "chat",
+      "gen_ai.provider.name": "openai",
+      "gen_ai.request.model": "gpt-4o",
+      "gen_ai.conversation.id": "conv_otel_test_001",
+      "gen_ai.usage.input_tokens": 80,
+      "gen_ai.usage.output_tokens": 25
+    },
+    "scope": {"name": "my-weather-app", "version": "1.0.0"},
+    "status": {"code": "OK"},
+    "span_events": [
+      {
+        "event_name": "gen_ai.client.inference.operation.details",
+        "timestamp": 1700000001500000000,
+        "attributes": {
+          "gen_ai.input.messages": [
+            {"role": "user", "parts": [{"type": "text", "content": "What's the weather in Paris and London?"}]}
+          ],
+          "gen_ai.output.messages": [
+            {
+              "role": "assistant",
+              "parts": [
+                {"type": "text", "content": "Let me check the weather for both cities."},
+                {"type": "tool_call", "id": "call_paris_001", "name": "get_weather", "arguments": {"location": "Paris"}},
+                {"type": "tool_call", "id": "call_london_001", "name": "get_weather", "arguments": {"location": "London"}}
+              ],
+              "finish_reason": "tool_calls"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "trace_id": "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4",
+    "span_id": "1000000000000003",
+    "parent_span_id": "1000000000000001",
+    "name": "execute_tool get_weather",
+    "start_time": 1700000002000000000,
+    "end_time": 1700000003000000000,
+    "attributes": {
+      "gen_ai.operation.name": "execute_tool",
+      "gen_ai.tool.name": "get_weather",
+      "gen_ai.tool.call.id": "call_paris_001",
+      "gen_ai.tool.type": "function",
+      "gen_ai.tool.call.arguments": "{\"location\": \"Paris\"}",
+      "gen_ai.tool.call.result": "rainy, 57°F",
+      "gen_ai.conversation.id": "conv_otel_test_001"
+    },
+    "scope": {"name": "my-weather-app", "version": "1.0.0"},
+    "status": {"code": "OK"},
+    "span_events": []
+  },
+  {
+    "trace_id": "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4",
+    "span_id": "1000000000000004",
+    "parent_span_id": "1000000000000001",
+    "name": "execute_tool get_weather",
+    "start_time": 1700000003000000000,
+    "end_time": 1700000004000000000,
+    "attributes": {
+      "gen_ai.operation.name": "execute_tool",
+      "gen_ai.tool.name": "get_weather",
+      "gen_ai.tool.call.id": "call_london_001",
+      "gen_ai.tool.type": "function",
+      "gen_ai.tool.call.arguments": "{\"location\": \"London\"}",
+      "gen_ai.conversation.id": "conv_otel_test_001",
+      "error.type": "TimeoutError"
+    },
+    "scope": {"name": "my-weather-app", "version": "1.0.0"},
+    "status": {"code": "ERROR"},
+    "span_events": []
+  },
+  {
+    "trace_id": "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4",
+    "span_id": "1000000000000005",
+    "parent_span_id": "1000000000000001",
+    "name": "chat gpt-4o",
+    "start_time": 1700000004000000000,
+    "end_time": 1700000005000000000,
+    "attributes": {
+      "gen_ai.operation.name": "chat",
+      "gen_ai.provider.name": "openai",
+      "gen_ai.request.model": "gpt-4o",
+      "gen_ai.conversation.id": "conv_otel_test_001",
+      "gen_ai.usage.input_tokens": 120,
+      "gen_ai.usage.output_tokens": 35
+    },
+    "scope": {"name": "my-weather-app", "version": "1.0.0"},
+    "status": {"code": "OK"},
+    "span_events": [
+      {
+        "event_name": "gen_ai.client.inference.operation.details",
+        "timestamp": 1700000004500000000,
+        "attributes": {
+          "gen_ai.input.messages": [
+            {"role": "user", "parts": [{"type": "text", "content": "What's the weather in Paris and London?"}]},
+            {"role": "assistant", "parts": [
+              {"type": "text", "content": "Let me check the weather for both cities."},
+              {"type": "tool_call", "id": "call_paris_001", "name": "get_weather", "arguments": {"location": "Paris"}},
+              {"type": "tool_call", "id": "call_london_001", "name": "get_weather", "arguments": {"location": "London"}}
+            ]},
+            {"role": "tool", "parts": [{"type": "tool_call_response", "id": "call_paris_001", "response": "rainy, 57°F"}]},
+            {"role": "tool", "parts": [{"type": "tool_call_response", "id": "call_london_001", "response": "Error: TimeoutError"}]}
+          ],
+          "gen_ai.output.messages": [
+            {
+              "role": "assistant",
+              "parts": [
+                {"type": "text", "content": "The weather in Paris is rainy at 57°F. I was unable to retrieve London's weather due to a service timeout."}
+              ],
+              "finish_reason": "stop"
+            }
+          ]
+        }
+      }
+    ]
+  }
+]

--- a/tests/strands_evals/mappers/fixtures/pydantic_ai_live_spans.json
+++ b/tests/strands_evals/mappers/fixtures/pydantic_ai_live_spans.json
@@ -1,0 +1,138 @@
+[
+  {
+    "trace_id": "25664b7144ee8f957a50b6ff74dfa337",
+    "span_id": "c3fd6f840203e945",
+    "parent_span_id": "1009ff1545ad6303",
+    "name": "chat us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+    "start_time": 1784744268114742538,
+    "end_time": 1784744270610173022,
+    "attributes": {
+      "gen_ai.operation.name": "chat",
+      "gen_ai.provider.name": "bedrock",
+      "gen_ai.system": "bedrock",
+      "gen_ai.request.model": "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+      "server.address": "bedrock-runtime.us-west-2.amazonaws.com",
+      "model_request_parameters": "{\"function_tools\":[{\"name\":\"get_weather\",\"parameters_json_schema\":{\"additionalProperties\":false,\"properties\":{\"city\":{\"type\":\"string\"}},\"required\":[\"city\"],\"type\":\"object\"},\"description\":\"Get current weather for a city.\",\"outer_typed_dict_key\":null,\"strict\":false,\"sequential\":false,\"kind\":\"function\",\"metadata\":null,\"timeout\":null,\"defer_loading\":false,\"unless_native\":null,\"with_native\":null,\"tool_kind\":null,\"return_schema\":null,\"include_return_schema\":null,\"capability_id\":null}],\"native_tools\":[],\"output_mode\":\"text\",\"output_object\":null,\"output_tools\":[],\"prompted_output_template\":null,\"allow_text_output\":true,\"allow_image_output\":false,\"instruction_parts\":null,\"thinking\":null}",
+      "gen_ai.agent.name": "agent",
+      "gen_ai.agent.call.id": "019f8b0c-5147-74b5-b1e4-f9b17c5d79ac",
+      "gen_ai.conversation.id": "019f8b0c-5147-74b5-b1e4-f9b086da98e0",
+      "gen_ai.tool.definitions": "[{\"type\":\"function\",\"name\":\"get_weather\",\"description\":\"Get current weather for a city.\",\"parameters\":{\"additionalProperties\":false,\"properties\":{\"city\":{\"type\":\"string\"}},\"required\":[\"city\"],\"type\":\"object\"}}]",
+      "gen_ai.input.messages": "[{\"role\":\"system\",\"parts\":[{\"type\":\"text\",\"content\":\"You are a helpful assistant. Use the provided tools when needed.\"}]},{\"role\":\"user\",\"parts\":[{\"type\":\"text\",\"content\":\"What's the weather like in Seattle right now?\"}]}]",
+      "gen_ai.output.messages": "[{\"role\":\"assistant\",\"parts\":[{\"type\":\"tool_call\",\"id\":\"tooluse_ThYFd3WOkO59ZUHC77SIdX\",\"name\":\"get_weather\",\"arguments\":{\"city\":\"Seattle\"}}],\"finish_reason\":\"tool_call\"}]",
+      "logfire.json_schema": "{\"type\":\"object\",\"properties\":{\"gen_ai.input.messages\":{\"type\":\"array\"},\"gen_ai.output.messages\":{\"type\":\"array\"},\"model_request_parameters\":{\"type\":\"object\"}}}",
+      "gen_ai.usage.input_tokens": 588,
+      "gen_ai.usage.output_tokens": 53,
+      "gen_ai.response.model": "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+      "operation.cost": 0.0028149,
+      "gen_ai.response.id": "bffa7bef-c9f7-4812-b5da-c789fc6f22a8",
+      "gen_ai.response.finish_reasons": [
+        "tool_call"
+      ]
+    },
+    "scope": {
+      "name": "pydantic-ai",
+      "version": "2.9.1"
+    },
+    "status": {
+      "code": "UNSET"
+    },
+    "span_events": []
+  },
+  {
+    "trace_id": "25664b7144ee8f957a50b6ff74dfa337",
+    "span_id": "ea4518243ec1a032",
+    "parent_span_id": "1009ff1545ad6303",
+    "name": "execute_tool get_weather",
+    "start_time": 1784744270611270959,
+    "end_time": 1784744270611689839,
+    "attributes": {
+      "gen_ai.operation.name": "execute_tool",
+      "gen_ai.tool.name": "get_weather",
+      "gen_ai.tool.call.id": "tooluse_ThYFd3WOkO59ZUHC77SIdX",
+      "gen_ai.tool.call.arguments": "{\"city\":\"Seattle\"}",
+      "gen_ai.agent.name": "agent",
+      "gen_ai.agent.call.id": "019f8b0c-5147-74b5-b1e4-f9b17c5d79ac",
+      "gen_ai.conversation.id": "019f8b0c-5147-74b5-b1e4-f9b086da98e0",
+      "logfire.msg": "running tool: get_weather",
+      "logfire.json_schema": "{\"type\":\"object\",\"properties\":{\"gen_ai.tool.call.arguments\":{\"type\":\"object\"},\"gen_ai.tool.call.result\":{\"type\":\"object\"},\"gen_ai.tool.name\":{},\"gen_ai.tool.call.id\":{}}}",
+      "gen_ai.tool.call.result": "62\u00b0F, cloudy with light rain"
+    },
+    "scope": {
+      "name": "pydantic-ai",
+      "version": "2.9.1"
+    },
+    "status": {
+      "code": "UNSET"
+    },
+    "span_events": []
+  },
+  {
+    "trace_id": "25664b7144ee8f957a50b6ff74dfa337",
+    "span_id": "17e1fc9e6431229c",
+    "parent_span_id": "1009ff1545ad6303",
+    "name": "chat us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+    "start_time": 1784744270612936360,
+    "end_time": 1784744272630736291,
+    "attributes": {
+      "gen_ai.operation.name": "chat",
+      "gen_ai.provider.name": "bedrock",
+      "gen_ai.system": "bedrock",
+      "gen_ai.request.model": "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+      "server.address": "bedrock-runtime.us-west-2.amazonaws.com",
+      "model_request_parameters": "{\"function_tools\":[{\"name\":\"get_weather\",\"parameters_json_schema\":{\"additionalProperties\":false,\"properties\":{\"city\":{\"type\":\"string\"}},\"required\":[\"city\"],\"type\":\"object\"},\"description\":\"Get current weather for a city.\",\"outer_typed_dict_key\":null,\"strict\":false,\"sequential\":false,\"kind\":\"function\",\"metadata\":null,\"timeout\":null,\"defer_loading\":false,\"unless_native\":null,\"with_native\":null,\"tool_kind\":null,\"return_schema\":null,\"include_return_schema\":null,\"capability_id\":null}],\"native_tools\":[],\"output_mode\":\"text\",\"output_object\":null,\"output_tools\":[],\"prompted_output_template\":null,\"allow_text_output\":true,\"allow_image_output\":false,\"instruction_parts\":null,\"thinking\":null}",
+      "gen_ai.agent.name": "agent",
+      "gen_ai.agent.call.id": "019f8b0c-5147-74b5-b1e4-f9b17c5d79ac",
+      "gen_ai.conversation.id": "019f8b0c-5147-74b5-b1e4-f9b086da98e0",
+      "gen_ai.tool.definitions": "[{\"type\":\"function\",\"name\":\"get_weather\",\"description\":\"Get current weather for a city.\",\"parameters\":{\"additionalProperties\":false,\"properties\":{\"city\":{\"type\":\"string\"}},\"required\":[\"city\"],\"type\":\"object\"}}]",
+      "gen_ai.input.messages": "[{\"role\":\"system\",\"parts\":[{\"type\":\"text\",\"content\":\"You are a helpful assistant. Use the provided tools when needed.\"}]},{\"role\":\"user\",\"parts\":[{\"type\":\"text\",\"content\":\"What's the weather like in Seattle right now?\"}]},{\"role\":\"assistant\",\"parts\":[{\"type\":\"tool_call\",\"id\":\"tooluse_ThYFd3WOkO59ZUHC77SIdX\",\"name\":\"get_weather\",\"arguments\":{\"city\":\"Seattle\"}}],\"finish_reason\":\"tool_call\"},{\"role\":\"user\",\"parts\":[{\"type\":\"tool_call_response\",\"id\":\"tooluse_ThYFd3WOkO59ZUHC77SIdX\",\"name\":\"get_weather\",\"result\":\"62\u00b0F, cloudy with light rain\"}]}]",
+      "gen_ai.output.messages": "[{\"role\":\"assistant\",\"parts\":[{\"type\":\"text\",\"content\":\"The current weather in Seattle is 62\u00b0F and cloudy with light rain. Pretty typical Seattle weather!\"}],\"finish_reason\":\"stop\"}]",
+      "logfire.json_schema": "{\"type\":\"object\",\"properties\":{\"gen_ai.input.messages\":{\"type\":\"array\"},\"gen_ai.output.messages\":{\"type\":\"array\"},\"model_request_parameters\":{\"type\":\"object\"}}}",
+      "gen_ai.usage.input_tokens": 663,
+      "gen_ai.usage.output_tokens": 25,
+      "gen_ai.response.model": "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+      "operation.cost": 0.0026004,
+      "gen_ai.response.id": "e18a158b-d4d9-4c86-912c-169abedd12cc",
+      "gen_ai.response.finish_reasons": [
+        "stop"
+      ]
+    },
+    "scope": {
+      "name": "pydantic-ai",
+      "version": "2.9.1"
+    },
+    "status": {
+      "code": "UNSET"
+    },
+    "span_events": []
+  },
+  {
+    "trace_id": "25664b7144ee8f957a50b6ff74dfa337",
+    "span_id": "1009ff1545ad6303",
+    "parent_span_id": null,
+    "name": "invoke_agent agent",
+    "start_time": 1784744268112921993,
+    "end_time": 1784744272631867669,
+    "attributes": {
+      "model_name": "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+      "agent_name": "agent",
+      "gen_ai.agent.name": "agent",
+      "gen_ai.agent.call.id": "019f8b0c-5147-74b5-b1e4-f9b17c5d79ac",
+      "gen_ai.conversation.id": "019f8b0c-5147-74b5-b1e4-f9b086da98e0",
+      "gen_ai.operation.name": "invoke_agent",
+      "logfire.msg": "agent run",
+      "final_result": "The current weather in Seattle is 62\u00b0F and cloudy with light rain. Pretty typical Seattle weather!",
+      "gen_ai.aggregated_usage.input_tokens": 1251,
+      "gen_ai.aggregated_usage.output_tokens": 78,
+      "pydantic_ai.all_messages": "[{\"role\":\"system\",\"parts\":[{\"type\":\"text\",\"content\":\"You are a helpful assistant. Use the provided tools when needed.\"}]},{\"role\":\"user\",\"parts\":[{\"type\":\"text\",\"content\":\"What's the weather like in Seattle right now?\"}]},{\"role\":\"assistant\",\"parts\":[{\"type\":\"tool_call\",\"id\":\"tooluse_ThYFd3WOkO59ZUHC77SIdX\",\"name\":\"get_weather\",\"arguments\":{\"city\":\"Seattle\"}}],\"finish_reason\":\"tool_call\"},{\"role\":\"user\",\"parts\":[{\"type\":\"tool_call_response\",\"id\":\"tooluse_ThYFd3WOkO59ZUHC77SIdX\",\"name\":\"get_weather\",\"result\":\"62\u00b0F, cloudy with light rain\"}]},{\"role\":\"assistant\",\"parts\":[{\"type\":\"text\",\"content\":\"The current weather in Seattle is 62\u00b0F and cloudy with light rain. Pretty typical Seattle weather!\"}],\"finish_reason\":\"stop\"}]",
+      "logfire.json_schema": "{\"type\":\"object\",\"properties\":{\"pydantic_ai.all_messages\":{\"type\":\"array\"},\"final_result\":{\"type\":\"object\"}}}"
+    },
+    "scope": {
+      "name": "pydantic-ai",
+      "version": "2.9.1"
+    },
+    "status": {
+      "code": "UNSET"
+    },
+    "span_events": []
+  }
+]

--- a/tests/strands_evals/mappers/test_generic_gen_ai_session_mapper.py
+++ b/tests/strands_evals/mappers/test_generic_gen_ai_session_mapper.py
@@ -1,0 +1,212 @@
+"""Tests for GenericGenAISessionMapper - dict-format spans with gen_ai.* attributes."""
+
+from strands_evals.mappers import GenericGenAISessionMapper
+from strands_evals.types.trace import AgentInvocationSpan, InferenceSpan, ToolExecutionSpan
+
+
+def make_span(
+    trace_id="trace-1",
+    span_id="span-1",
+    parent_span_id=None,
+    name="test-span",
+    operation_name="",
+    attributes=None,
+    span_events=None,
+    scope_name="custom-tracer",
+):
+    """Build a dict span with gen_ai.* attributes for GenericGenAISessionMapper."""
+    attrs = attributes or {}
+    if operation_name:
+        attrs.setdefault("gen_ai.operation.name", operation_name)
+    return {
+        "trace_id": trace_id,
+        "span_id": span_id,
+        "parent_span_id": parent_span_id,
+        "name": name,
+        "start_time": 1700000000000000000,
+        "end_time": 1700000001000000000,
+        "attributes": attrs,
+        "scope": {"name": scope_name, "version": "1.0"},
+        "status": {"code": "OK"},
+        "span_events": span_events or [],
+    }
+
+
+class TestToolExecutionSpan:
+    def setup_method(self):
+        self.mapper = GenericGenAISessionMapper()
+
+    def test_tool_span_from_attributes(self):
+        """Tool data extracted from gen_ai.tool.* attributes."""
+        span = make_span(
+            operation_name="execute_tool",
+            attributes={
+                "gen_ai.tool.name": "web_search",
+                "gen_ai.tool.call.id": "call-123",
+                "gen_ai.tool.input": '{"query": "weather london"}',
+                "gen_ai.tool.output": "15C and cloudy",
+                "gen_ai.tool.status": "success",
+            },
+        )
+        session = self.mapper.map_to_session([span], "sess-1")
+
+        tool = session.traces[0].spans[0]
+        assert isinstance(tool, ToolExecutionSpan)
+        assert tool.tool_call.name == "web_search"
+        assert tool.tool_call.arguments == {"query": "weather london"}
+        assert tool.tool_call.tool_call_id == "call-123"
+        assert tool.tool_result.content == "15C and cloudy"
+        assert tool.tool_result.error is None
+
+    def test_tool_span_from_events(self):
+        """Tool data extracted from span_events (Strands telemetry format)."""
+        span = make_span(
+            operation_name="execute_tool",
+            attributes={
+                "gen_ai.tool.name": "calc",
+                "gen_ai.tool.call.id": "t1",
+                "gen_ai.tool.status": "success",
+            },
+            span_events=[
+                {"event_name": "gen_ai.tool.message", "timestamp": 0, "attributes": {"content": '{"expr": "2+2"}'}},
+                {"event_name": "gen_ai.choice", "timestamp": 0, "attributes": {"message": '[{"text": "4"}]'}},
+            ],
+        )
+        session = self.mapper.map_to_session([span], "sess-1")
+
+        tool = session.traces[0].spans[0]
+        assert isinstance(tool, ToolExecutionSpan)
+        assert tool.tool_call.name == "calc"
+        assert tool.tool_call.arguments == {"expr": "2+2"}
+        assert tool.tool_result.content == "4"
+
+    def test_tool_span_missing_name_skipped(self):
+        """Tool span without gen_ai.tool.name is skipped."""
+        span = make_span(
+            operation_name="execute_tool",
+            attributes={
+                "gen_ai.tool.input": '{"x": 1}',
+                "gen_ai.tool.output": "result",
+            },
+        )
+        session = self.mapper.map_to_session([span], "sess-1")
+        assert session.traces == []
+
+
+class TestAgentInvocationSpan:
+    def setup_method(self):
+        self.mapper = GenericGenAISessionMapper()
+
+    def test_agent_span_with_events(self):
+        """Agent span extracts prompt/response from events and tools from attributes."""
+        span = make_span(
+            operation_name="invoke_agent",
+            attributes={
+                "gen_ai.agent.tools": '["web_search", "calculator"]',
+                "session.id": "sess-1",
+            },
+            span_events=[
+                {
+                    "event_name": "gen_ai.user.message",
+                    "timestamp": 0,
+                    "attributes": {"content": '[{"text": "What is 2+2?"}]'},
+                },
+                {
+                    "event_name": "gen_ai.choice",
+                    "timestamp": 0,
+                    "attributes": {"message": "The answer is 4."},
+                },
+            ],
+        )
+        session = self.mapper.map_to_session([span], "sess-1")
+
+        agent = session.traces[0].spans[0]
+        assert isinstance(agent, AgentInvocationSpan)
+        assert agent.user_prompt == "What is 2+2?"
+        assert agent.agent_response == "The answer is 4."
+        assert len(agent.available_tools) == 2
+        assert agent.available_tools[0].name == "web_search"
+        assert agent.available_tools[1].name == "calculator"
+
+    def test_agent_span_no_events(self):
+        """Agent span with no events still produces a span (empty prompt/response)."""
+        span = make_span(operation_name="invoke_agent")
+        session = self.mapper.map_to_session([span], "sess-1")
+
+        agent = session.traces[0].spans[0]
+        assert isinstance(agent, AgentInvocationSpan)
+        assert agent.user_prompt == ""
+        assert agent.agent_response == ""
+
+
+class TestInferenceSpan:
+    def setup_method(self):
+        self.mapper = GenericGenAISessionMapper()
+
+    def test_inference_span_with_events(self):
+        """Inference span extracts messages from events."""
+        span = make_span(
+            operation_name="chat",
+            span_events=[
+                {"event_name": "gen_ai.user.message", "timestamp": 0, "attributes": {"content": '[{"text": "Hello"}]'}},
+                {"event_name": "gen_ai.choice", "timestamp": 0, "attributes": {"message": '[{"text": "Hi there!"}]'}},
+            ],
+        )
+        session = self.mapper.map_to_session([span], "sess-1")
+
+        inference = session.traces[0].spans[0]
+        assert isinstance(inference, InferenceSpan)
+        assert len(inference.messages) == 2
+
+    def test_inference_span_no_events_filtered(self):
+        """Inference span with no events (no messages) is filtered out."""
+        span = make_span(operation_name="chat")
+        session = self.mapper.map_to_session([span], "sess-1")
+        assert session.traces == []
+
+
+class TestSessionBuilding:
+    def setup_method(self):
+        self.mapper = GenericGenAISessionMapper()
+
+    def test_empty_input(self):
+        """Empty list produces empty session."""
+        session = self.mapper.map_to_session([], "sess-1")
+        assert len(session.traces) == 0
+
+    def test_multi_span_trace(self):
+        """Multiple spans in same trace grouped correctly."""
+        spans = [
+            make_span(trace_id="t1", span_id="s1", operation_name="invoke_agent"),
+            make_span(
+                trace_id="t1",
+                span_id="s2",
+                parent_span_id="s1",
+                operation_name="execute_tool",
+                attributes={"gen_ai.tool.name": "calc", "gen_ai.tool.input": "{}", "gen_ai.tool.output": "4"},
+            ),
+        ]
+        session = self.mapper.map_to_session(spans, "sess-1")
+
+        assert len(session.traces) == 1
+        assert len(session.traces[0].spans) == 2
+
+    def test_session_id_filtering(self):
+        """Spans filtered by session.id when present."""
+        spans = [
+            make_span(trace_id="t1", span_id="s1", operation_name="invoke_agent", attributes={"session.id": "sess-A"}),
+            make_span(trace_id="t2", span_id="s2", operation_name="invoke_agent", attributes={"session.id": "sess-B"}),
+        ]
+        session = self.mapper.map_to_session(spans, "sess-A")
+
+        assert len(session.traces) == 1
+        assert session.traces[0].trace_id == "t1"
+
+    def test_no_session_id_includes_all(self):
+        """When no spans have session.id, all are included."""
+        spans = [
+            make_span(trace_id="t1", span_id="s1", operation_name="invoke_agent"),
+            make_span(trace_id="t2", span_id="s2", operation_name="invoke_agent"),
+        ]
+        session = self.mapper.map_to_session(spans, "any-id")
+        assert len(session.traces) == 2

--- a/tests/strands_evals/mappers/test_generic_gen_ai_session_mapper.py
+++ b/tests/strands_evals/mappers/test_generic_gen_ai_session_mapper.py
@@ -97,7 +97,6 @@ class TestToolExecutionSpan:
         session = self.mapper.map_to_session([span], "sess-1")
         assert session.traces == []
 
-
     def test_tool_span_from_operation_details_event(self):
         """Tool data extracted from gen_ai.client.inference.operation.details unified event."""
         span = make_span(
@@ -112,7 +111,7 @@ class TestToolExecutionSpan:
                     "timestamp": 0,
                     "attributes": {
                         "gen_ai.input.messages": json.dumps(
-                            [{"role": "user", "parts": [{"type": "text", "content": "{\"location\": \"Seattle\"}"}]}]
+                            [{"role": "user", "parts": [{"type": "text", "content": '{"location": "Seattle"}'}]}]
                         ),
                         "gen_ai.output.messages": json.dumps(
                             [{"role": "assistant", "parts": [{"type": "text", "content": "62F and cloudy"}]}]
@@ -144,7 +143,7 @@ class TestToolExecutionSpan:
                     "timestamp": 0,
                     "attributes": {
                         "gen_ai.input.messages": json.dumps(
-                            [{"role": "user", "parts": [{"type": "text", "content": "{\"query\": \"cats\"}"}]}]
+                            [{"role": "user", "parts": [{"type": "text", "content": '{"query": "cats"}'}]}]
                         ),
                         "gen_ai.output.messages": json.dumps(
                             [{"role": "tool", "id": "call-unified-2", "response": "Found 10 cats"}]
@@ -206,7 +205,6 @@ class TestAgentInvocationSpan:
         assert agent.user_prompt == ""
         assert agent.agent_response == ""
 
-
     def test_agent_span_from_operation_details_event(self):
         """Agent prompt/response extracted from gen_ai.client.inference.operation.details."""
         span = make_span(
@@ -223,7 +221,7 @@ class TestAgentInvocationSpan:
                             [{"role": "user", "parts": [{"type": "text", "content": "What is the weather in Paris?"}]}]
                         ),
                         "gen_ai.output.messages": json.dumps(
-                            [{"role": "assistant", "parts": [{"type": "text", "content": "It is 57F and rainy in Paris."}]}]
+                            [{"role": "assistant", "parts": [{"type": "text", "content": "57F and rainy"}]}]
                         ),
                     },
                 }
@@ -234,7 +232,7 @@ class TestAgentInvocationSpan:
         agent = session.traces[0].spans[0]
         assert isinstance(agent, AgentInvocationSpan)
         assert agent.user_prompt == "What is the weather in Paris?"
-        assert agent.agent_response == "It is 57F and rainy in Paris."
+        assert agent.agent_response == "57F and rainy"
 
     def test_agent_span_operation_details_flat_content(self):
         """Agent response from operation.details with flat content string (no parts)."""
@@ -248,9 +246,7 @@ class TestAgentInvocationSpan:
                         "gen_ai.input.messages": json.dumps(
                             [{"role": "user", "parts": [{"type": "text", "content": "Hello"}]}]
                         ),
-                        "gen_ai.output.messages": json.dumps(
-                            [{"role": "assistant", "content": "Hi there!"}]
-                        ),
+                        "gen_ai.output.messages": json.dumps([{"role": "assistant", "content": "Hi there!"}]),
                     },
                 }
             ],
@@ -339,7 +335,7 @@ class TestSessionBuilding:
         """String-encoded ns epoch (OTLP/JSON int64 encoding) parses to correct datetime."""
         from datetime import datetime, timezone
 
-        result = self.mapper._parse_timestamp("1700000000000000000")
+        result = self.mapper.parse_timestamp("1700000000000000000")
         expected = datetime.fromtimestamp(1700000000, tz=timezone.utc)
         assert result == expected
 
@@ -643,6 +639,41 @@ class TestToolErrorHandling:
                 "gen_ai.tool.output": "result",
             },
         )
+        session = self.mapper.map_to_session([span], "sess-1")
+        tool = session.traces[0].spans[0]
+        assert isinstance(tool, ToolExecutionSpan)
+        assert tool.tool_result.error is None
+
+    def test_status_none_does_not_crash(self):
+        """Span with status: None must not raise AttributeError."""
+        span = make_span(
+            operation_name="execute_tool",
+            attributes={
+                "gen_ai.tool.name": "safe_tool",
+                "gen_ai.tool.call.id": "call-null",
+                "gen_ai.tool.output": "ok",
+            },
+        )
+        span["status"] = None
+
+        session = self.mapper.map_to_session([span], "sess-1")
+        tool = session.traces[0].spans[0]
+        assert isinstance(tool, ToolExecutionSpan)
+        assert tool.tool_result.error is None
+        assert tool.tool_result.content == "ok"
+
+    def test_status_non_dict_does_not_crash(self):
+        """Span with non-dict status (e.g. string) must not crash."""
+        span = make_span(
+            operation_name="execute_tool",
+            attributes={
+                "gen_ai.tool.name": "robust_tool",
+                "gen_ai.tool.call.id": "call-str",
+                "gen_ai.tool.output": "done",
+            },
+        )
+        span["status"] = "OK"
+
         session = self.mapper.map_to_session([span], "sess-1")
         tool = session.traces[0].spans[0]
         assert isinstance(tool, ToolExecutionSpan)

--- a/tests/strands_evals/mappers/test_generic_gen_ai_session_mapper.py
+++ b/tests/strands_evals/mappers/test_generic_gen_ai_session_mapper.py
@@ -1,6 +1,11 @@
 """Tests for GenericGenAISessionMapper - dict-format spans with gen_ai.* attributes."""
 
-from strands_evals.mappers import GenericGenAISessionMapper
+import json
+from pathlib import Path
+
+import pytest
+
+from strands_evals.mappers import GenericGenAISessionMapper, detect_otel_mapper
 from strands_evals.types.trace import AgentInvocationSpan, InferenceSpan, ToolExecutionSpan
 
 
@@ -210,3 +215,198 @@ class TestSessionBuilding:
         ]
         session = self.mapper.map_to_session(spans, "any-id")
         assert len(session.traces) == 2
+
+
+# =============================================================================
+# Fixture-based integration tests — real captured traces
+# =============================================================================
+
+_FIXTURES_DIR = Path(__file__).resolve().parent / "fixtures"
+_PYDANTIC_AI_SPANS_FILE = _FIXTURES_DIR / "pydantic_ai_live_spans.json"
+_AUTOGEN_SPANS_FILE = _FIXTURES_DIR / "autogen_live_spans.json"
+
+
+@pytest.fixture(scope="module")
+def pydantic_ai_spans():
+    """Load real PydanticAI spans captured from Agent.instrument_all()."""
+    with open(_PYDANTIC_AI_SPANS_FILE) as f:
+        return json.load(f)
+
+
+@pytest.fixture(scope="module")
+def pydantic_ai_session(pydantic_ai_spans):
+    """Map PydanticAI spans to a Session using GenericGenAISessionMapper."""
+    mapper = GenericGenAISessionMapper()
+    # Auto-detect session_id from gen_ai.conversation.id
+    session_id = "test"
+    for s in pydantic_ai_spans:
+        sid = s.get("attributes", {}).get("gen_ai.conversation.id")
+        if sid:
+            session_id = str(sid)
+            break
+    return mapper.map_to_session(pydantic_ai_spans, session_id=session_id)
+
+
+@pytest.fixture(scope="module")
+def autogen_spans():
+    """Load real AutoGen spans captured from autogen_core native telemetry."""
+    with open(_AUTOGEN_SPANS_FILE) as f:
+        return json.load(f)
+
+
+@pytest.fixture(scope="module")
+def autogen_session(autogen_spans):
+    """Map AutoGen spans to a Session using GenericGenAISessionMapper."""
+    mapper = GenericGenAISessionMapper()
+    return mapper.map_to_session(autogen_spans, session_id="test")
+
+
+class TestPydanticAIFixtureRouting:
+    """Verify detect_otel_mapper routes PydanticAI spans to GenericGenAISessionMapper."""
+
+    def test_routes_to_generic_mapper(self, pydantic_ai_spans):
+        """PydanticAI scope 'pydantic-ai' routes to GenericGenAISessionMapper."""
+        mapper = detect_otel_mapper(pydantic_ai_spans)
+        assert isinstance(mapper, GenericGenAISessionMapper)
+
+    def test_scope_is_pydantic_ai(self, pydantic_ai_spans):
+        """All spans have scope.name = 'pydantic-ai'."""
+        scopes = {s["scope"]["name"] for s in pydantic_ai_spans}
+        assert scopes == {"pydantic-ai"}
+
+    def test_has_gen_ai_operation_names(self, pydantic_ai_spans):
+        """Spans use gen_ai.operation.name with expected values."""
+        operations = {s["attributes"].get("gen_ai.operation.name") for s in pydantic_ai_spans}
+        assert "chat" in operations
+        assert "execute_tool" in operations
+        assert "invoke_agent" in operations
+
+
+class TestPydanticAIFixtureIntegration:
+    """Integration tests using real PydanticAI trace (Agent + get_weather tool)."""
+
+    def test_session_has_traces(self, pydantic_ai_session):
+        """PydanticAI fixture produces at least one trace."""
+        assert len(pydantic_ai_session.traces) >= 1
+
+    def test_produces_expected_span_types(self, pydantic_ai_session):
+        """Real trace produces InferenceSpan, ToolExecutionSpan, and AgentInvocationSpan."""
+        all_spans = [s for t in pydantic_ai_session.traces for s in t.spans]
+        span_types = {type(s) for s in all_spans}
+        assert InferenceSpan in span_types
+        assert ToolExecutionSpan in span_types
+        assert AgentInvocationSpan in span_types
+
+    def test_tool_span_extracts_name_and_args(self, pydantic_ai_session):
+        """get_weather tool: extracts name, arguments, and result from attributes."""
+        all_spans = [s for t in pydantic_ai_session.traces for s in t.spans]
+        tool_spans = [s for s in all_spans if isinstance(s, ToolExecutionSpan)]
+        assert len(tool_spans) == 1
+
+        tool = tool_spans[0]
+        assert tool.tool_call.name == "get_weather"
+        assert tool.tool_call.arguments == {"city": "Seattle"}
+        assert "62°F" in tool.tool_result.content
+
+    def test_inference_span_has_messages(self, pydantic_ai_session):
+        """Chat spans produce InferenceSpans with user and assistant messages."""
+        all_spans = [s for t in pydantic_ai_session.traces for s in t.spans]
+        inference_spans = [s for s in all_spans if isinstance(s, InferenceSpan)]
+        assert len(inference_spans) >= 1
+
+        # At least one inference span should have an assistant text response
+        has_assistant_text = False
+        for span in inference_spans:
+            for msg in span.messages:
+                if msg.role.value == "assistant":
+                    for c in msg.content:
+                        if hasattr(c, "text") and c.text and "Seattle" in c.text:
+                            has_assistant_text = True
+        assert has_assistant_text
+
+    def test_agent_span_extracts_user_prompt(self, pydantic_ai_session):
+        """Agent invocation span extracts user prompt from conversation messages."""
+        all_spans = [s for t in pydantic_ai_session.traces for s in t.spans]
+        agent_spans = [s for s in all_spans if isinstance(s, AgentInvocationSpan)]
+        assert len(agent_spans) == 1
+
+        agent = agent_spans[0]
+        assert "weather" in agent.user_prompt.lower()
+        assert "Seattle" in agent.user_prompt
+
+    def test_agent_span_extracts_final_result(self, pydantic_ai_session):
+        """Agent invocation span extracts final_result as agent_response."""
+        all_spans = [s for t in pydantic_ai_session.traces for s in t.spans]
+        agent_spans = [s for s in all_spans if isinstance(s, AgentInvocationSpan)]
+        agent = agent_spans[0]
+        assert "62°F" in agent.agent_response
+
+    def test_session_id_filtering_with_conversation_id(self, pydantic_ai_spans):
+        """Filtering by gen_ai.conversation.id correctly includes/excludes spans."""
+        mapper = GenericGenAISessionMapper()
+
+        # Get the real conversation_id
+        real_id = pydantic_ai_spans[0]["attributes"]["gen_ai.conversation.id"]
+
+        # Correct session_id → spans included
+        session = mapper.map_to_session(pydantic_ai_spans, session_id=real_id)
+        assert len(session.traces) >= 1
+
+        # Wrong session_id → spans excluded
+        session_wrong = mapper.map_to_session(pydantic_ai_spans, session_id="nonexistent-id")
+        assert len(session_wrong.traces) == 0
+
+
+class TestAutoGenFixtureRouting:
+    """Verify detect_otel_mapper routes AutoGen spans to GenericGenAISessionMapper."""
+
+    def test_routes_to_generic_mapper(self, autogen_spans):
+        """AutoGen scope 'autogen-core' routes to GenericGenAISessionMapper."""
+        mapper = detect_otel_mapper(autogen_spans)
+        assert isinstance(mapper, GenericGenAISessionMapper)
+
+    def test_scope_is_autogen_core(self, autogen_spans):
+        """All spans have scope.name = 'autogen-core'."""
+        scopes = {s["scope"]["name"] for s in autogen_spans}
+        assert scopes == {"autogen-core"}
+
+    def test_has_gen_ai_operation_names(self, autogen_spans):
+        """Spans use gen_ai.operation.name with expected values."""
+        operations = {s["attributes"].get("gen_ai.operation.name") for s in autogen_spans}
+        assert "execute_tool" in operations
+        assert "invoke_agent" in operations
+        assert "create_agent" in operations
+
+
+class TestAutoGenFixtureIntegration:
+    """Integration tests using real AutoGen trace (AssistantAgent + calculate tool)."""
+
+    def test_session_has_traces(self, autogen_session):
+        """AutoGen fixture produces at least one trace."""
+        assert len(autogen_session.traces) >= 1
+
+    def test_tool_span_extracted(self, autogen_session):
+        """execute_tool span for 'calculate' is correctly parsed."""
+        all_spans = [s for t in autogen_session.traces for s in t.spans]
+        tool_spans = [s for s in all_spans if isinstance(s, ToolExecutionSpan)]
+        assert len(tool_spans) >= 1
+
+        calc = next(s for s in tool_spans if s.tool_call.name == "calculate")
+        assert calc.tool_call.tool_call_id == "toolu_bdrk_011nDreLrC9nv8NZs6iGrx6d"
+
+    def test_agent_span_extracted(self, autogen_session):
+        """invoke_agent span for 'math_assistant' is correctly parsed."""
+        all_spans = [s for t in autogen_session.traces for s in t.spans]
+        agent_spans = [s for s in all_spans if isinstance(s, AgentInvocationSpan)]
+        assert len(agent_spans) >= 1
+
+    def test_create_agent_span_skipped(self, autogen_spans):
+        """create_agent operation is not a recognized span type (skipped gracefully)."""
+        mapper = GenericGenAISessionMapper()
+        session = mapper.map_to_session(autogen_spans, session_id="test")
+        all_spans = [s for t in session.traces for s in t.spans]
+        # create_agent should not crash; it's simply not mapped to any known type
+        # The 3 raw spans are: create_agent, execute_tool, invoke_agent
+        # Only execute_tool and invoke_agent should produce mapped spans
+        span_types = {type(s).__name__ for s in all_spans}
+        assert "ToolExecutionSpan" in span_types or "AgentInvocationSpan" in span_types

--- a/tests/strands_evals/mappers/test_generic_gen_ai_session_mapper.py
+++ b/tests/strands_evals/mappers/test_generic_gen_ai_session_mapper.py
@@ -409,4 +409,551 @@ class TestAutoGenFixtureIntegration:
         # The 3 raw spans are: create_agent, execute_tool, invoke_agent
         # Only execute_tool and invoke_agent should produce mapped spans
         span_types = {type(s).__name__ for s in all_spans}
-        assert "ToolExecutionSpan" in span_types or "AgentInvocationSpan" in span_types
+        assert span_types == {"ToolExecutionSpan", "AgentInvocationSpan"}
+
+
+# =============================================================================
+# Regression tests for jjbuck review feedback
+# =============================================================================
+
+
+class TestToolErrorHandling:
+    """Regression: error.type + span status ERROR must surface as tool_result.error."""
+
+    def setup_method(self):
+        self.mapper = GenericGenAISessionMapper()
+
+    def test_error_type_attribute_sets_tool_error(self):
+        """Tool span with error.type="TimeoutError" and status ERROR reports error."""
+        span = make_span(
+            operation_name="execute_tool",
+            attributes={
+                "gen_ai.tool.name": "slow_api",
+                "gen_ai.tool.call.id": "call-err-1",
+                "gen_ai.tool.input": '{"timeout": 30}',
+                "error.type": "TimeoutError",
+            },
+        )
+        # Override status to ERROR
+        span["status"] = {"code": "ERROR"}
+
+        session = self.mapper.map_to_session([span], "sess-1")
+        tool = session.traces[0].spans[0]
+        assert isinstance(tool, ToolExecutionSpan)
+        assert tool.tool_result.error == "TimeoutError"
+
+    def test_span_status_error_without_error_type(self):
+        """Tool span with status ERROR but no error.type still reports an error."""
+        span = make_span(
+            operation_name="execute_tool",
+            attributes={
+                "gen_ai.tool.name": "flaky_tool",
+                "gen_ai.tool.call.id": "call-err-2",
+            },
+        )
+        span["status"] = {"code": "ERROR"}
+
+        session = self.mapper.map_to_session([span], "sess-1")
+        tool = session.traces[0].spans[0]
+        assert isinstance(tool, ToolExecutionSpan)
+        assert tool.tool_result.error == "ERROR"
+
+    def test_legacy_tool_status_failure_still_works(self):
+        """Legacy gen_ai.tool.status != 'success' still reports as error."""
+        span = make_span(
+            operation_name="execute_tool",
+            attributes={
+                "gen_ai.tool.name": "legacy_tool",
+                "gen_ai.tool.call.id": "call-err-3",
+                "gen_ai.tool.status": "failed",
+            },
+        )
+        session = self.mapper.map_to_session([span], "sess-1")
+        tool = session.traces[0].spans[0]
+        assert isinstance(tool, ToolExecutionSpan)
+        assert tool.tool_result.error == "failed"
+
+    def test_error_type_takes_precedence_over_tool_status(self):
+        """error.type takes precedence over gen_ai.tool.status."""
+        span = make_span(
+            operation_name="execute_tool",
+            attributes={
+                "gen_ai.tool.name": "dual_error",
+                "gen_ai.tool.call.id": "call-err-4",
+                "gen_ai.tool.status": "failed",
+                "error.type": "ConnectionError",
+            },
+        )
+        span["status"] = {"code": "ERROR"}
+
+        session = self.mapper.map_to_session([span], "sess-1")
+        tool = session.traces[0].spans[0]
+        assert isinstance(tool, ToolExecutionSpan)
+        assert tool.tool_result.error == "ConnectionError"
+
+    def test_successful_tool_no_error(self):
+        """Successful tool span (no error.type, status OK) has no error."""
+        span = make_span(
+            operation_name="execute_tool",
+            attributes={
+                "gen_ai.tool.name": "good_tool",
+                "gen_ai.tool.call.id": "call-ok",
+                "gen_ai.tool.status": "success",
+                "gen_ai.tool.output": "result",
+            },
+        )
+        session = self.mapper.map_to_session([span], "sess-1")
+        tool = session.traces[0].spans[0]
+        assert isinstance(tool, ToolExecutionSpan)
+        assert tool.tool_result.error is None
+
+
+class TestOperationDetailsEvent:
+    """Regression: gen_ai.client.inference.operation.details event must produce messages."""
+
+    def setup_method(self):
+        self.mapper = GenericGenAISessionMapper()
+
+    def test_operation_details_event_structured_messages(self):
+        """Chat span with operation.details event produces user and assistant messages."""
+        span = make_span(
+            operation_name="chat",
+            span_events=[
+                {
+                    "event_name": "gen_ai.client.inference.operation.details",
+                    "timestamp": 0,
+                    "attributes": {
+                        "gen_ai.input.messages": json.dumps(
+                            [{"role": "user", "parts": [{"type": "text", "content": "Hello"}]}]
+                        ),
+                        "gen_ai.output.messages": json.dumps(
+                            [{"role": "assistant", "parts": [{"type": "text", "content": "Hi there!"}]}]
+                        ),
+                    },
+                }
+            ],
+        )
+        session = self.mapper.map_to_session([span], "sess-1")
+        inference = session.traces[0].spans[0]
+        assert isinstance(inference, InferenceSpan)
+        assert len(inference.messages) == 2
+        assert inference.messages[0].role.value == "user"
+        assert inference.messages[1].role.value == "assistant"
+
+    def test_operation_details_event_list_format(self):
+        """operation.details with already-parsed list (not JSON string) still works."""
+        span = make_span(
+            operation_name="chat",
+            span_events=[
+                {
+                    "event_name": "gen_ai.client.inference.operation.details",
+                    "timestamp": 0,
+                    "attributes": {
+                        "gen_ai.input.messages": [
+                            {"role": "user", "parts": [{"type": "text", "content": "What's 2+2?"}]}
+                        ],
+                        "gen_ai.output.messages": [{"role": "assistant", "parts": [{"type": "text", "content": "4"}]}],
+                    },
+                }
+            ],
+        )
+        session = self.mapper.map_to_session([span], "sess-1")
+        inference = session.traces[0].spans[0]
+        assert isinstance(inference, InferenceSpan)
+        assert len(inference.messages) == 2
+
+    def test_operation_details_event_with_tool_role(self):
+        """operation.details with role 'tool' messages normalizes to ToolResultContent."""
+        span = make_span(
+            operation_name="chat",
+            span_events=[
+                {
+                    "event_name": "gen_ai.client.inference.operation.details",
+                    "timestamp": 0,
+                    "attributes": {
+                        "gen_ai.input.messages": json.dumps(
+                            [
+                                {"role": "user", "parts": [{"type": "text", "content": "Check weather"}]},
+                                {"role": "tool", "id": "call-1", "response": "72F sunny"},
+                            ]
+                        ),
+                        "gen_ai.output.messages": json.dumps(
+                            [{"role": "assistant", "parts": [{"type": "text", "content": "It's 72F and sunny"}]}]
+                        ),
+                    },
+                }
+            ],
+        )
+        session = self.mapper.map_to_session([span], "sess-1")
+        inference = session.traces[0].spans[0]
+        assert isinstance(inference, InferenceSpan)
+        # user + tool (as UserMessage) + assistant = 3 messages
+        assert len(inference.messages) == 3
+        # The tool message should be a UserMessage with ToolResultContent
+        tool_msg = inference.messages[1]
+        assert tool_msg.role.value == "user"
+        assert hasattr(tool_msg.content[0], "content")
+        assert tool_msg.content[0].content == "72F sunny"
+
+
+class TestSessionFilteringTraceLevel:
+    """Regression: untagged spans must not leak into sessions with tagged data."""
+
+    def setup_method(self):
+        self.mapper = GenericGenAISessionMapper()
+
+    def test_untagged_trace_excluded_when_sessions_present(self):
+        """Untagged trace excluded when session-tagged data exists."""
+        spans = [
+            # Trace 1: tagged with session A
+            make_span(
+                trace_id="t1",
+                span_id="s1",
+                operation_name="invoke_agent",
+                attributes={"session.id": "sess-A"},
+            ),
+            # Trace 2: completely untagged (unrelated)
+            make_span(
+                trace_id="t2",
+                span_id="s2",
+                operation_name="invoke_agent",
+            ),
+            # Trace 3: tagged with session B
+            make_span(
+                trace_id="t3",
+                span_id="s3",
+                operation_name="invoke_agent",
+                attributes={"session.id": "sess-B"},
+            ),
+        ]
+        session = self.mapper.map_to_session(spans, "sess-A")
+
+        # Only trace t1 should be included; t2 (untagged) should NOT leak in
+        assert len(session.traces) == 1
+        assert session.traces[0].trace_id == "t1"
+
+    def test_untagged_span_in_tagged_trace_included(self):
+        """Untagged span within a trace that has a tagged span IS included."""
+        spans = [
+            # Same trace: one span tagged, one not
+            make_span(
+                trace_id="t1",
+                span_id="s1",
+                operation_name="invoke_agent",
+                attributes={"session.id": "sess-A"},
+            ),
+            make_span(
+                trace_id="t1",
+                span_id="s2",
+                parent_span_id="s1",
+                operation_name="execute_tool",
+                attributes={"gen_ai.tool.name": "calc", "gen_ai.tool.output": "4"},
+            ),
+        ]
+        session = self.mapper.map_to_session(spans, "sess-A")
+
+        # Both spans in the same trace should be included
+        assert len(session.traces) == 1
+        assert len(session.traces[0].spans) == 2
+
+    def test_mixed_tagged_untagged_traces(self):
+        """Only traces with at least one matching span are included."""
+        spans = [
+            # t1: session A
+            make_span(trace_id="t1", span_id="s1", operation_name="invoke_agent", attributes={"session.id": "sess-A"}),
+            make_span(
+                trace_id="t1",
+                span_id="s2",
+                parent_span_id="s1",
+                operation_name="execute_tool",
+                attributes={"gen_ai.tool.name": "x", "gen_ai.tool.output": "y"},
+            ),
+            # t2: untagged
+            make_span(trace_id="t2", span_id="s3", operation_name="invoke_agent"),
+            # t3: session B
+            make_span(
+                trace_id="t3",
+                span_id="s4",
+                operation_name="invoke_agent",
+                attributes={"gen_ai.conversation.id": "sess-B"},
+            ),
+        ]
+        session_a = self.mapper.map_to_session(spans, "sess-A")
+        session_b = self.mapper.map_to_session(spans, "sess-B")
+
+        assert len(session_a.traces) == 1
+        assert session_a.traces[0].trace_id == "t1"
+        assert len(session_b.traces) == 1
+        assert session_b.traces[0].trace_id == "t3"
+
+
+class TestAgentResponseFromOutputMessages:
+    """Regression: invoke_agent must extract agent_response from gen_ai.output.messages."""
+
+    def setup_method(self):
+        self.mapper = GenericGenAISessionMapper()
+
+    def test_agent_response_from_output_messages(self):
+        """Agent response extracted from gen_ai.output.messages attribute."""
+        span = make_span(
+            operation_name="invoke_agent",
+            attributes={
+                "gen_ai.input.messages": json.dumps(
+                    [{"role": "user", "parts": [{"type": "text", "content": "What's the weather?"}]}]
+                ),
+                "gen_ai.output.messages": json.dumps(
+                    [{"role": "assistant", "parts": [{"type": "text", "content": "It's sunny and 72F"}]}]
+                ),
+            },
+        )
+        session = self.mapper.map_to_session([span], "sess-1")
+        agent = session.traces[0].spans[0]
+        assert isinstance(agent, AgentInvocationSpan)
+        assert agent.user_prompt == "What's the weather?"
+        assert agent.agent_response == "It's sunny and 72F"
+
+    def test_agent_response_flat_content_string(self):
+        """Agent response from gen_ai.output.messages with flat content (no parts)."""
+        span = make_span(
+            operation_name="invoke_agent",
+            attributes={
+                "gen_ai.output.messages": json.dumps([{"role": "assistant", "content": "The answer is 42"}]),
+            },
+        )
+        session = self.mapper.map_to_session([span], "sess-1")
+        agent = session.traces[0].spans[0]
+        assert isinstance(agent, AgentInvocationSpan)
+        assert agent.agent_response == "The answer is 42"
+
+    def test_final_result_used_when_no_output_messages(self):
+        """Falls back to final_result when gen_ai.output.messages absent."""
+        span = make_span(
+            operation_name="invoke_agent",
+            attributes={
+                "final_result": "Legacy result",
+            },
+        )
+        session = self.mapper.map_to_session([span], "sess-1")
+        agent = session.traces[0].spans[0]
+        assert isinstance(agent, AgentInvocationSpan)
+        assert agent.agent_response == "Legacy result"
+
+
+class TestToolRoleMessages:
+    """Regression: role 'tool' in gen_ai.input.messages must be parsed as ToolResultContent."""
+
+    def setup_method(self):
+        self.mapper = GenericGenAISessionMapper()
+
+    def test_tool_role_with_response_field(self):
+        """OTel convention: role 'tool' with 'response' field parsed correctly."""
+        span = make_span(
+            operation_name="chat",
+            attributes={
+                "gen_ai.input.messages": json.dumps(
+                    [
+                        {"role": "user", "parts": [{"type": "text", "content": "Search for cats"}]},
+                        {"role": "tool", "id": "call-t1", "response": "Found 10 cats"},
+                    ]
+                ),
+                "gen_ai.output.messages": json.dumps(
+                    [{"role": "assistant", "parts": [{"type": "text", "content": "I found 10 cats for you"}]}]
+                ),
+            },
+        )
+        session = self.mapper.map_to_session([span], "sess-1")
+        inference = session.traces[0].spans[0]
+        assert isinstance(inference, InferenceSpan)
+        assert len(inference.messages) == 3  # user + tool + assistant
+
+        # Check tool message
+        tool_msg = inference.messages[1]
+        assert tool_msg.role.value == "user"
+        assert tool_msg.content[0].content == "Found 10 cats"
+        assert tool_msg.content[0].tool_call_id == "call-t1"
+
+    def test_tool_role_with_dict_response(self):
+        """Tool role with dict response is JSON-serialized."""
+        span = make_span(
+            operation_name="chat",
+            attributes={
+                "gen_ai.input.messages": json.dumps(
+                    [
+                        {"role": "tool", "id": "call-t2", "response": {"status": "ok", "count": 5}},
+                    ]
+                ),
+            },
+        )
+        session = self.mapper.map_to_session([span], "sess-1")
+        inference = session.traces[0].spans[0]
+        assert isinstance(inference, InferenceSpan)
+        tool_msg = inference.messages[0]
+        assert '"count": 5' in tool_msg.content[0].content
+        assert '"status": "ok"' in tool_msg.content[0].content
+
+    def test_pydantic_ai_tool_call_response_still_works(self):
+        """PydanticAI format: tool_call_response under user role still parsed correctly."""
+        span = make_span(
+            operation_name="chat",
+            attributes={
+                "gen_ai.input.messages": json.dumps(
+                    [
+                        {
+                            "role": "user",
+                            "parts": [{"type": "tool_call_response", "id": "call-p1", "result": "42"}],
+                        }
+                    ]
+                ),
+            },
+        )
+        session = self.mapper.map_to_session([span], "sess-1")
+        inference = session.traces[0].spans[0]
+        assert isinstance(inference, InferenceSpan)
+        tool_msg = inference.messages[0]
+        assert tool_msg.content[0].content == "42"
+        assert tool_msg.content[0].tool_call_id == "call-p1"
+
+
+# =============================================================================
+# OTel GenAI Semantic Convention fixture tests (current spec)
+# Covers: gen_ai.client.inference.operation.details event, error.type on tools,
+# gen_ai.output.messages on invoke_agent, role "tool" with tool_call_response,
+# gen_ai.tool.call.arguments / gen_ai.tool.call.result, trace-level session filtering.
+# =============================================================================
+
+_OTEL_CONVENTION_SPANS_FILE = _FIXTURES_DIR / "otel_genai_convention_spans.json"
+
+
+@pytest.fixture(scope="module")
+def otel_convention_spans():
+    """Load hand-crafted spans following current OTel GenAI semantic conventions."""
+    with open(_OTEL_CONVENTION_SPANS_FILE) as f:
+        return json.load(f)
+
+
+@pytest.fixture(scope="module")
+def otel_convention_session(otel_convention_spans):
+    """Map OTel convention spans to a Session."""
+    mapper = GenericGenAISessionMapper()
+    return mapper.map_to_session(otel_convention_spans, session_id="conv_otel_test_001")
+
+
+class TestOtelConventionRouting:
+    """Verify detect_otel_mapper routes unrecognized scope to GenericGenAISessionMapper."""
+
+    def test_routes_to_generic_mapper(self, otel_convention_spans):
+        """Custom scope 'my-weather-app' routes to GenericGenAISessionMapper."""
+        mapper = detect_otel_mapper(otel_convention_spans)
+        assert isinstance(mapper, GenericGenAISessionMapper)
+
+    def test_scope_is_custom(self, otel_convention_spans):
+        """All spans have unrecognized scope.name."""
+        scopes = {s["scope"]["name"] for s in otel_convention_spans}
+        assert scopes == {"my-weather-app"}
+
+
+class TestOtelConventionIntegration:
+    """Full integration tests using current OTel GenAI semantic convention format."""
+
+    def test_session_has_single_trace(self, otel_convention_session):
+        """All spans share one trace_id → single trace."""
+        assert len(otel_convention_session.traces) == 1
+
+    def test_produces_all_span_types(self, otel_convention_session):
+        """Trace contains InferenceSpan, ToolExecutionSpan, and AgentInvocationSpan."""
+        all_spans = [s for t in otel_convention_session.traces for s in t.spans]
+        span_types = {type(s) for s in all_spans}
+        assert InferenceSpan in span_types
+        assert ToolExecutionSpan in span_types
+        assert AgentInvocationSpan in span_types
+
+    def test_agent_span_extracts_from_output_messages(self, otel_convention_session):
+        """invoke_agent extracts user_prompt and agent_response from gen_ai.input/output.messages."""
+        all_spans = [s for t in otel_convention_session.traces for s in t.spans]
+        agent_spans = [s for s in all_spans if isinstance(s, AgentInvocationSpan)]
+        assert len(agent_spans) == 1
+
+        agent = agent_spans[0]
+        assert "Paris" in agent.user_prompt and "London" in agent.user_prompt
+        assert "57" in agent.agent_response and "timeout" in agent.agent_response.lower()
+
+    def test_agent_span_has_tool_definitions(self, otel_convention_session):
+        """invoke_agent extracts available_tools from gen_ai.tool.definitions."""
+        all_spans = [s for t in otel_convention_session.traces for s in t.spans]
+        agent_spans = [s for s in all_spans if isinstance(s, AgentInvocationSpan)]
+        agent = agent_spans[0]
+        assert len(agent.available_tools) == 1
+        assert agent.available_tools[0].name == "get_weather"
+
+    def test_successful_tool_uses_call_arguments_and_result(self, otel_convention_session):
+        """Successful tool uses gen_ai.tool.call.arguments and gen_ai.tool.call.result."""
+        all_spans = [s for t in otel_convention_session.traces for s in t.spans]
+        tool_spans = [s for s in all_spans if isinstance(s, ToolExecutionSpan)]
+
+        paris_tool = next(s for s in tool_spans if s.tool_call.tool_call_id == "call_paris_001")
+        assert paris_tool.tool_call.name == "get_weather"
+        assert paris_tool.tool_call.arguments == {"location": "Paris"}
+        assert "rainy" in paris_tool.tool_result.content and "57" in paris_tool.tool_result.content
+        assert paris_tool.tool_result.error is None
+
+    def test_failed_tool_reports_error_type(self, otel_convention_session):
+        """Failed tool with error.type and status ERROR surfaces tool_result.error."""
+        all_spans = [s for t in otel_convention_session.traces for s in t.spans]
+        tool_spans = [s for s in all_spans if isinstance(s, ToolExecutionSpan)]
+
+        london_tool = next(s for s in tool_spans if s.tool_call.tool_call_id == "call_london_001")
+        assert london_tool.tool_call.name == "get_weather"
+        assert london_tool.tool_result.error == "TimeoutError"
+
+    def test_chat_span_with_operation_details_event(self, otel_convention_session):
+        """Chat span with gen_ai.client.inference.operation.details produces messages."""
+        all_spans = [s for t in otel_convention_session.traces for s in t.spans]
+        inference_spans = [s for s in all_spans if isinstance(s, InferenceSpan)]
+        assert len(inference_spans) == 2
+
+    def test_operation_details_parses_tool_calls(self, otel_convention_session):
+        """operation.details event extracts assistant tool_call parts."""
+        all_spans = [s for t in otel_convention_session.traces for s in t.spans]
+        inference_spans = [s for s in all_spans if isinstance(s, InferenceSpan)]
+
+        # First chat span has the initial tool_call response
+        first_chat = inference_spans[0]
+        # Should have user message + assistant message with tool calls
+        assert len(first_chat.messages) >= 2
+
+    def test_operation_details_parses_tool_role(self, otel_convention_session):
+        """operation.details event with role 'tool' produces ToolResultContent."""
+        all_spans = [s for t in otel_convention_session.traces for s in t.spans]
+        inference_spans = [s for s in all_spans if isinstance(s, InferenceSpan)]
+
+        # Second chat span has role "tool" messages in input
+        second_chat = inference_spans[1]
+        # Should contain: user + assistant + 2x tool + assistant output = multiple messages
+        assert len(second_chat.messages) >= 4
+
+        # Find the tool role messages (mapped as UserMessage with ToolResultContent)
+        tool_messages = []
+        for msg in second_chat.messages:
+            if msg.role.value == "user":
+                for c in msg.content:
+                    if hasattr(c, "tool_call_id") and c.tool_call_id:
+                        tool_messages.append(c)
+        assert len(tool_messages) >= 1
+        # The Paris tool result should be present
+        paris_result = next((m for m in tool_messages if m.tool_call_id == "call_paris_001"), None)
+        assert paris_result is not None
+        assert "rainy" in paris_result.content and "57" in paris_result.content
+
+    def test_session_id_filtering(self, otel_convention_spans):
+        """Correct session_id includes all spans; wrong one excludes them."""
+        mapper = GenericGenAISessionMapper()
+
+        # Correct session_id
+        session = mapper.map_to_session(otel_convention_spans, session_id="conv_otel_test_001")
+        assert len(session.traces) == 1
+        all_spans = [s for t in session.traces for s in t.spans]
+        assert len(all_spans) == 5  # 1 agent + 2 chat + 2 tool
+
+        # Wrong session_id → no traces
+        session_wrong = mapper.map_to_session(otel_convention_spans, session_id="wrong-id")
+        assert len(session_wrong.traces) == 0

--- a/tests/strands_evals/mappers/test_generic_gen_ai_session_mapper.py
+++ b/tests/strands_evals/mappers/test_generic_gen_ai_session_mapper.py
@@ -216,6 +216,28 @@ class TestSessionBuilding:
         session = self.mapper.map_to_session(spans, "any-id")
         assert len(session.traces) == 2
 
+    def test_string_nanosecond_timestamp_parsed_correctly(self):
+        """String-encoded ns epoch (OTLP/JSON int64 encoding) parses to correct datetime."""
+        from datetime import datetime, timezone
+
+        result = self.mapper._parse_timestamp("1700000000000000000")
+        expected = datetime.fromtimestamp(1700000000, tz=timezone.utc)
+        assert result == expected
+
+    def test_string_timestamp_in_span_produces_correct_time(self):
+        """Span with string timestamps (CloudWatch/ADOT path) maps to correct year."""
+        span = make_span(
+            operation_name="invoke_agent",
+            attributes={"gen_ai.tool.definitions": "[]"},
+        )
+        span["start_time"] = "1700000000000000000"
+        span["end_time"] = "1700000001000000000"
+
+        session = self.mapper.map_to_session([span], "sess-1")
+        agent = session.traces[0].spans[0]
+        assert isinstance(agent, AgentInvocationSpan)
+        assert agent.span_info.start_time.year == 2023
+
 
 # =============================================================================
 # Fixture-based integration tests — real captured traces
@@ -686,6 +708,58 @@ class TestSessionFilteringTraceLevel:
         assert len(session_b.traces) == 1
         assert session_b.traces[0].trace_id == "t3"
 
+    def test_different_session_span_in_same_trace_excluded(self):
+        """Two spans sharing a trace with different session tags — only matching one returned."""
+        spans = [
+            make_span(
+                trace_id="tSHARED",
+                span_id="s1",
+                operation_name="invoke_agent",
+                attributes={"session.id": "session-123"},
+            ),
+            make_span(
+                trace_id="tSHARED",
+                span_id="s2",
+                operation_name="invoke_agent",
+                attributes={"session.id": "session-456"},
+            ),
+        ]
+        session = self.mapper.map_to_session(spans, "session-123")
+
+        assert len(session.traces) == 1
+        assert len(session.traces[0].spans) == 1
+        assert session.traces[0].spans[0].span_info.span_id == "s1"
+
+    def test_untagged_span_inherits_while_foreign_excluded(self):
+        """Untagged span inherits trace match; explicitly foreign-tagged span excluded."""
+        spans = [
+            make_span(
+                trace_id="tSHARED",
+                span_id="s1",
+                operation_name="invoke_agent",
+                attributes={"session.id": "session-123"},
+            ),
+            make_span(
+                trace_id="tSHARED",
+                span_id="s2",
+                parent_span_id="s1",
+                operation_name="execute_tool",
+                attributes={"gen_ai.tool.name": "calc", "gen_ai.tool.output": "4"},
+            ),
+            make_span(
+                trace_id="tSHARED",
+                span_id="s3",
+                operation_name="invoke_agent",
+                attributes={"session.id": "session-456"},
+            ),
+        ]
+        session = self.mapper.map_to_session(spans, "session-123")
+
+        assert len(session.traces) == 1
+        assert len(session.traces[0].spans) == 2
+        span_ids = {s.span_info.span_id for s in session.traces[0].spans}
+        assert span_ids == {"s1", "s2"}
+
 
 class TestAgentResponseFromOutputMessages:
     """Regression: invoke_agent must extract agent_response from gen_ai.output.messages."""
@@ -812,6 +886,98 @@ class TestToolRoleMessages:
         tool_msg = inference.messages[0]
         assert tool_msg.content[0].content == "42"
         assert tool_msg.content[0].tool_call_id == "call-p1"
+
+    def test_tool_result_json_block_preserved(self):
+        """toolResult.content with a json block serializes it rather than dropping."""
+        span = make_span(
+            operation_name="chat",
+            span_events=[
+                {
+                    "event_name": "gen_ai.tool.message",
+                    "timestamp": 0,
+                    "attributes": {
+                        "content": json.dumps(
+                            [
+                                {
+                                    "toolResult": {
+                                        "toolUseId": "tool-j1",
+                                        "content": [{"json": {"result": 42, "status": "ok"}}],
+                                    }
+                                }
+                            ]
+                        )
+                    },
+                }
+            ],
+        )
+        session = self.mapper.map_to_session([span], "sess-1")
+        inference = session.traces[0].spans[0]
+        assert isinstance(inference, InferenceSpan)
+        tool_msg = inference.messages[0]
+        assert "42" in tool_msg.content[0].content
+        assert "result" in tool_msg.content[0].content
+
+    def test_tool_result_image_block_placeholder(self):
+        """toolResult.content with an image block produces [image] placeholder."""
+        span = make_span(
+            operation_name="chat",
+            span_events=[
+                {
+                    "event_name": "gen_ai.tool.message",
+                    "timestamp": 0,
+                    "attributes": {
+                        "content": json.dumps(
+                            [
+                                {
+                                    "toolResult": {
+                                        "toolUseId": "tool-img1",
+                                        "content": [{"image": {"format": "png", "data": "base64..."}}],
+                                    }
+                                }
+                            ]
+                        )
+                    },
+                }
+            ],
+        )
+        session = self.mapper.map_to_session([span], "sess-1")
+        inference = session.traces[0].spans[0]
+        tool_msg = inference.messages[0]
+        assert "[image]" in tool_msg.content[0].content
+
+    def test_tool_result_mixed_text_and_json_blocks(self):
+        """toolResult.content with text + json blocks joins both with newline."""
+        span = make_span(
+            operation_name="chat",
+            span_events=[
+                {
+                    "event_name": "gen_ai.tool.message",
+                    "timestamp": 0,
+                    "attributes": {
+                        "content": json.dumps(
+                            [
+                                {
+                                    "toolResult": {
+                                        "toolUseId": "tool-mix1",
+                                        "content": [
+                                            {"text": "Summary:"},
+                                            {"json": {"temp": 72, "unit": "F"}},
+                                        ],
+                                    }
+                                }
+                            ]
+                        )
+                    },
+                }
+            ],
+        )
+        session = self.mapper.map_to_session([span], "sess-1")
+        inference = session.traces[0].spans[0]
+        tool_msg = inference.messages[0]
+        content = tool_msg.content[0].content
+        assert "Summary:" in content
+        assert "72" in content
+        assert "\n" in content
 
 
 # =============================================================================

--- a/tests/strands_evals/mappers/test_generic_gen_ai_session_mapper.py
+++ b/tests/strands_evals/mappers/test_generic_gen_ai_session_mapper.py
@@ -1064,8 +1064,8 @@ class TestToolRoleMessages:
         inference = session.traces[0].spans[0]
         assert isinstance(inference, InferenceSpan)
         tool_msg = inference.messages[0]
-        assert "42" in tool_msg.content[0].content
-        assert "result" in tool_msg.content[0].content
+        # Assert exact serialized JSON string, not just substrings
+        assert tool_msg.content[0].content == '{"result": 42, "status": "ok"}'
 
     def test_tool_result_image_block_placeholder(self):
         """toolResult.content with an image block produces [image] placeholder."""
@@ -1128,6 +1128,195 @@ class TestToolRoleMessages:
         assert "Summary:" in content
         assert "72" in content
         assert "\n" in content
+
+    def test_user_role_tool_call_response_with_list_response(self):
+        """role:'user' tool_call_response with list-valued 'response' joins text blocks."""
+        span = make_span(
+            operation_name="chat",
+            attributes={
+                "gen_ai.input.messages": json.dumps(
+                    [
+                        {
+                            "role": "user",
+                            "parts": [
+                                {
+                                    "type": "tool_call_response",
+                                    "id": "call-list-u1",
+                                    "response": [{"text": "Seattle: 62F, cloudy with light rain"}],
+                                }
+                            ],
+                        }
+                    ]
+                ),
+            },
+        )
+        session = self.mapper.map_to_session([span], "sess-1")
+        inference = session.traces[0].spans[0]
+        assert isinstance(inference, InferenceSpan)
+        tool_msg = inference.messages[0]
+        assert tool_msg.content[0].content == "Seattle: 62F, cloudy with light rain"
+        assert tool_msg.content[0].tool_call_id == "call-list-u1"
+
+    def test_tool_role_parts_branch_with_list_response(self):
+        """role:'tool' parts branch with list-valued 'response' joins text blocks."""
+        span = make_span(
+            operation_name="chat",
+            attributes={
+                "gen_ai.input.messages": json.dumps(
+                    [
+                        {
+                            "role": "tool",
+                            "parts": [
+                                {
+                                    "type": "tool_call_response",
+                                    "id": "call-list-t1",
+                                    "response": [
+                                        {"text": "Paris: 57F, rainy"},
+                                        {"text": "Wind: 12mph NW"},
+                                    ],
+                                }
+                            ],
+                        }
+                    ]
+                ),
+            },
+        )
+        session = self.mapper.map_to_session([span], "sess-1")
+        inference = session.traces[0].spans[0]
+        assert isinstance(inference, InferenceSpan)
+        tool_msg = inference.messages[0]
+        assert "Paris: 57F, rainy" in tool_msg.content[0].content
+        assert "Wind: 12mph NW" in tool_msg.content[0].content
+        assert tool_msg.content[0].tool_call_id == "call-list-t1"
+
+    def test_tool_role_flat_branch_with_list_response(self):
+        """role:'tool' flat (no parts) with list-valued 'response' joins text blocks."""
+        span = make_span(
+            operation_name="chat",
+            attributes={
+                "gen_ai.input.messages": json.dumps(
+                    [
+                        {
+                            "role": "tool",
+                            "id": "call-list-flat1",
+                            "response": [{"text": "London: 55F, overcast"}],
+                        }
+                    ]
+                ),
+            },
+        )
+        session = self.mapper.map_to_session([span], "sess-1")
+        inference = session.traces[0].spans[0]
+        assert isinstance(inference, InferenceSpan)
+        tool_msg = inference.messages[0]
+        assert tool_msg.content[0].content == "London: 55F, overcast"
+        assert tool_msg.content[0].tool_call_id == "call-list-flat1"
+
+    def test_tool_role_flat_branch_with_json_block_in_list(self):
+        """role:'tool' flat with json block in list serializes it, not repr."""
+        span = make_span(
+            operation_name="chat",
+            attributes={
+                "gen_ai.input.messages": json.dumps(
+                    [
+                        {
+                            "role": "tool",
+                            "id": "call-flat-json1",
+                            "response": [
+                                {"text": "Weather:"},
+                                {"json": {"temp": 62, "unit": "F", "condition": "cloudy"}},
+                            ],
+                        }
+                    ]
+                ),
+            },
+        )
+        session = self.mapper.map_to_session([span], "sess-1")
+        inference = session.traces[0].spans[0]
+        assert isinstance(inference, InferenceSpan)
+        tool_msg = inference.messages[0]
+        content = tool_msg.content[0].content
+        # Must contain the text block and serialized json, not Python repr
+        assert "Weather:" in content
+        assert '"temp": 62' in content or '"temp":62' in content
+        # Must NOT contain Python repr artifacts
+        assert "[{" not in content or '{"' in content  # no list-repr wrapper
+        assert "'json'" not in content  # no dict key as Python repr
+
+    def test_non_dict_message_skipped_gracefully(self):
+        """A non-dict entry in the message list is skipped without crashing."""
+        span = make_span(
+            operation_name="chat",
+            attributes={
+                "gen_ai.input.messages": json.dumps(
+                    [
+                        "unexpected string entry",
+                        None,
+                        {"role": "user", "parts": [{"type": "text", "content": "hello"}]},
+                    ]
+                ),
+            },
+        )
+        session = self.mapper.map_to_session([span], "sess-1")
+        inference = session.traces[0].spans[0]
+        assert isinstance(inference, InferenceSpan)
+        # Only the valid dict message should be parsed
+        assert len(inference.messages) == 1
+        assert inference.messages[0].content[0].text == "hello"
+
+    def test_user_role_tool_call_response_falls_back_to_result_key(self):
+        """role:'user' tool_call_response reads 'result' when 'response' is absent."""
+        span = make_span(
+            operation_name="chat",
+            attributes={
+                "gen_ai.input.messages": json.dumps(
+                    [
+                        {
+                            "role": "user",
+                            "parts": [
+                                {
+                                    "type": "tool_call_response",
+                                    "id": "call-fallback1",
+                                    "result": [{"text": "fallback content"}],
+                                }
+                            ],
+                        }
+                    ]
+                ),
+            },
+        )
+        session = self.mapper.map_to_session([span], "sess-1")
+        inference = session.traces[0].spans[0]
+        assert isinstance(inference, InferenceSpan)
+        tool_msg = inference.messages[0]
+        assert tool_msg.content[0].content == "fallback content"
+
+    def test_tool_role_parts_branch_falls_back_to_result_key(self):
+        """role:'tool' parts branch reads 'result' when 'response' is absent."""
+        span = make_span(
+            operation_name="chat",
+            attributes={
+                "gen_ai.input.messages": json.dumps(
+                    [
+                        {
+                            "role": "tool",
+                            "parts": [
+                                {
+                                    "type": "tool_call_response",
+                                    "id": "call-fallback2",
+                                    "result": [{"text": "tool fallback"}],
+                                }
+                            ],
+                        }
+                    ]
+                ),
+            },
+        )
+        session = self.mapper.map_to_session([span], "sess-1")
+        inference = session.traces[0].spans[0]
+        assert isinstance(inference, InferenceSpan)
+        tool_msg = inference.messages[0]
+        assert tool_msg.content[0].content == "tool fallback"
 
 
 # =============================================================================

--- a/tests/strands_evals/mappers/test_generic_gen_ai_session_mapper.py
+++ b/tests/strands_evals/mappers/test_generic_gen_ai_session_mapper.py
@@ -98,6 +98,69 @@ class TestToolExecutionSpan:
         assert session.traces == []
 
 
+    def test_tool_span_from_operation_details_event(self):
+        """Tool data extracted from gen_ai.client.inference.operation.details unified event."""
+        span = make_span(
+            operation_name="execute_tool",
+            attributes={
+                "gen_ai.tool.name": "get_weather",
+                "gen_ai.tool.call.id": "call-unified-1",
+            },
+            span_events=[
+                {
+                    "event_name": "gen_ai.client.inference.operation.details",
+                    "timestamp": 0,
+                    "attributes": {
+                        "gen_ai.input.messages": json.dumps(
+                            [{"role": "user", "parts": [{"type": "text", "content": "{\"location\": \"Seattle\"}"}]}]
+                        ),
+                        "gen_ai.output.messages": json.dumps(
+                            [{"role": "assistant", "parts": [{"type": "text", "content": "62F and cloudy"}]}]
+                        ),
+                    },
+                }
+            ],
+        )
+        session = self.mapper.map_to_session([span], "sess-1")
+
+        tool = session.traces[0].spans[0]
+        assert isinstance(tool, ToolExecutionSpan)
+        assert tool.tool_call.name == "get_weather"
+        assert tool.tool_call.arguments == {"location": "Seattle"}
+        assert tool.tool_result.content == "62F and cloudy"
+        assert tool.tool_result.error is None
+
+    def test_tool_span_operation_details_with_tool_result_content(self):
+        """Tool result from operation.details with ToolResultContent (role=tool)."""
+        span = make_span(
+            operation_name="execute_tool",
+            attributes={
+                "gen_ai.tool.name": "search",
+                "gen_ai.tool.call.id": "call-unified-2",
+            },
+            span_events=[
+                {
+                    "event_name": "gen_ai.client.inference.operation.details",
+                    "timestamp": 0,
+                    "attributes": {
+                        "gen_ai.input.messages": json.dumps(
+                            [{"role": "user", "parts": [{"type": "text", "content": "{\"query\": \"cats\"}"}]}]
+                        ),
+                        "gen_ai.output.messages": json.dumps(
+                            [{"role": "tool", "id": "call-unified-2", "response": "Found 10 cats"}]
+                        ),
+                    },
+                }
+            ],
+        )
+        session = self.mapper.map_to_session([span], "sess-1")
+
+        tool = session.traces[0].spans[0]
+        assert isinstance(tool, ToolExecutionSpan)
+        assert tool.tool_call.arguments == {"query": "cats"}
+        assert tool.tool_result.content == "Found 10 cats"
+
+
 class TestAgentInvocationSpan:
     def setup_method(self):
         self.mapper = GenericGenAISessionMapper()
@@ -142,6 +205,62 @@ class TestAgentInvocationSpan:
         assert isinstance(agent, AgentInvocationSpan)
         assert agent.user_prompt == ""
         assert agent.agent_response == ""
+
+
+    def test_agent_span_from_operation_details_event(self):
+        """Agent prompt/response extracted from gen_ai.client.inference.operation.details."""
+        span = make_span(
+            operation_name="invoke_agent",
+            attributes={
+                "gen_ai.agent.tools": '["get_weather"]',
+            },
+            span_events=[
+                {
+                    "event_name": "gen_ai.client.inference.operation.details",
+                    "timestamp": 0,
+                    "attributes": {
+                        "gen_ai.input.messages": json.dumps(
+                            [{"role": "user", "parts": [{"type": "text", "content": "What is the weather in Paris?"}]}]
+                        ),
+                        "gen_ai.output.messages": json.dumps(
+                            [{"role": "assistant", "parts": [{"type": "text", "content": "It is 57F and rainy in Paris."}]}]
+                        ),
+                    },
+                }
+            ],
+        )
+        session = self.mapper.map_to_session([span], "sess-1")
+
+        agent = session.traces[0].spans[0]
+        assert isinstance(agent, AgentInvocationSpan)
+        assert agent.user_prompt == "What is the weather in Paris?"
+        assert agent.agent_response == "It is 57F and rainy in Paris."
+
+    def test_agent_span_operation_details_flat_content(self):
+        """Agent response from operation.details with flat content string (no parts)."""
+        span = make_span(
+            operation_name="invoke_agent",
+            span_events=[
+                {
+                    "event_name": "gen_ai.client.inference.operation.details",
+                    "timestamp": 0,
+                    "attributes": {
+                        "gen_ai.input.messages": json.dumps(
+                            [{"role": "user", "parts": [{"type": "text", "content": "Hello"}]}]
+                        ),
+                        "gen_ai.output.messages": json.dumps(
+                            [{"role": "assistant", "content": "Hi there!"}]
+                        ),
+                    },
+                }
+            ],
+        )
+        session = self.mapper.map_to_session([span], "sess-1")
+
+        agent = session.traces[0].spans[0]
+        assert isinstance(agent, AgentInvocationSpan)
+        assert agent.user_prompt == "Hello"
+        assert agent.agent_response == "Hi there!"
 
 
 class TestInferenceSpan:

--- a/tests/strands_evals/mappers/test_openinference_session_mapper.py
+++ b/tests/strands_evals/mappers/test_openinference_session_mapper.py
@@ -1439,16 +1439,20 @@ class TestSmolagentsScopeSupport:
             attributes={
                 "openinference.span.kind": "TOOL",
                 "tool.name": "search",
-                "tool.parameters": json.dumps({
-                    "query": {"type": "string"},
-                    "limit": {"type": "integer"},
-                    "offset": {"type": "integer"},
-                }),
-                "input.value": json.dumps({
-                    "args": ["tokyo", 5],
-                    "kwargs": {"offset": 10},
-                    "sanitize_inputs_outputs": False,
-                }),
+                "tool.parameters": json.dumps(
+                    {
+                        "query": {"type": "string"},
+                        "limit": {"type": "integer"},
+                        "offset": {"type": "integer"},
+                    }
+                ),
+                "input.value": json.dumps(
+                    {
+                        "args": ["tokyo", 5],
+                        "kwargs": {"offset": 10},
+                        "sanitize_inputs_outputs": False,
+                    }
+                ),
                 "output.value": "results",
             },
         )
@@ -1483,13 +1487,15 @@ class TestSmolagentsScopeSupport:
             scope_name=SMOLAGENTS_SCOPE_NAME,
             attributes={
                 "openinference.span.kind": "AGENT",
-                "input.value": json.dumps({
-                    "task": "What is 2+2?",
-                    "stream": False,
-                    "reset": True,
-                    "images": None,
-                    "additional_args": None,
-                }),
+                "input.value": json.dumps(
+                    {
+                        "task": "What is 2+2?",
+                        "stream": False,
+                        "reset": True,
+                        "images": None,
+                        "additional_args": None,
+                    }
+                ),
                 "output.value": "The answer is 4.",
             },
         )

--- a/tests/strands_evals/mappers/test_utils.py
+++ b/tests/strands_evals/mappers/test_utils.py
@@ -233,13 +233,16 @@ class TestDetectOtelMapper:
         mapper = detect_otel_mapper(spans)
         assert isinstance(mapper, OpenInferenceSessionMapper)
 
-    def test_raw_readable_spans_route_to_strands_mapper(self):
-        """Raw ReadableSpan objects (not dicts) route directly to StrandsInMemorySessionMapper."""
+    def test_non_dict_spans_fall_through_to_strands_mapper(self):
+        """Non-dict spans (no scope/body/gen_ai attrs to match) fall through to default StrandsInMemorySessionMapper."""
         from unittest.mock import MagicMock
 
+        # Simulates the case where raw ReadableSpan objects are passed without
+        # calling readable_spans_to_dicts() first. detect_otel_mapper doesn't
+        # crash but falls through to the default mapper since get_scope_name()
+        # handles non-dict inputs via hasattr checks.
         mock_span = MagicMock()
-        mock_span.context.trace_id = 0x123
-        mock_span.context.span_id = 0x456
+        mock_span.instrumentation_scope.name = ""
         mapper = detect_otel_mapper([mock_span])
         assert isinstance(mapper, StrandsInMemorySessionMapper)
 

--- a/tests/strands_evals/mappers/test_utils.py
+++ b/tests/strands_evals/mappers/test_utils.py
@@ -4,6 +4,7 @@ from datetime import datetime, timezone
 
 from strands_evals.mappers import (
     CloudWatchSessionMapper,
+    GenericGenAISessionMapper,
     LangChainOtelSessionMapper,
     OpenInferenceSessionMapper,
     StrandsInMemorySessionMapper,
@@ -211,11 +212,11 @@ class TestDetectOtelMapper:
         mapper = detect_otel_mapper(spans)
         assert isinstance(mapper, StrandsInMemorySessionMapper)
 
-    def test_defaults_to_strands_mapper_for_unknown_scope(self):
-        """Defaults to StrandsInMemorySessionMapper for unknown scope."""
+    def test_defaults_to_generic_mapper_for_unknown_scope(self):
+        """Defaults to GenericGenAISessionMapper for unknown scope."""
         spans = [make_span_dict(scope_name="unknown.scope")]
         mapper = detect_otel_mapper(spans)
-        assert isinstance(mapper, StrandsInMemorySessionMapper)
+        assert isinstance(mapper, GenericGenAISessionMapper)
 
     def test_skips_spans_without_scope(self):
         """Skips spans without scope and continues detection."""
@@ -231,6 +232,33 @@ class TestDetectOtelMapper:
         spans = [make_span_dict(scope_name="openinference.instrumentation.smolagents")]
         mapper = detect_otel_mapper(spans)
         assert isinstance(mapper, OpenInferenceSessionMapper)
+
+    def test_raw_readable_spans_route_to_strands_mapper(self):
+        """Raw ReadableSpan objects (not dicts) route directly to StrandsInMemorySessionMapper."""
+        from unittest.mock import MagicMock
+
+        mock_span = MagicMock()
+        mock_span.context.trace_id = 0x123
+        mock_span.context.span_id = 0x456
+        mapper = detect_otel_mapper([mock_span])
+        assert isinstance(mapper, StrandsInMemorySessionMapper)
+
+    def test_unrecognized_scope_with_gen_ai_attrs_routes_to_generic_mapper(self):
+        """Dict spans with unrecognized scope but gen_ai.operation.name route to GenericGenAISessionMapper."""
+        spans = [
+            make_span_dict(
+                scope_name="my-custom-tracer",
+                attributes={"gen_ai.operation.name": "execute_tool", "gen_ai.tool.name": "calc"},
+            )
+        ]
+        mapper = detect_otel_mapper(spans)
+        assert isinstance(mapper, GenericGenAISessionMapper)
+
+    def test_unrecognized_scope_without_gen_ai_attrs_still_returns_mapper(self):
+        """Dict spans with unrecognized scope and no gen_ai attrs still return a mapper (default)."""
+        spans = [make_span_dict(scope_name="totally.unknown", attributes={"custom.key": "val"})]
+        mapper = detect_otel_mapper(spans)
+        assert isinstance(mapper, GenericGenAISessionMapper)
 
 
 class TestReadableSpansToDicts:

--- a/tests/strands_evals/mappers/test_utils.py
+++ b/tests/strands_evals/mappers/test_utils.py
@@ -212,11 +212,11 @@ class TestDetectOtelMapper:
         mapper = detect_otel_mapper(spans)
         assert isinstance(mapper, StrandsInMemorySessionMapper)
 
-    def test_defaults_to_generic_mapper_for_unknown_scope(self):
-        """Defaults to GenericGenAISessionMapper for unknown scope."""
+    def test_defaults_to_strands_mapper_for_unknown_scope(self):
+        """Defaults to StrandsInMemorySessionMapper for unknown scope without gen_ai attrs."""
         spans = [make_span_dict(scope_name="unknown.scope")]
         mapper = detect_otel_mapper(spans)
-        assert isinstance(mapper, GenericGenAISessionMapper)
+        assert isinstance(mapper, StrandsInMemorySessionMapper)
 
     def test_skips_spans_without_scope(self):
         """Skips spans without scope and continues detection."""
@@ -254,11 +254,11 @@ class TestDetectOtelMapper:
         mapper = detect_otel_mapper(spans)
         assert isinstance(mapper, GenericGenAISessionMapper)
 
-    def test_unrecognized_scope_without_gen_ai_attrs_still_returns_mapper(self):
-        """Dict spans with unrecognized scope and no gen_ai attrs still return a mapper (default)."""
+    def test_unrecognized_scope_without_gen_ai_attrs_defaults_to_strands(self):
+        """Dict spans with unrecognized scope and no gen_ai attrs default to StrandsInMemorySessionMapper."""
         spans = [make_span_dict(scope_name="totally.unknown", attributes={"custom.key": "val"})]
         mapper = detect_otel_mapper(spans)
-        assert isinstance(mapper, GenericGenAISessionMapper)
+        assert isinstance(mapper, StrandsInMemorySessionMapper)
 
 
 class TestReadableSpansToDicts:


### PR DESCRIPTION
## Description
### Problem
detect_otel_mapper() routes dict-format spans (from readable_spans_to_dicts()) to StrandsInMemorySessionMapper when the scope is unrecognized. But StrandsInMemorySessionMapper only accepts raw ReadableSpan objects — causing an AttributeError crash.

This happens when agents are manually instrumented with a custom OTel tracer (e.g. get_tracer("my-app")) and use gen_ai.* attributes for tool/inference data.

### Fix
Introduce GenericGenAISessionMapper — a new mapper that accepts dict-format spans and parses gen_ai.operation.name, gen_ai.tool.*, and span events. detect_otel_mapper() now routes unrecognized scopes to this mapper instead of StrandsInMemorySessionMapper.

StrandsInMemorySessionMapper remains unchanged and only handles ReadableSpan input for Strands-scoped traces.

## Related Issues

<!-- Link to related issues using #issue-number format -->

## Documentation PR

<!-- Link to any related documentation PR -->

## Type of Change
Bug fix

## Testing

How have you tested the change? Verify that the changes do not break functionality or introduce new warnings.

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.