### PR TITLE
fix: fix tool parsing from list

### DIFF
--- a/src/strands_evals/providers/langfuse_provider.py
+++ b/src/strands_evals/providers/langfuse_provider.py
@@ -543,6 +543,8 @@ class LangfuseProvider(TraceProvider):
                 error = None if status == "success" else (str(status) if status else None)
                 return content, error
             # Strands OTEL format: {"message": "<JSON string of [{\"text\": ...}]>", "id": "..."}
+            # This payload carries no error/status field; failed tool calls surface a
+            # "result"/"status" dict instead, handled by the branch above.
             if "message" in obs_output:
                 return self._parse_tool_result_message(obs_output["message"]), None
             # LangChain ToolMessage format: {"content": "...", "type": "tool", ...}
@@ -568,15 +570,7 @@ class LangfuseProvider(TraceProvider):
         Falls back to the raw string when the JSON does not decode to a
         non-empty list of text blocks.
         """
-        if isinstance(message, str):
-            try:
-                parsed = json.loads(message)
-            except (json.JSONDecodeError, ValueError):
-                return message
-            return self._first_text_from_list(parsed) or message
-        if isinstance(message, list):
-            return self._first_text_from_list(message) or str(message)
-        return str(message)
+        return self._extract_text_from_content(message) or str(message)
 
     def _convert_agent_invocation(self, obs: Any, session_id: str) -> AgentInvocationSpan:
         """Convert an agent observation to an AgentInvocationSpan.

--- a/src/strands_evals/providers/langfuse_provider.py
+++ b/src/strands_evals/providers/langfuse_provider.py
@@ -440,13 +440,18 @@ class LangfuseProvider(TraceProvider):
         Handles two formats:
 
         **Strands** (obs.type == "SPAN", name starts with "execute_tool"):
-            obs.input: ``{"name": "calc", "arguments": {"x": "2+2"}, "toolUseId": "..."}``
-            obs.output: ``"42"`` or ``{"result": "4", "status": "success"}``
+            obs.input: `{"name": "calc", "arguments": {"x": "2+2"}, "toolUseId": "..."}`
+            obs.output: `"42"` or `{"result": "4", "status": "success"}`
 
         **LangChain / universal** (obs.type == "TOOL"):
-            obs.name: tool name (e.g. ``"add_numbers"``)
+            obs.name: tool name (e.g. `"add_numbers"`)
             obs.input: tool arguments (dict or other)
             obs.output: tool result
+
+        **Strands OTEL** (obs.type == "TOOL", from OTEL instrumentation):
+            obs.name: tool name (e.g. `"bsm-get-case"`)
+            obs.input: `[{"role": "tool", "content": "<JSON args>", "id": "tooluse_..."}]`
+            obs.output: `{"message": "<JSON string of [{\"text\": ...}]>", "id": "tooluse_..."}`
         """
         span_info = self._create_span_info(obs, session_id)
         obs_input = obs.input or {}
@@ -461,6 +466,9 @@ class LangfuseProvider(TraceProvider):
             tool_name = obs.name or ""
             if isinstance(obs_input, dict):
                 tool_arguments = obs_input
+            elif isinstance(obs_input, list):
+                # Strands OTEL format: [{"role": "tool", "content": "<JSON args>", "id": "..."}]
+                tool_arguments = self._parse_tool_arguments_from_list(obs_input)
             elif isinstance(obs_input, str):
                 # Try parsing as JSON; LangChain may send stringified dicts
                 try:
@@ -486,16 +494,43 @@ class LangfuseProvider(TraceProvider):
             span_info=span_info, tool_call=tool_call, tool_result=tool_result, metadata=obs.metadata or {}
         )
 
+    def _parse_tool_arguments_from_list(self, obs_input: list) -> dict:
+        """Extract tool arguments from a Strands OTEL TOOL-message list.
+
+        Input format:
+            `[{"role": "tool", "content": "<JSON args>", "id": "tooluse_..."}]`
+
+        The actual arguments live in the first item's `content` field as a
+        JSON string. Returns the parsed dict, or `{"input": <content>}` when
+        the content is not JSON, or `{"input": str(obs_input)}` when no item
+        carries a `content` field.
+        """
+        for item in obs_input:
+            if isinstance(item, dict) and "content" in item:
+                content = item["content"]
+                if isinstance(content, dict):
+                    return content
+                if isinstance(content, str):
+                    try:
+                        parsed = json.loads(content)
+                    except (json.JSONDecodeError, ValueError):
+                        return {"input": content}
+                    return parsed if isinstance(parsed, dict) else {"input": content}
+                return {"input": str(content)}
+        return {"input": str(obs_input)}
+
     def _parse_tool_result(self, obs_output: Any) -> tuple[str, str | None]:
         """Parse tool execution output into (content, error).
 
         Input formats:
-            str:  ``"42"``                                            → ``("42", None)``
-            dict: ``{"result": "4", "status": "success"}``            → ``("4", None)``
-            dict: ``{"result": "...", "status": "error"}``             → ``("...", "error")``
-            dict: ``{"content": "Weather...", "type": "tool", ...}``   → ``("Weather...", None)``
+            str:  `"42"`                                            → `("42", None)`
+            dict: `{"result": "4", "status": "success"}`            → `("4", None)`
+            dict: `{"result": "...", "status": "error"}`             → `("...", "error")`
+            dict: `{"content": "Weather...", "type": "tool", ...}`   → `("Weather...", None)`
                   (LangChain ToolMessage format via Langfuse)
-            None:                                                      → ``("", None)``
+            dict: `{"message": "<JSON of [{\"text\": ...}]>", ...}`  → `("...", None)`
+                  (Strands OTEL TOOL format via Langfuse)
+            None:                                                    → `("", None)`
         """
         if isinstance(obs_output, str):
             return obs_output, None
@@ -507,6 +542,9 @@ class LangfuseProvider(TraceProvider):
                 status = obs_output.get("status", "")
                 error = None if status == "success" else (str(status) if status else None)
                 return content, error
+            # Strands OTEL format: {"message": "<JSON string of [{\"text\": ...}]>", "id": "..."}
+            if "message" in obs_output:
+                return self._parse_tool_result_message(obs_output["message"]), None
             # LangChain ToolMessage format: {"content": "...", "type": "tool", ...}
             if "content" in obs_output:
                 content = obs_output["content"]
@@ -517,6 +555,28 @@ class LangfuseProvider(TraceProvider):
 
         content = str(obs_output) if obs_output is not None else ""
         return content, None
+
+    def _parse_tool_result_message(self, message: Any) -> str:
+        """Extract tool result text from a Strands OTEL `message` field.
+
+        Input format:
+            str (JSON): `'[{"text": "result text"}]'`  → `"result text"`
+            str:        `"plain text"`                  → `"plain text"`
+            list[dict]: `[{"text": "result text"}]`     → `"result text"`
+            other:                                       → `str(message)`
+
+        Falls back to the raw string when the JSON does not decode to a
+        non-empty list of text blocks.
+        """
+        if isinstance(message, str):
+            try:
+                parsed = json.loads(message)
+            except (json.JSONDecodeError, ValueError):
+                return message
+            return self._first_text_from_list(parsed) or message
+        if isinstance(message, list):
+            return self._first_text_from_list(message) or str(message)
+        return str(message)
 
     def _convert_agent_invocation(self, obs: Any, session_id: str) -> AgentInvocationSpan:
         """Convert an agent observation to an AgentInvocationSpan.

--- a/tests/strands_evals/providers/test_langfuse_provider.py
+++ b/tests/strands_evals/providers/test_langfuse_provider.py
@@ -718,6 +718,67 @@ class TestLangChainToolType:
         assert tools[0].tool_call.arguments == {"q": "weather"}
         assert tools[0].tool_result.content == "Sunny and 72F"
 
+    def test_tool_type_strands_otel_list_input_dict_content(self, provider, mock_client):
+        """TOOL list input with dict content returns the dict as-is."""
+        spans = self._get_spans(
+            provider,
+            mock_client,
+            [
+                _obs(
+                    "o-tool",
+                    "t1",
+                    "TOOL",
+                    name="search",
+                    obs_input=[{"role": "tool", "content": {"q": "weather"}}],
+                    obs_output="ok",
+                ),
+                _obs("o-agent", "t1", "SPAN", name="invoke_agent a", obs_input=[{"text": "q"}], obs_output="a"),
+            ],
+        )
+        tools = [s for s in spans if isinstance(s, ToolExecutionSpan)]
+        assert tools[0].tool_call.arguments == {"q": "weather"}
+
+    def test_tool_type_strands_otel_list_input_no_content(self, provider, mock_client):
+        """TOOL list input where no item carries a content field falls back to str(input)."""
+        spans = self._get_spans(
+            provider,
+            mock_client,
+            [
+                _obs(
+                    "o-tool",
+                    "t1",
+                    "TOOL",
+                    name="echo",
+                    obs_input=[{"role": "tool", "id": "tooluse_x"}],
+                    obs_output="ok",
+                ),
+                _obs("o-agent", "t1", "SPAN", name="invoke_agent a", obs_input=[{"text": "q"}], obs_output="a"),
+            ],
+        )
+        tools = [s for s in spans if isinstance(s, ToolExecutionSpan)]
+        assert tools[0].tool_call.arguments == {"input": "[{'role': 'tool', 'id': 'tooluse_x'}]"}
+
+    def test_tool_type_strands_otel_message_output_list(self, provider, mock_client):
+        """TOOL output with a list-typed message extracts the first text block."""
+        spans = self._get_spans(
+            provider,
+            mock_client,
+            [
+                _obs(
+                    "o-tool",
+                    "t1",
+                    "TOOL",
+                    name="search",
+                    obs_input=[{"role": "tool", "content": '{"q": "weather"}'}],
+                    obs_output={"message": [{"text": "Sunny and 72F"}]},
+                ),
+                _obs("o-agent", "t1", "SPAN", name="invoke_agent a", obs_input=[{"text": "q"}], obs_output="a"),
+            ],
+        )
+        tools = [s for s in spans if isinstance(s, ToolExecutionSpan)]
+        assert tools[0].tool_result.content == "Sunny and 72F"
+        assert tools[0].tool_result.error is None
+
 
 class TestLangChainChainType:
     """CHAIN-type observations from LangChain via Langfuse."""

--- a/tests/strands_evals/providers/test_langfuse_provider.py
+++ b/tests/strands_evals/providers/test_langfuse_provider.py
@@ -648,6 +648,76 @@ class TestLangChainToolType:
         assert tools[0].tool_call.name == "echo"
         assert tools[0].tool_call.arguments == {"input": "hello"}
 
+    def test_tool_type_strands_otel_list_input(self, provider, mock_client):
+        """TOOL with Strands OTEL list input parses arguments from item content (issue #312)."""
+        spans = self._get_spans(
+            provider,
+            mock_client,
+            [
+                _obs(
+                    "o-tool",
+                    "t1",
+                    "TOOL",
+                    name="bsm-get-case",
+                    obs_input=[
+                        {
+                            "role": "tool",
+                            "content": '{"caseId": "abc123", "marketplaceId": "ATVPDKIKX0DER"}',
+                            "id": "tooluse_x",
+                        }
+                    ],
+                    obs_output={"message": '[{"text": "Data stored under key bsm-get-case (9 fields)"}]'},
+                ),
+                _obs("o-agent", "t1", "SPAN", name="invoke_agent a", obs_input=[{"text": "q"}], obs_output="a"),
+            ],
+        )
+        tools = [s for s in spans if isinstance(s, ToolExecutionSpan)]
+        assert tools[0].tool_call.name == "bsm-get-case"
+        assert tools[0].tool_call.arguments == {"caseId": "abc123", "marketplaceId": "ATVPDKIKX0DER"}
+        assert tools[0].tool_result.content == "Data stored under key bsm-get-case (9 fields)"
+        assert tools[0].tool_result.error is None
+
+    def test_tool_type_strands_otel_list_input_non_json_content(self, provider, mock_client):
+        """TOOL list input with non-JSON content wraps it as {"input": content}."""
+        spans = self._get_spans(
+            provider,
+            mock_client,
+            [
+                _obs(
+                    "o-tool",
+                    "t1",
+                    "TOOL",
+                    name="echo",
+                    obs_input=[{"role": "tool", "content": "just a string"}],
+                    obs_output="ok",
+                ),
+                _obs("o-agent", "t1", "SPAN", name="invoke_agent a", obs_input=[{"text": "q"}], obs_output="a"),
+            ],
+        )
+        tools = [s for s in spans if isinstance(s, ToolExecutionSpan)]
+        assert tools[0].tool_call.arguments == {"input": "just a string"}
+
+    def test_tool_type_strands_otel_message_output_plain_string(self, provider, mock_client):
+        """TOOL output with a plain-string message key falls back to the raw string."""
+        spans = self._get_spans(
+            provider,
+            mock_client,
+            [
+                _obs(
+                    "o-tool",
+                    "t1",
+                    "TOOL",
+                    name="search",
+                    obs_input=[{"role": "tool", "content": '{"q": "weather"}'}],
+                    obs_output={"message": "Sunny and 72F"},
+                ),
+                _obs("o-agent", "t1", "SPAN", name="invoke_agent a", obs_input=[{"text": "q"}], obs_output="a"),
+            ],
+        )
+        tools = [s for s in spans if isinstance(s, ToolExecutionSpan)]
+        assert tools[0].tool_call.arguments == {"q": "weather"}
+        assert tools[0].tool_result.content == "Sunny and 72F"
+
 
 class TestLangChainChainType:
     """CHAIN-type observations from LangChain via Langfuse."""


### PR DESCRIPTION
## Description

`LangfuseProvider._convert_tool_execution` lost tool data for Strands agents instrumented via the standard OTEL → Langfuse pipeline. 

For these traces, `obs.type == "TOOL"` observations arrive as:
- `obs.input` = a **list**: `[{"role": "tool", "content": "<JSON args>", "id": "tooluse_..."}]`
- `obs.output` = `{"message": "<JSON string of [{\"text\": ...}]>", "id": "tooluse_..."}`

The `elif obs.type == "TOOL"` branch only handled `dict` and `str` inputs, so a list fell through to `{"input": str(obs_input)}`

### Changes

- Add a `list` branch to `_convert_tool_execution`, delegating to a new `_parse_tool_arguments_from_list` helper.
  - It extracts the first message item's `content`, parses it as JSON when it's a string, and falls back to `{"input": ...}` for non-JSON content.
- Add a `"message"`-key branch to `_parse_tool_result`, delegating to a new `_parse_tool_result_message` helper that JSON-decodes the message and extracts the first `text` block (reusing `_first_text_from_list`), falling back to the raw string when the shape doesn't match.

Existing `dict` / `str` handling and the native Strands `SPAN` (`execute_tool`) path are unchanged.

## Related Issues

Fixes #312

## Documentation PR

N/A

## Type of Change

Bug fix

## Testing
- Tested end-to-end with sending the traces to langfuse and load them back via the provider.
- [s] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
