### PR TITLE
feat(evaluators): allow custom tools on judge-based evaluators (Trajectory, Output, Multimodal)

### DIFF
--- a/src/strands_evals/evaluators/multimodal_correctness_evaluator.py
+++ b/src/strands_evals/evaluators/multimodal_correctness_evaluator.py
@@ -25,6 +25,7 @@ class MultimodalCorrectnessEvaluator(MultimodalOutputEvaluator):
         reference_suffix: str | None = None,
         uses_environment_state: bool = False,
         name: str | None = None,
+        tools: list | None = None,
     ):
         super().__init__(
             rubric=rubric if rubric is not None else CORRECTNESS_RUBRIC_V0,
@@ -34,4 +35,5 @@ class MultimodalCorrectnessEvaluator(MultimodalOutputEvaluator):
             reference_suffix=reference_suffix,
             uses_environment_state=uses_environment_state,
             name=name,
+            tools=tools,
         )

--- a/src/strands_evals/evaluators/multimodal_faithfulness_evaluator.py
+++ b/src/strands_evals/evaluators/multimodal_faithfulness_evaluator.py
@@ -24,6 +24,7 @@ class MultimodalFaithfulnessEvaluator(MultimodalOutputEvaluator):
         reference_suffix: str | None = None,
         uses_environment_state: bool = False,
         name: str | None = None,
+        tools: list | None = None,
     ):
         super().__init__(
             rubric=rubric if rubric is not None else FAITHFULNESS_RUBRIC_V0,
@@ -33,4 +34,5 @@ class MultimodalFaithfulnessEvaluator(MultimodalOutputEvaluator):
             reference_suffix=reference_suffix,
             uses_environment_state=uses_environment_state,
             name=name,
+            tools=tools,
         )

--- a/src/strands_evals/evaluators/multimodal_instruction_following_evaluator.py
+++ b/src/strands_evals/evaluators/multimodal_instruction_following_evaluator.py
@@ -24,6 +24,7 @@ class MultimodalInstructionFollowingEvaluator(MultimodalOutputEvaluator):
         reference_suffix: str | None = None,
         uses_environment_state: bool = False,
         name: str | None = None,
+        tools: list | None = None,
     ):
         super().__init__(
             rubric=rubric if rubric is not None else INSTRUCTION_FOLLOWING_RUBRIC_V0,
@@ -33,4 +34,5 @@ class MultimodalInstructionFollowingEvaluator(MultimodalOutputEvaluator):
             reference_suffix=reference_suffix,
             uses_environment_state=uses_environment_state,
             name=name,
+            tools=tools,
         )

--- a/src/strands_evals/evaluators/multimodal_output_evaluator.py
+++ b/src/strands_evals/evaluators/multimodal_output_evaluator.py
@@ -46,6 +46,7 @@ REFERENCE COMPARISON:
         reference_suffix: str | None = None,
         uses_environment_state: bool = False,
         name: str | None = None,
+        tools: list | None = None,
     ):
         super().__init__(
             rubric=rubric,
@@ -54,6 +55,7 @@ REFERENCE COMPARISON:
             include_inputs=include_inputs,
             uses_environment_state=uses_environment_state,
             name=name,
+            tools=tools,
         )
         self.reference_suffix = reference_suffix if reference_suffix is not None else self.DEFAULT_REFERENCE_SUFFIX
 

--- a/src/strands_evals/evaluators/multimodal_overall_quality_evaluator.py
+++ b/src/strands_evals/evaluators/multimodal_overall_quality_evaluator.py
@@ -35,6 +35,7 @@ class MultimodalOverallQualityEvaluator(MultimodalOutputEvaluator):
         reference_suffix: str | None = None,
         uses_environment_state: bool = False,
         name: str | None = None,
+        tools: list | None = None,
     ):
         super().__init__(
             rubric=rubric if rubric is not None else OVERALL_QUALITY_RUBRIC_V0,
@@ -44,4 +45,5 @@ class MultimodalOverallQualityEvaluator(MultimodalOutputEvaluator):
             reference_suffix=reference_suffix if reference_suffix is not None else _OVERALL_QUALITY_REFERENCE_SUFFIX,
             uses_environment_state=uses_environment_state,
             name=name,
+            tools=tools,
         )

--- a/src/strands_evals/evaluators/output_evaluator.py
+++ b/src/strands_evals/evaluators/output_evaluator.py
@@ -31,8 +31,8 @@ class OutputEvaluator(Evaluator[InputT, OutputT]):
         system_prompt: str = SYSTEM_PROMPT,
         include_inputs: bool = True,
         uses_environment_state: bool = False,
-        tools: list[Any] | None = None,
         name: str | None = None,
+        tools: list[Any] | None = None,
     ):
         super().__init__(name=name)
         self.rubric = rubric
@@ -40,7 +40,7 @@ class OutputEvaluator(Evaluator[InputT, OutputT]):
         self.include_inputs = include_inputs
         self.system_prompt = system_prompt
         self.uses_environment_state = uses_environment_state
-        self._tools = tools
+        self.tools = tools
 
     def _build_prompt(self, evaluation_case: EvaluationData[InputT, OutputT]) -> str | list:
         """Build the evaluation prompt for a test case.
@@ -70,17 +70,12 @@ class OutputEvaluator(Evaluator[InputT, OutputT]):
         Returns:
             The results of the evaluation as EvaluationOutput.
         """
-        evaluator_agent = self._create_evaluator_agent()
+        evaluator_agent = Agent(
+            model=self.model, tools=self.tools, system_prompt=self.system_prompt, callback_handler=None
+        )
         evaluation_prompt = self._build_prompt(evaluation_case)
         result = evaluator_agent(evaluation_prompt, structured_output_model=EvaluationOutput)
         return [cast(EvaluationOutput, result.structured_output)]
-
-    def _create_evaluator_agent(self) -> Agent:
-        """Create the judge agent, including custom tools when provided."""
-        kwargs: dict[str, Any] = {"model": self.model, "system_prompt": self.system_prompt, "callback_handler": None}
-        if self._tools:
-            kwargs["tools"] = self._tools
-        return Agent(**kwargs)
 
     async def evaluate_async(self, evaluation_case: EvaluationData[InputT, OutputT]) -> list[EvaluationOutput]:
         """
@@ -92,7 +87,9 @@ class OutputEvaluator(Evaluator[InputT, OutputT]):
         Returns:
             The results of the evaluation as EvaluationOutput.
         """
-        evaluator_agent = self._create_evaluator_agent()
+        evaluator_agent = Agent(
+            model=self.model, tools=self.tools, system_prompt=self.system_prompt, callback_handler=None
+        )
         evaluation_prompt = self._build_prompt(evaluation_case)
         result = await evaluator_agent.invoke_async(evaluation_prompt, structured_output_model=EvaluationOutput)
         return [cast(EvaluationOutput, result.structured_output)]

--- a/src/strands_evals/evaluators/output_evaluator.py
+++ b/src/strands_evals/evaluators/output_evaluator.py
@@ -1,4 +1,4 @@
-from typing import cast
+from typing import Any, cast
 
 from strands import Agent
 from strands.models.model import Model
@@ -20,6 +20,8 @@ class OutputEvaluator(Evaluator[InputT, OutputT]):
         system_prompt: System prompt to guide model behavior.
                     If None, the evaluator will use one of the default template.
         include_inputs: Whether to include inputs to the task in the evaluation or not.
+        tools: Optional tools for the evaluator agent (e.g., domain-specific verification
+                    functions the judge can call). Defaults to None (no tools).
     """
 
     def __init__(
@@ -29,6 +31,7 @@ class OutputEvaluator(Evaluator[InputT, OutputT]):
         system_prompt: str = SYSTEM_PROMPT,
         include_inputs: bool = True,
         uses_environment_state: bool = False,
+        tools: list[Any] | None = None,
         name: str | None = None,
     ):
         super().__init__(name=name)
@@ -37,6 +40,7 @@ class OutputEvaluator(Evaluator[InputT, OutputT]):
         self.include_inputs = include_inputs
         self.system_prompt = system_prompt
         self.uses_environment_state = uses_environment_state
+        self._tools = tools
 
     def _build_prompt(self, evaluation_case: EvaluationData[InputT, OutputT]) -> str | list:
         """Build the evaluation prompt for a test case.
@@ -66,10 +70,17 @@ class OutputEvaluator(Evaluator[InputT, OutputT]):
         Returns:
             The results of the evaluation as EvaluationOutput.
         """
-        evaluator_agent = Agent(model=self.model, system_prompt=self.system_prompt, callback_handler=None)
+        evaluator_agent = self._create_evaluator_agent()
         evaluation_prompt = self._build_prompt(evaluation_case)
         result = evaluator_agent(evaluation_prompt, structured_output_model=EvaluationOutput)
         return [cast(EvaluationOutput, result.structured_output)]
+
+    def _create_evaluator_agent(self) -> Agent:
+        """Create the judge agent, including custom tools when provided."""
+        kwargs: dict[str, Any] = {"model": self.model, "system_prompt": self.system_prompt, "callback_handler": None}
+        if self._tools:
+            kwargs["tools"] = self._tools
+        return Agent(**kwargs)
 
     async def evaluate_async(self, evaluation_case: EvaluationData[InputT, OutputT]) -> list[EvaluationOutput]:
         """
@@ -81,7 +92,7 @@ class OutputEvaluator(Evaluator[InputT, OutputT]):
         Returns:
             The results of the evaluation as EvaluationOutput.
         """
-        evaluator_agent = Agent(model=self.model, system_prompt=self.system_prompt, callback_handler=None)
+        evaluator_agent = self._create_evaluator_agent()
         evaluation_prompt = self._build_prompt(evaluation_case)
         result = await evaluator_agent.invoke_async(evaluation_prompt, structured_output_model=EvaluationOutput)
         return [cast(EvaluationOutput, result.structured_output)]

--- a/src/strands_evals/evaluators/trajectory_evaluator.py
+++ b/src/strands_evals/evaluators/trajectory_evaluator.py
@@ -34,18 +34,19 @@ class TrajectoryEvaluator(Evaluator[InputT, OutputT]):
         model: Model | str | None = None,
         system_prompt: str = SYSTEM_PROMPT,
         include_inputs: bool = True,
-        tools: list[Any] | None = None,
         name: str | None = None,
+        tools: list[Any] | None = None,
     ):
         super().__init__(name=name)
         self.rubric = rubric
         self.trajectory_description = trajectory_description
         self.model = model
         self.include_inputs = include_inputs
-        self._tools: list[str | dict[str, str] | Any] | None = list(tools or []) + [
+        self._tools: list[str | dict[str, str] | Any] = [
             exact_match_scorer,
             in_order_match_scorer,
             any_order_match_scorer,
+            *(tools or []),
         ]
         self.system_prompt = system_prompt
 

--- a/src/strands_evals/evaluators/trajectory_evaluator.py
+++ b/src/strands_evals/evaluators/trajectory_evaluator.py
@@ -23,6 +23,8 @@ class TrajectoryEvaluator(Evaluator[InputT, OutputT]):
         system_prompt: System prompt to guide model behavior.
                     If None, the evaluator will use one of the default template.
         include_inputs: Whether to include inputs to the task in the evaluation or not.
+        tools: Optional additional tools for the evaluator agent. Merged with the
+                    default trajectory scoring tools (exact/in-order/any-order match).
     """
 
     def __init__(
@@ -32,6 +34,7 @@ class TrajectoryEvaluator(Evaluator[InputT, OutputT]):
         model: Model | str | None = None,
         system_prompt: str = SYSTEM_PROMPT,
         include_inputs: bool = True,
+        tools: list[Any] | None = None,
         name: str | None = None,
     ):
         super().__init__(name=name)
@@ -39,7 +42,7 @@ class TrajectoryEvaluator(Evaluator[InputT, OutputT]):
         self.trajectory_description = trajectory_description
         self.model = model
         self.include_inputs = include_inputs
-        self._tools: list[str | dict[str, str] | Any] | None = [
+        self._tools: list[str | dict[str, str] | Any] | None = list(tools or []) + [
             exact_match_scorer,
             in_order_match_scorer,
             any_order_match_scorer,

--- a/tests/strands_evals/evaluators/test_output_evaluator.py
+++ b/tests/strands_evals/evaluators/test_output_evaluator.py
@@ -70,7 +70,9 @@ def test_output_evaluator_evaluate_with_inputs(mock_agent_class, evaluation_data
     result = evaluator.evaluate(evaluation_data)
 
     # Verify Agent was created with correct parameters
-    mock_agent_class.assert_called_once_with(model=None, system_prompt=evaluator.system_prompt, callback_handler=None)
+    mock_agent_class.assert_called_once_with(
+        model=None, tools=None, system_prompt=evaluator.system_prompt, callback_handler=None
+    )
 
     # Verify agent was called
     mock_agent.assert_called_once()
@@ -148,7 +150,9 @@ async def test_output_evaluator_evaluate_async_with_inputs(mock_agent_class, eva
     result = await evaluator.evaluate_async(evaluation_data)
 
     # Verify Agent was created with correct parameters
-    mock_agent_class.assert_called_once_with(model=None, system_prompt=evaluator.system_prompt, callback_handler=None)
+    mock_agent_class.assert_called_once_with(
+        model=None, tools=None, system_prompt=evaluator.system_prompt, callback_handler=None
+    )
 
     assert len(result) == 1
     assert result[0].score == 0.8
@@ -269,14 +273,14 @@ def test_output_evaluator_init_with_tools():
 
     evaluator = OutputEvaluator(rubric="Test rubric", tools=[verify_claim])
 
-    assert evaluator._tools == [verify_claim]
+    assert evaluator.tools == [verify_claim]
 
 
 def test_output_evaluator_init_without_tools_defaults_to_none():
     """Test OutputEvaluator has no tools by default (current behavior preserved)"""
     evaluator = OutputEvaluator(rubric="Test rubric")
 
-    assert evaluator._tools is None
+    assert evaluator.tools is None
 
 
 @patch("strands_evals.evaluators.output_evaluator.Agent")
@@ -292,20 +296,9 @@ def test_output_evaluator_evaluate_passes_tools_to_agent(mock_agent_class, evalu
     result = evaluator.evaluate(evaluation_data)
 
     mock_agent_class.assert_called_once_with(
-        model=None, system_prompt=evaluator.system_prompt, callback_handler=None, tools=[verify_claim]
+        model=None, tools=[verify_claim], system_prompt=evaluator.system_prompt, callback_handler=None
     )
     assert result[0].score == 0.8
-
-
-@patch("strands_evals.evaluators.output_evaluator.Agent")
-def test_output_evaluator_evaluate_without_tools_omits_tools_kwarg(mock_agent_class, evaluation_data, mock_agent):
-    """Test that no tools kwarg is passed when tools are not provided (backward compatible)"""
-    mock_agent_class.return_value = mock_agent
-    evaluator = OutputEvaluator(rubric="Test rubric")
-
-    evaluator.evaluate(evaluation_data)
-
-    mock_agent_class.assert_called_once_with(model=None, system_prompt=evaluator.system_prompt, callback_handler=None)
 
 
 @pytest.mark.asyncio
@@ -324,6 +317,6 @@ async def test_output_evaluator_evaluate_async_passes_tools_to_agent(
     result = await evaluator.evaluate_async(evaluation_data)
 
     mock_agent_class.assert_called_once_with(
-        model=None, system_prompt=evaluator.system_prompt, callback_handler=None, tools=[verify_claim]
+        model=None, tools=[verify_claim], system_prompt=evaluator.system_prompt, callback_handler=None
     )
     assert result[0].score == 0.8

--- a/tests/strands_evals/evaluators/test_output_evaluator.py
+++ b/tests/strands_evals/evaluators/test_output_evaluator.py
@@ -259,3 +259,71 @@ async def test_output_evaluator_evaluate_async_includes_environment_state(mock_a
 
     assert len(result) == 1
     assert result[0].test_pass is True
+
+
+def test_output_evaluator_init_with_tools():
+    """Test OutputEvaluator initialization with custom tools"""
+
+    def verify_claim(claim: str) -> str:
+        return "verified"
+
+    evaluator = OutputEvaluator(rubric="Test rubric", tools=[verify_claim])
+
+    assert evaluator._tools == [verify_claim]
+
+
+def test_output_evaluator_init_without_tools_defaults_to_none():
+    """Test OutputEvaluator has no tools by default (current behavior preserved)"""
+    evaluator = OutputEvaluator(rubric="Test rubric")
+
+    assert evaluator._tools is None
+
+
+@patch("strands_evals.evaluators.output_evaluator.Agent")
+def test_output_evaluator_evaluate_passes_tools_to_agent(mock_agent_class, evaluation_data, mock_agent):
+    """Test that custom tools are passed to the evaluator agent"""
+    mock_agent_class.return_value = mock_agent
+
+    def verify_claim(claim: str) -> str:
+        return "verified"
+
+    evaluator = OutputEvaluator(rubric="Test rubric", tools=[verify_claim])
+
+    result = evaluator.evaluate(evaluation_data)
+
+    mock_agent_class.assert_called_once_with(
+        model=None, system_prompt=evaluator.system_prompt, callback_handler=None, tools=[verify_claim]
+    )
+    assert result[0].score == 0.8
+
+
+@patch("strands_evals.evaluators.output_evaluator.Agent")
+def test_output_evaluator_evaluate_without_tools_omits_tools_kwarg(mock_agent_class, evaluation_data, mock_agent):
+    """Test that no tools kwarg is passed when tools are not provided (backward compatible)"""
+    mock_agent_class.return_value = mock_agent
+    evaluator = OutputEvaluator(rubric="Test rubric")
+
+    evaluator.evaluate(evaluation_data)
+
+    mock_agent_class.assert_called_once_with(model=None, system_prompt=evaluator.system_prompt, callback_handler=None)
+
+
+@pytest.mark.asyncio
+@patch("strands_evals.evaluators.output_evaluator.Agent")
+async def test_output_evaluator_evaluate_async_passes_tools_to_agent(
+    mock_agent_class, evaluation_data, mock_async_agent
+):
+    """Test that custom tools are passed to the evaluator agent in async path"""
+    mock_agent_class.return_value = mock_async_agent
+
+    def verify_claim(claim: str) -> str:
+        return "verified"
+
+    evaluator = OutputEvaluator(rubric="Test rubric", tools=[verify_claim])
+
+    result = await evaluator.evaluate_async(evaluation_data)
+
+    mock_agent_class.assert_called_once_with(
+        model=None, system_prompt=evaluator.system_prompt, callback_handler=None, tools=[verify_claim]
+    )
+    assert result[0].score == 0.8

--- a/tests/strands_evals/evaluators/test_trajectory_evaluator.py
+++ b/tests/strands_evals/evaluators/test_trajectory_evaluator.py
@@ -258,7 +258,7 @@ def test_trajectory_evaluator_update_trajectory_description():
 
 
 def test_trajectory_evaluator_init_with_tools_merges_with_defaults():
-    """Test that custom tools are merged with the default scoring tools"""
+    """Test that custom tools are appended after the default scoring tools"""
     from strands_evals.tools.evaluation_tools import (
         any_order_match_scorer,
         exact_match_scorer,
@@ -270,7 +270,7 @@ def test_trajectory_evaluator_init_with_tools_merges_with_defaults():
 
     evaluator = TrajectoryEvaluator(rubric="Test rubric", tools=[verify_step])
 
-    assert evaluator._tools == [verify_step, exact_match_scorer, in_order_match_scorer, any_order_match_scorer]
+    assert evaluator._tools == [exact_match_scorer, in_order_match_scorer, any_order_match_scorer, verify_step]
 
 
 def test_trajectory_evaluator_init_without_tools_keeps_default_scorers():
@@ -288,7 +288,13 @@ def test_trajectory_evaluator_init_without_tools_keeps_default_scorers():
 
 @patch("strands_evals.evaluators.trajectory_evaluator.Agent")
 def test_trajectory_evaluator_evaluate_passes_custom_tools_to_agent(mock_agent_class, evaluation_data, mock_agent):
-    """Test that merged tools (custom + defaults) reach the evaluator agent"""
+    """Test that merged tools (defaults + custom) reach the evaluator agent"""
+    from strands_evals.tools.evaluation_tools import (
+        any_order_match_scorer,
+        exact_match_scorer,
+        in_order_match_scorer,
+    )
+
     mock_agent_class.return_value = mock_agent
 
     def verify_step(step: str) -> str:
@@ -299,7 +305,9 @@ def test_trajectory_evaluator_evaluate_passes_custom_tools_to_agent(mock_agent_c
     result = evaluator.evaluate(evaluation_data)
 
     mock_agent_class.assert_called_once_with(
-        model=None, system_prompt=evaluator.system_prompt, tools=evaluator._tools, callback_handler=None
+        model=None,
+        system_prompt=evaluator.system_prompt,
+        tools=[exact_match_scorer, in_order_match_scorer, any_order_match_scorer, verify_step],
+        callback_handler=None,
     )
-    assert verify_step in mock_agent_class.call_args[1]["tools"]
     assert result[0].score == 0.9

--- a/tests/strands_evals/evaluators/test_trajectory_evaluator.py
+++ b/tests/strands_evals/evaluators/test_trajectory_evaluator.py
@@ -255,3 +255,51 @@ def test_trajectory_evaluator_update_trajectory_description():
     evaluator.update_trajectory_description(new_description)
 
     assert evaluator.trajectory_description == new_description
+
+
+def test_trajectory_evaluator_init_with_tools_merges_with_defaults():
+    """Test that custom tools are merged with the default scoring tools"""
+    from strands_evals.tools.evaluation_tools import (
+        any_order_match_scorer,
+        exact_match_scorer,
+        in_order_match_scorer,
+    )
+
+    def verify_step(step: str) -> str:
+        return "valid"
+
+    evaluator = TrajectoryEvaluator(rubric="Test rubric", tools=[verify_step])
+
+    assert evaluator._tools == [verify_step, exact_match_scorer, in_order_match_scorer, any_order_match_scorer]
+
+
+def test_trajectory_evaluator_init_without_tools_keeps_default_scorers():
+    """Test that default scoring tools are unchanged when no custom tools are provided"""
+    from strands_evals.tools.evaluation_tools import (
+        any_order_match_scorer,
+        exact_match_scorer,
+        in_order_match_scorer,
+    )
+
+    evaluator = TrajectoryEvaluator(rubric="Test rubric")
+
+    assert evaluator._tools == [exact_match_scorer, in_order_match_scorer, any_order_match_scorer]
+
+
+@patch("strands_evals.evaluators.trajectory_evaluator.Agent")
+def test_trajectory_evaluator_evaluate_passes_custom_tools_to_agent(mock_agent_class, evaluation_data, mock_agent):
+    """Test that merged tools (custom + defaults) reach the evaluator agent"""
+    mock_agent_class.return_value = mock_agent
+
+    def verify_step(step: str) -> str:
+        return "valid"
+
+    evaluator = TrajectoryEvaluator(rubric="Test rubric", tools=[verify_step])
+
+    result = evaluator.evaluate(evaluation_data)
+
+    mock_agent_class.assert_called_once_with(
+        model=None, system_prompt=evaluator.system_prompt, tools=evaluator._tools, callback_handler=None
+    )
+    assert verify_step in mock_agent_class.call_args[1]["tools"]
+    assert result[0].score == 0.9


### PR DESCRIPTION
Closes #322

## Description

Adds an optional `tools=` constructor parameter so the judge agent can call domain-specific verification functions during evaluation. Follows the same opt-in pattern accepted for `ToolSimulator` in #208 / #209.

Covered evaluators: `TrajectoryEvaluator`, `OutputEvaluator`, `MultimodalOutputEvaluator`, and its specialized subclasses (`MultimodalCorrectnessEvaluator`, `MultimodalFaithfulnessEvaluator`, `MultimodalInstructionFollowingEvaluator`, `MultimodalOverallQualityEvaluator`).

- **TrajectoryEvaluator**: user tools are appended after the default trajectory scoring tools (exact/in-order/any-order match), which are always retained.
- **OutputEvaluator**: `tools` defaults to `None`, preserving the current no-tools judge (`Agent` accepts `tools=None`).
- **Multimodal evaluators**: `MultimodalOutputEvaluator` accepts `tools` and forwards it to `OutputEvaluator`; the four specialized subclasses accept and forward it likewise, so tool-augmented judging works for multimodal rubrics too.

Non-breaking: `tools` is appended after `name` in every signature, so existing positional and keyword callers are unaffected; omitting it keeps current behavior exactly.

## Example

```python
from strands import tool
from strands_evals.evaluators import TrajectoryEvaluator

@tool
def verify_ticket_id(ticket_id: str) -> str:
    """Check whether a ticket ID matches the support system's format."""
    return "valid" if ticket_id.startswith("TKT-") else "invalid format"

evaluator = TrajectoryEvaluator(
    rubric="Verify the agent referenced only valid ticket IDs.",
    tools=[verify_ticket_id],
)
```

## Testing

- New unit tests: constructor defaults preserved, merged tools list asserted explicitly (trajectory), tools passed through to the judge agent (output, sync + async), and `tools=None` default verified.
- Full evaluator + experiment unit suites pass; `ruff check` and `ruff format` clean.

## Checklist

- [x] Non-breaking change
- [x] Unit tests added
- [x] Conventional commit
- [x] Lint/format clean
