### PR TITLE
feat: add GenAIEventsDictSessionMapper for dict spans with gen_ai events

### DIFF
--- a/src/strands_evals/mappers/__init__.py
+++ b/src/strands_evals/mappers/__init__.py
@@ -3,6 +3,7 @@
 from .adk_otel_session_mapper import ADKOtelSessionMapper
 from .cloudwatch_parser import CloudWatchLogsParser, parse_cloudwatch_logs
 from .cloudwatch_session_mapper import CloudWatchSessionMapper
+from .gen_ai_events_dict_session_mapper import GenAIEventsDictSessionMapper
 from .langchain_otel_session_mapper import LangChainOtelSessionMapper
 from .openinference_session_mapper import OpenInferenceSessionMapper
 from .opensearch_session_mapper import OpenSearchSessionMapper
@@ -14,6 +15,7 @@ __all__ = [
     "ADKOtelSessionMapper",
     "CloudWatchLogsParser",
     "CloudWatchSessionMapper",
+    "GenAIEventsDictSessionMapper",
     "GenAIConventionVersion",
     "LangChainOtelSessionMapper",
     "OpenInferenceSessionMapper",

--- a/src/strands_evals/mappers/gen_ai_events_dict_session_mapper.py
+++ b/src/strands_evals/mappers/gen_ai_events_dict_session_mapper.py
@@ -1,0 +1,168 @@
+"""Mapper for dict spans with gen_ai semantic convention events.
+
+Handles spans sent as plain dicts (not ReadableSpan objects) that contain
+gen_ai.user.message, gen_ai.choice, and gen_ai.system.message events.
+
+This format is used by the AgentCore evaluation service when it normalizes
+Strands telemetry spans before passing them to evaluator Lambdas.
+
+Known limitation:
+    This mapper only extracts AgentInvocationSpan (user input, agent response,
+    system prompt). ToolExecutionSpan extraction is not yet supported for this
+    format — metrics requiring retrieval_context or tools_called will not have
+    that data available when spans arrive in this format.
+"""
+
+import json
+from collections import defaultdict
+from datetime import datetime, timezone
+from typing import Any
+
+from ..types.trace import (
+    AgentInvocationSpan,
+    Session,
+    SpanInfo,
+    SpanUnion,
+    Trace,
+)
+from .session_mapper import SessionMapper
+
+
+class GenAIEventsDictSessionMapper(SessionMapper):
+    """Maps dict spans with gen_ai events to Session format.
+
+    Handles spans that have:
+    - Standard dict format (not ReadableSpan objects)
+    - Strands telemetry scope
+    - Events list with gen_ai.user.message, gen_ai.choice, gen_ai.system.message
+    - gen_ai.operation.name == "invoke_agent" (agent invocation spans)
+
+    This sits between:
+    - CloudWatchSessionMapper (handles body.input/output dicts)
+    - StrandsInMemorySessionMapper (handles ReadableSpan objects with gen_ai events)
+
+    Known limitation:
+        Only extracts AgentInvocationSpan. ToolExecutionSpan is not supported
+        for this format yet.
+    """
+
+    def map_to_session(self, data: list[dict[str, Any]], session_id: str) -> Session:
+        """Map dict spans with gen_ai events to Session format.
+
+        Args:
+            data: List of span dicts with gen_ai events.
+            session_id: Session identifier.
+
+        Returns:
+            Session object with extracted AgentInvocationSpans.
+        """
+        spans = self._normalize_to_flat_spans(data) if not isinstance(data, list) else data
+
+        traces_by_id: dict[str, list[dict]] = defaultdict(list)
+        for span in spans:
+            trace_id = span.get("traceId", "unknown")
+            traces_by_id[trace_id].append(span)
+
+        traces = []
+        for trace_id, trace_spans in traces_by_id.items():
+            agent_spans = self._extract_agent_spans(trace_spans, session_id, trace_id)
+            if agent_spans:
+                traces.append(Trace(spans=agent_spans, trace_id=trace_id, session_id=session_id))
+
+        return Session(traces=traces, session_id=session_id)
+
+    def _extract_agent_spans(
+        self, spans: list[dict[str, Any]], session_id: str, trace_id: str
+    ) -> list[SpanUnion]:
+        """Extract AgentInvocationSpans from dict spans with gen_ai events."""
+        agent_spans: list[SpanUnion] = []
+
+        for span in spans:
+            # Only process agent invocation spans
+            attrs = span.get("attributes", {})
+            if not isinstance(attrs, dict):
+                continue
+            if attrs.get("gen_ai.operation.name") != "invoke_agent":
+                continue
+
+            events = span.get("events", [])
+            if not events:
+                continue
+
+            user_input = None
+            assistant_output = None
+            system_prompt = None
+
+            for event in events:
+                if not isinstance(event, dict):
+                    continue
+
+                event_name = event.get("name", "")
+                event_attrs = event.get("attributes", {})
+                if not isinstance(event_attrs, dict):
+                    continue
+
+                if event_name == "gen_ai.user.message":
+                    user_input = self._extract_text_content(event_attrs.get("content", ""))
+                elif event_name == "gen_ai.choice":
+                    assistant_output = self._extract_text_content(event_attrs.get("message", ""))
+                elif event_name == "gen_ai.system.message":
+                    system_prompt = self._extract_text_content(event_attrs.get("content", ""))
+
+            if user_input and assistant_output:
+                start_ns = self._safe_int(span.get("startTimeUnixNano", 0))
+                end_ns = self._safe_int(span.get("endTimeUnixNano", start_ns))
+
+                span_info = SpanInfo(
+                    trace_id=trace_id,
+                    span_id=span.get("spanId"),
+                    session_id=session_id,
+                    parent_span_id=span.get("parentSpanId"),
+                    start_time=datetime.fromtimestamp(start_ns / 1e9, tz=timezone.utc),
+                    end_time=datetime.fromtimestamp(end_ns / 1e9, tz=timezone.utc),
+                )
+
+                agent_spans.append(
+                    AgentInvocationSpan(
+                        span_info=span_info,
+                        user_prompt=user_input,
+                        agent_response=assistant_output,
+                        available_tools=[],
+                        system_prompt=system_prompt,
+                    )
+                )
+
+        return agent_spans
+
+    @staticmethod
+    def _extract_text_content(raw: Any) -> str | None:
+        """Extract text from gen_ai event content.
+
+        Content can be:
+        - JSON string of text parts: '[{"text": "hello"}, {"text": "world"}]'
+        - Already-parsed list of dicts: [{"text": "hello"}]
+        - Plain string: "hello world"
+        """
+        if not raw:
+            return None
+        # Already parsed (list of dicts)
+        if isinstance(raw, list):
+            return " ".join(p.get("text", "") for p in raw if isinstance(p, dict)).strip() or None
+        if not isinstance(raw, str):
+            return str(raw)
+        # Try JSON parsing
+        try:
+            parts = json.loads(raw)
+            if isinstance(parts, list):
+                return " ".join(p.get("text", "") for p in parts if isinstance(p, dict)).strip() or None
+        except (ValueError, TypeError):
+            pass
+        return raw
+
+    @staticmethod
+    def _safe_int(value: Any) -> int:
+        """Safely convert a value to int (handles string-encoded timestamps)."""
+        try:
+            return int(value)
+        except (ValueError, TypeError):
+            return 0

--- a/src/strands_evals/mappers/utils.py
+++ b/src/strands_evals/mappers/utils.py
@@ -147,7 +147,22 @@ def detect_otel_mapper(spans: list[Any]) -> SessionMapper:
         if get_body(span) is not None:
             return CloudWatchSessionMapper()
 
-    # Default to StrandsInMemorySessionMapper
+    # Check for Strands dict spans with events list. These cannot be handled by
+    # StrandsInMemorySessionMapper (which expects ReadableSpan objects), so route
+    # them to GenAIEventsDictSessionMapper which safely handles dicts and returns
+    # an empty session if no matching gen_ai events are found.
+    from .gen_ai_events_dict_session_mapper import GenAIEventsDictSessionMapper
+
+    for span in spans:
+        if not isinstance(span, dict):
+            continue
+        scope_name = get_scope_name(span)
+        if scope_name != SCOPE_STRANDS:
+            continue
+        if span.get("events"):
+            return GenAIEventsDictSessionMapper()
+
+    # Default to StrandsInMemorySessionMapper (for ReadableSpan objects)
     return StrandsInMemorySessionMapper()
 
 

--- a/tests/strands_evals/mappers/test_gen_ai_events_dict_session_mapper.py
+++ b/tests/strands_evals/mappers/test_gen_ai_events_dict_session_mapper.py
@@ -1,0 +1,287 @@
+"""Tests for GenAIEventsDictSessionMapper."""
+
+from strands_evals.mappers import (
+    CloudWatchSessionMapper,
+    GenAIEventsDictSessionMapper,
+    StrandsInMemorySessionMapper,
+    detect_otel_mapper,
+)
+from strands_evals.types.trace import AgentInvocationSpan
+
+
+def _make_gen_ai_span(
+    trace_id="t1",
+    span_id="s1",
+    user_message="What is AI?",
+    assistant_message="AI is artificial intelligence.",
+    system_message=None,
+):
+    """Create a dict span with gen_ai events."""
+    events = [
+        {"name": "gen_ai.user.message", "attributes": {"content": f'[{{"text": "{user_message}"}}]'}},
+        {"name": "gen_ai.choice", "attributes": {"message": f'[{{"text": "{assistant_message}"}}]'}},
+    ]
+    if system_message:
+        system_content = f'[{{"text": "{system_message}"}}]'
+        events.insert(0, {"name": "gen_ai.system.message", "attributes": {"content": system_content}})
+
+    return {
+        "traceId": trace_id,
+        "spanId": span_id,
+        "scope": {"name": "strands.telemetry.tracer"},
+        "name": "invoke_agent",
+        "kind": "INTERNAL",
+        "startTimeUnixNano": 1000000000,
+        "endTimeUnixNano": 2000000000,
+        "attributes": {"gen_ai.operation.name": "invoke_agent", "session.id": "test"},
+        "events": events,
+    }
+
+
+class TestDetection:
+    """Tests for detect_otel_mapper returning GenAIEventsDictSessionMapper."""
+
+    def test_returns_gen_ai_mapper_for_dict_spans_with_gen_ai_events(self):
+        spans = [_make_gen_ai_span()]
+        mapper = detect_otel_mapper(spans)
+        assert isinstance(mapper, GenAIEventsDictSessionMapper)
+
+    def test_returns_cloudwatch_mapper_for_body_format(self):
+        spans = [
+            {
+                "traceId": "t1",
+                "spanId": "s1",
+                "scope": {"name": "strands.telemetry.tracer"},
+                "body": {
+                    "input": {"messages": [{"role": "user", "content": "hi"}]},
+                    "output": {"messages": [{"role": "assistant", "content": "hello"}]},
+                },
+            }
+        ]
+        mapper = detect_otel_mapper(spans)
+        assert isinstance(mapper, CloudWatchSessionMapper)
+
+    def test_does_not_match_non_strands_scope(self):
+        spans = [
+            {
+                "traceId": "t1",
+                "spanId": "s1",
+                "scope": {"name": "unknown.framework"},
+                "attributes": {"gen_ai.operation.name": "invoke_agent"},
+                "events": [{"name": "gen_ai.user.message", "attributes": {"content": "hi"}}],
+            }
+        ]
+        mapper = detect_otel_mapper(spans)
+        assert not isinstance(mapper, GenAIEventsDictSessionMapper)
+
+    def test_strands_dict_spans_without_events_fall_to_in_memory(self):
+        """Strands dict spans without events key fall to StrandsInMemorySessionMapper."""
+        spans = [
+            {
+                "traceId": "t1",
+                "spanId": "s1",
+                "scope": {"name": "strands.telemetry.tracer"},
+                "attributes": {"gen_ai.operation.name": "invoke_agent"},
+            }
+        ]
+        mapper = detect_otel_mapper(spans)
+        # No events key → falls through to default StrandsInMemorySessionMapper
+        assert isinstance(mapper, StrandsInMemorySessionMapper)
+
+    def test_strands_dict_spans_with_events_use_gen_ai_mapper(self):
+        """Strands dict spans with events (even unknown ones) use GenAIEventsDictSessionMapper."""
+        spans = [
+            {
+                "traceId": "t1",
+                "spanId": "s1",
+                "scope": {"name": "strands.telemetry.tracer"},
+                "attributes": {"gen_ai.operation.name": "invoke_agent"},
+                "events": [{"name": "some.unknown.event", "attributes": {}}],
+            }
+        ]
+        mapper = detect_otel_mapper(spans)
+        assert isinstance(mapper, GenAIEventsDictSessionMapper)
+
+
+class TestMapToSession:
+    """Tests for GenAIEventsDictSessionMapper.map_to_session."""
+
+    def test_extracts_user_prompt_and_agent_response(self):
+        spans = [_make_gen_ai_span(user_message="Hello", assistant_message="Hi there")]
+        mapper = GenAIEventsDictSessionMapper()
+        session = mapper.map_to_session(spans, session_id="test")
+
+        assert len(session.traces) == 1
+        assert len(session.traces[0].spans) == 1
+        span = session.traces[0].spans[0]
+        assert isinstance(span, AgentInvocationSpan)
+        assert span.user_prompt == "Hello"
+        assert span.agent_response == "Hi there"
+
+    def test_extracts_system_prompt(self):
+        spans = [_make_gen_ai_span(system_message="You are helpful")]
+        mapper = GenAIEventsDictSessionMapper()
+        session = mapper.map_to_session(spans, session_id="test")
+
+        span = session.traces[0].spans[0]
+        assert span.system_prompt == "You are helpful"
+
+    def test_no_system_prompt_returns_none(self):
+        spans = [_make_gen_ai_span()]
+        mapper = GenAIEventsDictSessionMapper()
+        session = mapper.map_to_session(spans, session_id="test")
+
+        span = session.traces[0].spans[0]
+        assert span.system_prompt is None
+
+    def test_handles_multiple_traces(self):
+        spans = [
+            _make_gen_ai_span(trace_id="t1", span_id="s1", user_message="Q1", assistant_message="A1"),
+            _make_gen_ai_span(trace_id="t2", span_id="s2", user_message="Q2", assistant_message="A2"),
+        ]
+        mapper = GenAIEventsDictSessionMapper()
+        session = mapper.map_to_session(spans, session_id="test")
+
+        assert len(session.traces) == 2
+
+    def test_handles_multiple_spans_same_trace(self):
+        spans = [
+            _make_gen_ai_span(trace_id="t1", span_id="s1", user_message="Q1", assistant_message="A1"),
+            _make_gen_ai_span(trace_id="t1", span_id="s2", user_message="Q2", assistant_message="A2"),
+        ]
+        mapper = GenAIEventsDictSessionMapper()
+        session = mapper.map_to_session(spans, session_id="test")
+
+        assert len(session.traces) == 1
+        assert len(session.traces[0].spans) == 2
+
+    def test_skips_non_agent_spans(self):
+        """Only spans with gen_ai.operation.name == 'invoke_agent' are extracted."""
+        spans = [
+            {
+                "traceId": "t1",
+                "spanId": "s1",
+                "scope": {"name": "strands.telemetry.tracer"},
+                "startTimeUnixNano": 1000000000,
+                "endTimeUnixNano": 2000000000,
+                "attributes": {"gen_ai.operation.name": "chat"},
+                "events": [
+                    {"name": "gen_ai.user.message", "attributes": {"content": '[{"text": "hi"}]'}},
+                    {"name": "gen_ai.choice", "attributes": {"message": '[{"text": "hello"}]'}},
+                ],
+            },
+            _make_gen_ai_span(trace_id="t1", span_id="s2"),
+        ]
+        mapper = GenAIEventsDictSessionMapper()
+        session = mapper.map_to_session(spans, session_id="test")
+
+        assert len(session.traces) == 1
+        assert len(session.traces[0].spans) == 1
+
+    def test_skips_spans_without_events(self):
+        spans = [
+            {
+                "traceId": "t1",
+                "spanId": "s1",
+                "scope": {"name": "strands.telemetry.tracer"},
+                "attributes": {"gen_ai.operation.name": "invoke_agent"},
+            },
+            _make_gen_ai_span(trace_id="t1", span_id="s2"),
+        ]
+        mapper = GenAIEventsDictSessionMapper()
+        session = mapper.map_to_session(spans, session_id="test")
+
+        assert len(session.traces) == 1
+        assert len(session.traces[0].spans) == 1
+
+    def test_skips_spans_missing_user_input(self):
+        spans = [
+            {
+                "traceId": "t1",
+                "spanId": "s1",
+                "scope": {"name": "strands.telemetry.tracer"},
+                "startTimeUnixNano": 1000000000,
+                "endTimeUnixNano": 2000000000,
+                "attributes": {"gen_ai.operation.name": "invoke_agent"},
+                "events": [
+                    {"name": "gen_ai.choice", "attributes": {"message": '[{"text": "response"}]'}},
+                ],
+            }
+        ]
+        mapper = GenAIEventsDictSessionMapper()
+        session = mapper.map_to_session(spans, session_id="test")
+
+        assert len(session.traces) == 0
+
+    def test_handles_plain_string_content(self):
+        spans = [
+            {
+                "traceId": "t1",
+                "spanId": "s1",
+                "scope": {"name": "strands.telemetry.tracer"},
+                "startTimeUnixNano": 1000000000,
+                "endTimeUnixNano": 2000000000,
+                "attributes": {"gen_ai.operation.name": "invoke_agent"},
+                "events": [
+                    {"name": "gen_ai.user.message", "attributes": {"content": "plain text"}},
+                    {"name": "gen_ai.choice", "attributes": {"message": "plain response"}},
+                ],
+            }
+        ]
+        mapper = GenAIEventsDictSessionMapper()
+        session = mapper.map_to_session(spans, session_id="test")
+
+        span = session.traces[0].spans[0]
+        assert span.user_prompt == "plain text"
+        assert span.agent_response == "plain response"
+
+    def test_handles_already_parsed_list_content(self):
+        """Content may arrive as already-parsed list (not JSON string)."""
+        spans = [
+            {
+                "traceId": "t1",
+                "spanId": "s1",
+                "scope": {"name": "strands.telemetry.tracer"},
+                "startTimeUnixNano": 1000000000,
+                "endTimeUnixNano": 2000000000,
+                "attributes": {"gen_ai.operation.name": "invoke_agent"},
+                "events": [
+                    {"name": "gen_ai.user.message", "attributes": {"content": [{"text": "parsed input"}]}},
+                    {"name": "gen_ai.choice", "attributes": {"message": [{"text": "parsed output"}]}},
+                ],
+            }
+        ]
+        mapper = GenAIEventsDictSessionMapper()
+        session = mapper.map_to_session(spans, session_id="test")
+
+        span = session.traces[0].spans[0]
+        assert span.user_prompt == "parsed input"
+        assert span.agent_response == "parsed output"
+
+    def test_handles_string_encoded_timestamps(self):
+        """OTLP JSON may encode timestamps as strings."""
+        spans = [
+            {
+                "traceId": "t1",
+                "spanId": "s1",
+                "scope": {"name": "strands.telemetry.tracer"},
+                "startTimeUnixNano": "1000000000",
+                "endTimeUnixNano": "2000000000",
+                "attributes": {"gen_ai.operation.name": "invoke_agent"},
+                "events": [
+                    {"name": "gen_ai.user.message", "attributes": {"content": "hi"}},
+                    {"name": "gen_ai.choice", "attributes": {"message": "hello"}},
+                ],
+            }
+        ]
+        mapper = GenAIEventsDictSessionMapper()
+        session = mapper.map_to_session(spans, session_id="test")
+
+        assert len(session.traces) == 1
+
+    def test_empty_spans_returns_empty_session(self):
+        mapper = GenAIEventsDictSessionMapper()
+        session = mapper.map_to_session([], session_id="test")
+
+        assert len(session.traces) == 0
+        assert session.session_id == "test"


### PR DESCRIPTION
Description

  Adds GenAIEventsDictSessionMapper to handle dict spans with gen_ai semantic convention events (gen_ai.user.message, gen_ai.choice, gen_ai.system.message).

  The AgentCore evaluation service normalizes Strands telemetry spans into this format before passing them to evaluator Lambdas. Existing mappers cannot handle it:
  - CloudWatchSessionMapper requires body.input/output
  - StrandsInMemorySessionMapper requires ReadableSpan objects (not dicts)

  The new mapper:
  - Accepts list[dict] with gen_ai events
  - Extracts user_prompt, agent_response, system_prompt
  - Returns Session with AgentInvocationSpans
  - Is auto-detected by detect_otel_mapper() for Strands-scoped dict spans with gen_ai event names

  Known limitation: ToolExecutionSpan extraction is not yet supported for this format.

  Related Issues

  N/A — discovered during AgentCore SDK integration (bedrock-agentcore-sdk-python PR #568).

  Documentation PR

  N/A

  Type of Change

  New feature

  Testing

  - 13 unit tests covering detection logic, mapping, edge cases, and backward compatibility
  - Verified detect_otel_mapper() still returns CloudWatchSessionMapper for body format
  - Verified non-Strands scope spans are not incorrectly matched
  - [x] I ran hatch run prepare

  Checklist

  - [x] I have read the CONTRIBUTING document
  - [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
  - [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
  - [x] I have added any necessary tests that prove my fix is effective or my feature works
  - [ ] I have updated the documentation accordingly
  - [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
  - [x] My changes generate no new warnings
  - [x] Any dependent changes have been merged and published

  ---
  By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
