### PR TITLE
fix: include prior tool results in session_history for tool-level evaluators

### DIFF
--- a/src/strands_evals/evaluators/evaluator.py
+++ b/src/strands_evals/evaluators/evaluator.py
@@ -207,7 +207,10 @@ class Evaluator(Generic[InputT, OutputT]):
                     # Handle tool execution lists
                     for tool_exec in msg:
                         history_lines.append(f"Tool call: {tool_exec.tool_call.name}({tool_exec.tool_call.arguments})")
-                        history_lines.append(f"Tool result: {tool_exec.tool_result.content}")
+                        if tool_exec.tool_result.error:
+                            history_lines.append(f"Tool result: ERROR - {tool_exec.tool_result.error}")
+                        else:
+                            history_lines.append(f"Tool result: {tool_exec.tool_result.content}")
                 else:
                     text = msg.content[0].text if msg.content and hasattr(msg.content[0], "text") else ""
                     history_lines.append(f"{msg.role.value.capitalize()}: {text}")
@@ -232,7 +235,10 @@ class Evaluator(Generic[InputT, OutputT]):
                     # Handle tool execution lists
                     for tool_exec in msg:
                         history_lines.append(f"Tool call: {tool_exec.tool_call.name}({tool_exec.tool_call.arguments})")
-                        history_lines.append(f"Tool result: {tool_exec.tool_result.content}")
+                        if tool_exec.tool_result.error:
+                            history_lines.append(f"Tool result: ERROR - {tool_exec.tool_result.error}")
+                        else:
+                            history_lines.append(f"Tool result: {tool_exec.tool_result.content}")
                 else:
                     text = msg.content[0].text if msg.content and hasattr(msg.content[0], "text") else ""
                     history_lines.append(f"{msg.role.value.capitalize()}: {text}")

--- a/src/strands_evals/evaluators/evaluator.py
+++ b/src/strands_evals/evaluators/evaluator.py
@@ -207,10 +207,7 @@ class Evaluator(Generic[InputT, OutputT]):
                     # Handle tool execution lists
                     for tool_exec in msg:
                         history_lines.append(f"Tool call: {tool_exec.tool_call.name}({tool_exec.tool_call.arguments})")
-                        if tool_exec.tool_result.error:
-                            history_lines.append(f"Tool result: ERROR - {tool_exec.tool_result.error}")
-                        else:
-                            history_lines.append(f"Tool result: {tool_exec.tool_result.content}")
+                        history_lines.append(f"Tool result: {tool_exec.tool_result.content}")
                 else:
                     text = msg.content[0].text if msg.content and hasattr(msg.content[0], "text") else ""
                     history_lines.append(f"{msg.role.value.capitalize()}: {text}")
@@ -235,10 +232,7 @@ class Evaluator(Generic[InputT, OutputT]):
                     # Handle tool execution lists
                     for tool_exec in msg:
                         history_lines.append(f"Tool call: {tool_exec.tool_call.name}({tool_exec.tool_call.arguments})")
-                        if tool_exec.tool_result.error:
-                            history_lines.append(f"Tool result: ERROR - {tool_exec.tool_result.error}")
-                        else:
-                            history_lines.append(f"Tool result: {tool_exec.tool_result.content}")
+                        history_lines.append(f"Tool result: {tool_exec.tool_result.content}")
                 else:
                     text = msg.content[0].text if msg.content and hasattr(msg.content[0], "text") else ""
                     history_lines.append(f"{msg.role.value.capitalize()}: {text}")

--- a/src/strands_evals/extractors/trace_extractor.py
+++ b/src/strands_evals/extractors/trace_extractor.py
@@ -110,11 +110,10 @@ class TraceExtractor:
                     )
                 )
 
-            if tool_spans:
-                tool_executions = [
-                    ToolExecution(tool_call=span.tool_call, tool_result=span.tool_result) for span in tool_spans
-                ]
-                session_history.append(tool_executions)
+                # Accumulate this tool's execution so subsequent tool spans see it
+                session_history.append(
+                    [ToolExecution(tool_call=tool_span.tool_call, tool_result=tool_span.tool_result)]
+                )
 
             if agent_span and agent_span.agent_response:
                 session_history.append(AssistantMessage(content=[TextContent(text=agent_span.agent_response)]))

--- a/src/strands_evals/extractors/trace_extractor.py
+++ b/src/strands_evals/extractors/trace_extractor.py
@@ -1,4 +1,5 @@
 import logging
+from datetime import datetime, timezone
 
 from ..types.trace import (
     AgentInvocationSpan,
@@ -18,6 +19,13 @@ from ..types.trace import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def _to_aware_utc(dt: datetime) -> datetime:
+    """Normalize a datetime to timezone-aware UTC."""
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=timezone.utc)
+    return dt
 
 
 class TraceExtractor:
@@ -108,7 +116,7 @@ class TraceExtractor:
                 prior_executions = [
                     ToolExecution(tool_call=span.tool_call, tool_result=span.tool_result)
                     for span in tool_spans[:index]
-                    if span.span_info.end_time <= tool_span.span_info.start_time
+                    if _to_aware_utc(span.span_info.end_time) <= _to_aware_utc(tool_span.span_info.start_time)
                 ]
 
                 evaluator_inputs.append(

--- a/src/strands_evals/extractors/trace_extractor.py
+++ b/src/strands_evals/extractors/trace_extractor.py
@@ -85,7 +85,11 @@ class TraceExtractor:
         return evaluation_inputs
 
     def _extract_tool_level(self, session: Session) -> list[ToolLevelInput]:
-        """Extract tool-level inputs with session and tool context."""
+        """Extract tool-level inputs with session and tool context.
+
+        Note: spans are not scoped by parent_span_id, so nested agent-as-tool traces
+        may leak child-agent internals into the parent's history.
+        """
         evaluator_inputs: list[ToolLevelInput] = []
         session_history: list[UserMessage | list[ToolExecution] | AssistantMessage] = []
         available_tools: list[ToolConfig] = []
@@ -100,20 +104,27 @@ class TraceExtractor:
             if agent_span and agent_span.user_prompt:
                 session_history.append(UserMessage(content=[TextContent(text=agent_span.user_prompt)]))
 
-            for tool_span in tool_spans:
+            for index, tool_span in enumerate(tool_spans):
+                prior_executions = [
+                    ToolExecution(tool_call=span.tool_call, tool_result=span.tool_result)
+                    for span in tool_spans[:index]
+                    if span.span_info.end_time <= tool_span.span_info.start_time
+                ]
+
                 evaluator_inputs.append(
                     ToolLevelInput(
                         span_info=tool_span.span_info,
                         available_tools=available_tools,
                         tool_execution_details=tool_span,
-                        session_history=list(session_history),
+                        session_history=list(session_history) + ([prior_executions] if prior_executions else []),
                     )
                 )
 
-                # Accumulate this tool's execution so subsequent tool spans see it
-                session_history.append(
-                    [ToolExecution(tool_call=tool_span.tool_call, tool_result=tool_span.tool_result)]
-                )
+            if tool_spans:
+                tool_executions = [
+                    ToolExecution(tool_call=span.tool_call, tool_result=span.tool_result) for span in tool_spans
+                ]
+                session_history.append(tool_executions)
 
             if agent_span and agent_span.agent_response:
                 session_history.append(AssistantMessage(content=[TextContent(text=agent_span.agent_response)]))

--- a/src/strands_evals/extractors/trace_extractor.py
+++ b/src/strands_evals/extractors/trace_extractor.py
@@ -115,7 +115,10 @@ class TraceExtractor:
             tool_executions = [
                 ToolExecution(tool_call=span.tool_call, tool_result=span.tool_result) for span in tool_spans
             ]
-            tool_end_times = [_to_aware_utc(span.span_info.end_time) for span in tool_spans]
+            tool_end_times = [
+                max(_to_aware_utc(span.span_info.end_time), _to_aware_utc(span.span_info.start_time))
+                for span in tool_spans
+            ]
 
             for index, tool_span in enumerate(tool_spans):
                 target_start = _to_aware_utc(tool_span.span_info.start_time)

--- a/src/strands_evals/extractors/trace_extractor.py
+++ b/src/strands_evals/extractors/trace_extractor.py
@@ -112,11 +112,19 @@ class TraceExtractor:
             if agent_span and agent_span.user_prompt:
                 session_history.append(UserMessage(content=[TextContent(text=agent_span.user_prompt)]))
 
+            tool_executions = [
+                ToolExecution(tool_call=span.tool_call, tool_result=span.tool_result) for span in tool_spans
+            ]
+            tool_end_times = [_to_aware_utc(span.span_info.end_time) for span in tool_spans]
+
             for index, tool_span in enumerate(tool_spans):
+                target_start = _to_aware_utc(tool_span.span_info.start_time)
                 prior_executions = [
-                    ToolExecution(tool_call=span.tool_call, tool_result=span.tool_result)
-                    for span in tool_spans[:index]
-                    if _to_aware_utc(span.span_info.end_time) <= _to_aware_utc(tool_span.span_info.start_time)
+                    tool_executions[position]
+                    for position in range(len(tool_spans))
+                    if position != index
+                    and tool_end_times[position] <= target_start
+                    and (tool_end_times[position] < target_start or position < index)
                 ]
 
                 evaluator_inputs.append(
@@ -129,9 +137,6 @@ class TraceExtractor:
                 )
 
             if tool_spans:
-                tool_executions = [
-                    ToolExecution(tool_call=span.tool_call, tool_result=span.tool_result) for span in tool_spans
-                ]
                 session_history.append(tool_executions)
 
             if agent_span and agent_span.agent_response:

--- a/src/strands_evals/types/trace.py
+++ b/src/strands_evals/types/trace.py
@@ -167,7 +167,12 @@ class TraceLevelInput(BaseEvaluationInput):
 
 
 class ToolLevelInput(BaseEvaluationInput):
-    """Input for tool-level evaluators"""
+    """Input for tool-level evaluators.
+
+    `session_history` is the context preceding `tool_execution_details` and never includes the
+    call under evaluation. Unlike `TraceLevelInput`, where each `list[ToolExecution]` entry is one
+    turn's whole batch, here each entry holds exactly one execution.
+    """
 
     available_tools: list[ToolConfig]
     tool_execution_details: ToolExecutionSpan

--- a/src/strands_evals/types/trace.py
+++ b/src/strands_evals/types/trace.py
@@ -170,8 +170,8 @@ class ToolLevelInput(BaseEvaluationInput):
     """Input for tool-level evaluators.
 
     `session_history` is the context preceding `tool_execution_details` and never includes the
-    call under evaluation. Unlike `TraceLevelInput`, where each `list[ToolExecution]` entry is one
-    turn's whole batch, here each entry holds exactly one execution.
+    call under evaluation. Tool executions that precede it within the same trace are appended as a
+    single `list[ToolExecution]` entry, in span order.
     """
 
     available_tools: list[ToolConfig]

--- a/src/strands_evals/types/trace.py
+++ b/src/strands_evals/types/trace.py
@@ -169,9 +169,9 @@ class TraceLevelInput(BaseEvaluationInput):
 class ToolLevelInput(BaseEvaluationInput):
     """Input for tool-level evaluators.
 
-    `session_history` is the context preceding `tool_execution_details` and never includes the
-    call under evaluation. Tool executions that precede it within the same trace are appended as a
-    single `list[ToolExecution]` entry, in span order.
+    `session_history` never includes the call under evaluation. Within the same trace, only tool
+    executions that completed before this tool started (`end_time <= start_time`) are included,
+    with list position as tiebreaker for equal timestamps. Cross-trace history is unfiltered.
     """
 
     available_tools: list[ToolConfig]

--- a/tests/strands_evals/extractors/test_trace_extractor.py
+++ b/tests/strands_evals/extractors/test_trace_extractor.py
@@ -157,3 +157,41 @@ def test_extract_empty_session_tool_level():
 
     assert isinstance(result, list)
     assert len(result) == 0
+
+
+def test_extract_tool_level_incremental_session_history():
+    """Test that each tool span sees prior tool results in session_history."""
+    now = datetime.now()
+    agent_span = AgentInvocationSpan(
+        span_info=SpanInfo(session_id="test", span_id="a0", start_time=now, end_time=now),
+        user_prompt="What is the square root of 1764, multiplied by 3?",
+        agent_response="126",
+        available_tools=[ToolConfig(name="square_root"), ToolConfig(name="multiply_numbers")],
+    )
+    tool_span_1 = ToolExecutionSpan(
+        span_info=SpanInfo(session_id="test", span_id="t1", parent_span_id="a0", start_time=now, end_time=now),
+        tool_call=ToolCall(name="square_root", arguments={"n": 1764}),
+        tool_result=ToolResult(content="42.0"),
+    )
+    tool_span_2 = ToolExecutionSpan(
+        span_info=SpanInfo(session_id="test", span_id="t2", parent_span_id="a0", start_time=now, end_time=now),
+        tool_call=ToolCall(name="multiply_numbers", arguments={"a": 42, "b": 3}),
+        tool_result=ToolResult(content="126"),
+    )
+
+    trace = Trace(spans=[agent_span, tool_span_1, tool_span_2], trace_id="trace1", session_id="test")
+    session = Session(traces=[trace], session_id="test")
+
+    extractor = TraceExtractor(EvaluationLevel.TOOL_LEVEL)
+    result = extractor.extract(session)
+
+    assert len(result) == 2
+
+    # First tool: sees only the user prompt
+    assert len(result[0].session_history) == 1
+
+    # Second tool: sees user prompt + first tool's execution
+    assert len(result[1].session_history) == 2
+    assert isinstance(result[1].session_history[1], list)
+    assert result[1].session_history[1][0].tool_call.name == "square_root"
+    assert result[1].session_history[1][0].tool_result.content == "42.0"

--- a/tests/strands_evals/extractors/test_trace_extractor.py
+++ b/tests/strands_evals/extractors/test_trace_extractor.py
@@ -160,10 +160,19 @@ def test_extract_empty_session_tool_level():
 
 
 def test_extract_tool_level_incremental_session_history():
-    """Each tool span sees exactly its true predecessors in session_history, in order."""
-    now = datetime.now()
+    """Each tool span sees exactly its causally-completed predecessors in session_history.
+
+    Uses distinct timestamps so the causality filter is exercised:
+    - tool_1 (t=0→1) finishes before tool_2 starts → prior for tool_2 and tool_3
+    - tool_2 (t=1→4) is long-running and still in-flight when tool_3 starts at t=2 → NOT a prior for tool_3
+    - tool_3 (t=2→3) starts while tool_2 is still running
+    """
+    from datetime import timedelta, timezone
+
+    base = datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+
     agent_span = AgentInvocationSpan(
-        span_info=SpanInfo(session_id="test", span_id="a0", start_time=now, end_time=now),
+        span_info=SpanInfo(session_id="test", span_id="a0", start_time=base, end_time=base + timedelta(seconds=10)),
         user_prompt="What is the square root of 1764, multiplied by 3, then add 1?",
         agent_response="127",
         available_tools=[
@@ -173,17 +182,36 @@ def test_extract_tool_level_incremental_session_history():
         ],
     )
     tool_span_1 = ToolExecutionSpan(
-        span_info=SpanInfo(session_id="test", span_id="t1", parent_span_id="a0", start_time=now, end_time=now),
+        span_info=SpanInfo(
+            session_id="test",
+            span_id="t1",
+            parent_span_id="a0",
+            start_time=base,
+            end_time=base + timedelta(seconds=1),
+        ),
         tool_call=ToolCall(name="square_root", arguments={"n": 1764}),
         tool_result=ToolResult(content="42.0"),
     )
+    # Long-running: finishes at t=4, AFTER tool_3 starts at t=2
     tool_span_2 = ToolExecutionSpan(
-        span_info=SpanInfo(session_id="test", span_id="t2", parent_span_id="a0", start_time=now, end_time=now),
+        span_info=SpanInfo(
+            session_id="test",
+            span_id="t2",
+            parent_span_id="a0",
+            start_time=base + timedelta(seconds=1),
+            end_time=base + timedelta(seconds=4),
+        ),
         tool_call=ToolCall(name="multiply_numbers", arguments={"a": 42, "b": 3}),
         tool_result=ToolResult(content="126"),
     )
     tool_span_3 = ToolExecutionSpan(
-        span_info=SpanInfo(session_id="test", span_id="t3", parent_span_id="a0", start_time=now, end_time=now),
+        span_info=SpanInfo(
+            session_id="test",
+            span_id="t3",
+            parent_span_id="a0",
+            start_time=base + timedelta(seconds=2),
+            end_time=base + timedelta(seconds=3),
+        ),
         tool_call=ToolCall(name="add_numbers", arguments={"a": 126, "b": 1}),
         tool_result=ToolResult(content="127"),
     )
@@ -202,7 +230,7 @@ def test_extract_tool_level_incremental_session_history():
     )
     assert result[0].tool_execution_details.tool_call.name == "square_root"
 
-    # Second tool: sees user prompt + first tool's execution
+    # Second tool: sees user prompt + first tool's execution (square_root finished at t=1 <= t=1)
     assert len(result[1].session_history) == 2, (
         f"second tool should see user prompt + 1 prior execution, got {len(result[1].session_history)} entries"
     )
@@ -210,11 +238,66 @@ def test_extract_tool_level_incremental_session_history():
     assert result[1].session_history[1][0].tool_call.name == "square_root"
     assert result[1].session_history[1][0].tool_result.content == "42.0"
 
-    # Third tool: sees user prompt + [square_root, multiply_numbers] in order
+    # Third tool: only square_root is a valid prior (multiply_numbers ends at t=4 > t=2 start)
     assert len(result[2].session_history) == 2, (
         f"expected 2 entries (user + prior tools), got {len(result[2].session_history)}"
     )
     prior_names = [entry.tool_call.name for entry in result[2].session_history[1]]
-    assert prior_names == ["square_root", "multiply_numbers"], (
-        f"expected [square_root, multiply_numbers] in order, got {prior_names}"
+    assert prior_names == ["square_root"], (
+        f"expected only [square_root] (multiply_numbers still running), got {prior_names}"
     )
+
+
+def test_extract_tool_level_mixed_tz_timestamps():
+    """The causality filter handles mixed naive/aware timestamps without raising TypeError."""
+    from datetime import timedelta, timezone
+
+    base_naive = datetime(2024, 1, 1, 12, 0, 0)  # no tzinfo
+    base_aware = datetime(2024, 1, 1, 12, 0, 1, tzinfo=timezone.utc)  # aware
+
+    agent_span = AgentInvocationSpan(
+        span_info=SpanInfo(
+            session_id="test", span_id="a0", start_time=base_naive, end_time=base_aware + timedelta(seconds=5)
+        ),
+        user_prompt="Mixed tz test",
+        agent_response="Done",
+        available_tools=[ToolConfig(name="tool_x"), ToolConfig(name="tool_y")],
+    )
+    # tool_x: naive timestamps
+    tool_x = ToolExecutionSpan(
+        span_info=SpanInfo(
+            session_id="test",
+            span_id="tx",
+            parent_span_id="a0",
+            start_time=base_naive,
+            end_time=base_naive + timedelta(seconds=1),
+        ),
+        tool_call=ToolCall(name="tool_x", arguments={}),
+        tool_result=ToolResult(content="x_result"),
+    )
+    # tool_y: aware timestamps — starts after tool_x ends
+    tool_y = ToolExecutionSpan(
+        span_info=SpanInfo(
+            session_id="test",
+            span_id="ty",
+            parent_span_id="a0",
+            start_time=base_aware,
+            end_time=base_aware + timedelta(seconds=1),
+        ),
+        tool_call=ToolCall(name="tool_y", arguments={}),
+        tool_result=ToolResult(content="y_result"),
+    )
+
+    trace = Trace(spans=[agent_span, tool_x, tool_y], trace_id="trace1", session_id="test")
+    session = Session(traces=[trace], session_id="test")
+
+    extractor = TraceExtractor(EvaluationLevel.TOOL_LEVEL)
+    # Should not raise TypeError
+    result = extractor.extract(session)
+
+    assert len(result) == 2
+    # tool_y should see tool_x as a prior (naive 12:00:01 <= aware 12:00:01 UTC)
+    assert result[1].tool_execution_details.tool_call.name == "tool_y"
+    assert len(result[1].session_history) == 2
+    prior_names = [e.tool_call.name for e in result[1].session_history[1]]
+    assert prior_names == ["tool_x"]

--- a/tests/strands_evals/extractors/test_trace_extractor.py
+++ b/tests/strands_evals/extractors/test_trace_extractor.py
@@ -160,13 +160,17 @@ def test_extract_empty_session_tool_level():
 
 
 def test_extract_tool_level_incremental_session_history():
-    """Test that each tool span sees prior tool results in session_history."""
+    """Each tool span sees exactly its true predecessors in session_history, in order."""
     now = datetime.now()
     agent_span = AgentInvocationSpan(
         span_info=SpanInfo(session_id="test", span_id="a0", start_time=now, end_time=now),
-        user_prompt="What is the square root of 1764, multiplied by 3?",
-        agent_response="126",
-        available_tools=[ToolConfig(name="square_root"), ToolConfig(name="multiply_numbers")],
+        user_prompt="What is the square root of 1764, multiplied by 3, then add 1?",
+        agent_response="127",
+        available_tools=[
+            ToolConfig(name="square_root"),
+            ToolConfig(name="multiply_numbers"),
+            ToolConfig(name="add_numbers"),
+        ],
     )
     tool_span_1 = ToolExecutionSpan(
         span_info=SpanInfo(session_id="test", span_id="t1", parent_span_id="a0", start_time=now, end_time=now),
@@ -178,20 +182,39 @@ def test_extract_tool_level_incremental_session_history():
         tool_call=ToolCall(name="multiply_numbers", arguments={"a": 42, "b": 3}),
         tool_result=ToolResult(content="126"),
     )
+    tool_span_3 = ToolExecutionSpan(
+        span_info=SpanInfo(session_id="test", span_id="t3", parent_span_id="a0", start_time=now, end_time=now),
+        tool_call=ToolCall(name="add_numbers", arguments={"a": 126, "b": 1}),
+        tool_result=ToolResult(content="127"),
+    )
 
-    trace = Trace(spans=[agent_span, tool_span_1, tool_span_2], trace_id="trace1", session_id="test")
+    trace = Trace(spans=[agent_span, tool_span_1, tool_span_2, tool_span_3], trace_id="trace1", session_id="test")
     session = Session(traces=[trace], session_id="test")
 
     extractor = TraceExtractor(EvaluationLevel.TOOL_LEVEL)
     result = extractor.extract(session)
 
-    assert len(result) == 2
+    assert len(result) == 3, f"expected 3 tool-level inputs, got {len(result)}"
 
-    # First tool: sees only the user prompt
-    assert len(result[0].session_history) == 1
+    # First tool: sees only the user prompt, no prior executions
+    assert len(result[0].session_history) == 1, (
+        f"first tool should only see user prompt, got {len(result[0].session_history)} entries"
+    )
+    assert result[0].tool_execution_details.tool_call.name == "square_root"
 
     # Second tool: sees user prompt + first tool's execution
-    assert len(result[1].session_history) == 2
+    assert len(result[1].session_history) == 2, (
+        f"second tool should see user prompt + 1 prior execution, got {len(result[1].session_history)} entries"
+    )
     assert isinstance(result[1].session_history[1], list)
     assert result[1].session_history[1][0].tool_call.name == "square_root"
     assert result[1].session_history[1][0].tool_result.content == "42.0"
+
+    # Third tool: sees user prompt + [square_root, multiply_numbers] in order
+    assert len(result[2].session_history) == 2, (
+        f"expected 2 entries (user + prior tools), got {len(result[2].session_history)}"
+    )
+    prior_names = [entry.tool_call.name for entry in result[2].session_history[1]]
+    assert prior_names == ["square_root", "multiply_numbers"], (
+        f"expected [square_root, multiply_numbers] in order, got {prior_names}"
+    )

--- a/tests/strands_evals/extractors/test_trace_extractor.py
+++ b/tests/strands_evals/extractors/test_trace_extractor.py
@@ -160,13 +160,7 @@ def test_extract_empty_session_tool_level():
 
 
 def test_extract_tool_level_incremental_session_history():
-    """Each tool span sees exactly its causally-completed predecessors in session_history.
-
-    Uses distinct timestamps so the causality filter is exercised:
-    - tool_1 (t=0→1) finishes before tool_2 starts → prior for tool_2 and tool_3
-    - tool_2 (t=1→4) is long-running and still in-flight when tool_3 starts at t=2 → NOT a prior for tool_3
-    - tool_3 (t=2→3) starts while tool_2 is still running
-    """
+    """Each tool span sees exactly its causally-completed predecessors in session_history."""
     from datetime import timedelta, timezone
 
     base = datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
@@ -192,14 +186,15 @@ def test_extract_tool_level_incremental_session_history():
         tool_call=ToolCall(name="square_root", arguments={"n": 1764}),
         tool_result=ToolResult(content="42.0"),
     )
-    # Long-running: finishes at t=4, AFTER tool_3 starts at t=2
+    # Finishes at t=2.5: AFTER tool_3 starts (t=2) but BEFORE tool_3 ends (t=3)
+    # This discriminates start_time vs end_time comparison targets
     tool_span_2 = ToolExecutionSpan(
         span_info=SpanInfo(
             session_id="test",
             span_id="t2",
             parent_span_id="a0",
             start_time=base + timedelta(seconds=1),
-            end_time=base + timedelta(seconds=4),
+            end_time=base + timedelta(milliseconds=2500),
         ),
         tool_call=ToolCall(name="multiply_numbers", arguments={"a": 42, "b": 3}),
         tool_result=ToolResult(content="126"),
@@ -238,13 +233,13 @@ def test_extract_tool_level_incremental_session_history():
     assert result[1].session_history[1][0].tool_call.name == "square_root"
     assert result[1].session_history[1][0].tool_result.content == "42.0"
 
-    # Third tool: only square_root is a valid prior (multiply_numbers ends at t=4 > t=2 start)
+    # Third tool: only square_root is a valid prior
     assert len(result[2].session_history) == 2, (
         f"expected 2 entries (user + prior tools), got {len(result[2].session_history)}"
     )
     prior_names = [entry.tool_call.name for entry in result[2].session_history[1]]
     assert prior_names == ["square_root"], (
-        f"expected only [square_root] (multiply_numbers still running), got {prior_names}"
+        f"expected only [square_root] (multiply_numbers still running at tool_3.start_time), got {prior_names}"
     )
 
 
@@ -253,17 +248,21 @@ def test_extract_tool_level_mixed_tz_timestamps():
     from datetime import timedelta, timezone
 
     base_naive = datetime(2024, 1, 1, 12, 0, 0)  # no tzinfo
-    base_aware = datetime(2024, 1, 1, 12, 0, 1, tzinfo=timezone.utc)  # aware
+    base_aware = datetime(2024, 1, 1, 12, 0, 2, tzinfo=timezone.utc)  # aware, starts at +2s
 
     agent_span = AgentInvocationSpan(
         span_info=SpanInfo(
-            session_id="test", span_id="a0", start_time=base_naive, end_time=base_aware + timedelta(seconds=5)
+            session_id="test", span_id="a0", start_time=base_naive, end_time=base_aware + timedelta(seconds=10)
         ),
         user_prompt="Mixed tz test",
         agent_response="Done",
-        available_tools=[ToolConfig(name="tool_x"), ToolConfig(name="tool_y")],
+        available_tools=[
+            ToolConfig(name="tool_x"),
+            ToolConfig(name="tool_long"),
+            ToolConfig(name="tool_y"),
+        ],
     )
-    # tool_x: naive timestamps
+    # tool_x: ends at 12:00:01 (before tool_y starts)
     tool_x = ToolExecutionSpan(
         span_info=SpanInfo(
             session_id="test",
@@ -275,7 +274,19 @@ def test_extract_tool_level_mixed_tz_timestamps():
         tool_call=ToolCall(name="tool_x", arguments={}),
         tool_result=ToolResult(content="x_result"),
     )
-    # tool_y: aware timestamps — starts after tool_x ends
+    # tool_long: ends at 12:00:05 (after tool_y starts at 12:00:02)
+    tool_long = ToolExecutionSpan(
+        span_info=SpanInfo(
+            session_id="test",
+            span_id="tl",
+            parent_span_id="a0",
+            start_time=base_naive,
+            end_time=base_naive + timedelta(seconds=5),
+        ),
+        tool_call=ToolCall(name="tool_long", arguments={}),
+        tool_result=ToolResult(content="long_result"),
+    )
+    # tool_y: starts at 12:00:02 UTC
     tool_y = ToolExecutionSpan(
         span_info=SpanInfo(
             session_id="test",
@@ -288,16 +299,18 @@ def test_extract_tool_level_mixed_tz_timestamps():
         tool_result=ToolResult(content="y_result"),
     )
 
-    trace = Trace(spans=[agent_span, tool_x, tool_y], trace_id="trace1", session_id="test")
+    trace = Trace(spans=[agent_span, tool_x, tool_long, tool_y], trace_id="trace1", session_id="test")
     session = Session(traces=[trace], session_id="test")
 
     extractor = TraceExtractor(EvaluationLevel.TOOL_LEVEL)
-    # Should not raise TypeError
+    # Should not raise TypeError from mixed tz comparison
     result = extractor.extract(session)
 
-    assert len(result) == 2
-    # tool_y should see tool_x as a prior (naive 12:00:01 <= aware 12:00:01 UTC)
-    assert result[1].tool_execution_details.tool_call.name == "tool_y"
-    assert len(result[1].session_history) == 2
-    prior_names = [e.tool_call.name for e in result[1].session_history[1]]
-    assert prior_names == ["tool_x"]
+    assert len(result) == 3
+    # tool_y should see ONLY tool_x as a prior
+    assert result[2].tool_execution_details.tool_call.name == "tool_y"
+    assert len(result[2].session_history) == 2
+    prior_names = [e.tool_call.name for e in result[2].session_history[1]]
+    assert prior_names == ["tool_x"], (
+        f"expected only ['tool_x'] as prior for tool_y (tool_long still running), got {prior_names}"
+    )


### PR DESCRIPTION
## Description

`TraceExtractor._extract_tool_level` builds `session_history` at trace-level granularity rather than per-tool-span. All tool spans within the same trace receive an identical history snapshot — one that contains only the user prompt and results from *previous* traces, but none of the tool results from sibling tool calls earlier in the same trace.

This causes `ToolSelectionAccuracyEvaluator` and `ToolParameterAccuracyEvaluator` to produce false negatives: the judge model sees a tool call using values that appear "hallucinated" because it cannot see that a prior tool call already returned those values.

## Related Issues

Fixes #337

## Documentation PR

N/A

## Type of Change

Bug fix

## Testing

Added `test_extract_tool_level_incremental_session_history` which verifies that:
- Tool span 0 (`square_root`) sees only the user prompt in `session_history`
- Tool span 1 (`multiply_numbers`) sees the user prompt **plus** the prior `square_root` call and its result (`42.0`)

The test fails without the fix (`assert 1 == 2` — second tool only sees user prompt) and passes with it.

- [x]  I ran `hatch run prepare`

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.