### PR TITLE
fix: detect_otel_mapper checks all spans for body in CloudWatch split format

### DIFF
--- a/src/strands_evals/mappers/utils.py
+++ b/src/strands_evals/mappers/utils.py
@@ -109,7 +109,9 @@ def detect_otel_mapper(spans: list[Any]) -> SessionMapper:
 
         if scope_name == SCOPE_STRANDS:
             # Auto-detect format for Strands
-            if get_body(span) is not None:
+            # Check ALL spans for body — CloudWatch split format has body
+            # on a separate entry from the scope entry
+            if any(get_body(s) is not None for s in spans):
                 return CloudWatchSessionMapper()
             else:
                 return StrandsInMemorySessionMapper()

--- a/src/strands_evals/mappers/utils.py
+++ b/src/strands_evals/mappers/utils.py
@@ -108,13 +108,10 @@ def detect_otel_mapper(spans: list[Any]) -> SessionMapper:
             return OpenInferenceSessionMapper()
 
         if scope_name == SCOPE_STRANDS:
-            # Auto-detect format for Strands
-            # Check ALL spans for body — CloudWatch split format has body
-            # on a separate entry from the scope entry
-            if any(get_body(s) is not None for s in spans):
-                return CloudWatchSessionMapper()
-            else:
-                return StrandsInMemorySessionMapper()
+            # CloudWatch split format puts body on a separate entry from
+            # the scoped metadata entry. Break here and let the fallback
+            # body-scan below determine CloudWatch vs InMemory.
+            break
 
     # Fallback: check if spans use the CloudWatch body format (no scope.name
     # but have body.input/output structure). This handles raw CloudWatch

--- a/tests/strands_evals/mappers/test_utils.py
+++ b/tests/strands_evals/mappers/test_utils.py
@@ -178,6 +178,25 @@ class TestDetectOtelMapper:
         mapper = detect_otel_mapper(spans)
         assert isinstance(mapper, CloudWatchSessionMapper)
 
+    def test_detects_strands_cloudwatch_split_format(self):
+        """CloudWatch split format: Strands scope entry has no body, a later
+        entry carries the body — must still route to CloudWatchSessionMapper."""
+        spans = [
+            # Entry 1: metadata — Strands scope, no body
+            make_span_dict(
+                scope_name="strands.telemetry.tracer",
+                attributes={"gen_ai.operation.name": "invoke_agent"},
+            ),
+            # Entry 2: log event — body with input/output, no scope
+            {
+                "trace_id": "trace-1",
+                "span_id": "span-1",
+                "body": {"input": {"messages": []}, "output": {"messages": []}},
+            },
+        ]
+        mapper = detect_otel_mapper(spans)
+        assert isinstance(mapper, CloudWatchSessionMapper)
+
     def test_detects_strands_in_memory_format(self):
         """Detects StrandsInMemorySessionMapper for strands scope without body format."""
         spans = [


### PR DESCRIPTION
## Description

  In CloudWatch split format, each span produces two separate log entries:
  1. Span metadata (has `scope.name` but no `body`)
  2. Log event (has `body` with input/output messages)

  `detect_otel_mapper` checks `get_body(span)` on the first Strands-scoped span only. Since that's always the
  metadata entry (no body), it incorrectly returns `StrandsInMemorySessionMapper` instead of
  `CloudWatchSessionMapper`, which then crashes with `AttributeError: 'dict' object has no attribute
  'attributes'`.

  **Example:**
  Entry 1: {"spanId": "s1", "scope": {"name": "strands.telemetry.tracer"}, "attributes": {...}}  ← NO body
  Entry 2: {"spanId": "s1", "body": {"input": {...}, "output": {...}}}                           ← HAS body

  `detect_otel_mapper` hits Entry 1 first → scope is Strands → `get_body(Entry 1)` = None → returns
  `StrandsInMemorySessionMapper` → CRASH: `'dict' has no attribute 'attributes'`
  It never checks Entry 2 (which has the body).

  **Fix:** When Strands scope is detected, `break` out of the scope-detection loop and fall through to the
  existing body-scan fallback (lines 119-124) which already checks all spans for body. This avoids a nested scan
  while correctly routing to `CloudWatchSessionMapper`.

  ## Related Issues

  N/A

  ## Documentation PR

  N/A

  ## Type of Change

  Bug fix

  ## Testing

  - Added regression test: `test_detects_strands_cloudwatch_split_format` — verifies split-format spans (scope
  entry without body + separate body entry) correctly route to `CloudWatchSessionMapper`
  - All 42 existing tests passing
  - Verified locally: CloudWatch split-format spans now correctly route to `CloudWatchSessionMapper`
  - Workaround currently in bedrock-agentcore-sdk-python PR #568 (can be removed once this fix ships)

  ## Checklist
  - [x] I have read the CONTRIBUTING document
  can explain why it works
  - [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
  - [x] I have added any necessary tests that prove my fix is effective or my feature works
  - [x] I have updated the documentation accordingly
  - [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are
  needed
  - [x] My changes generate no new warnings
  - [x] Any dependent changes have been merged and published

  ----
  
  By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution,
  under the terms of your choice.