### PR TITLE
fix: scope tools to owning agent in multi-agent traces

### DIFF
--- a/src/strands_evals/evaluators/evaluator.py
+++ b/src/strands_evals/evaluators/evaluator.py
@@ -198,6 +198,16 @@ class Evaluator(Generic[InputT, OutputT]):
         # Format available tools
         if tool_input.available_tools:
             parts.append(f"## Available tool-calls\n{self._format_tools(tool_input.available_tools)}")
+        else:
+            logger.debug(
+                "span_id=<%s> | no available tools resolved for tool-level evaluation",
+                tool_input.span_info.span_id,
+            )
+            parts.append(
+                "## Available tool-calls\n"
+                "No tool list could be resolved for this agent. "
+                "Evaluate the tool call based on the user's request and conversation context."
+            )
 
         # Format previous conversation history
         if tool_input.session_history:

--- a/src/strands_evals/extractors/trace_extractor.py
+++ b/src/strands_evals/extractors/trace_extractor.py
@@ -54,12 +54,10 @@ class TraceExtractor:
         previous_turns: list[UserMessage | list[ToolExecution] | AssistantMessage] = []
 
         for trace in session.traces:
+            agent_spans = self._find_agent_invocation_spans(trace)
             tool_spans = self._find_tool_execution_spans(trace)
 
-            for span in trace.spans:
-                if not isinstance(span, AgentInvocationSpan):
-                    continue
-
+            for span in agent_spans:
                 try:
                     text_content = TextContent(text=span.user_prompt)
                     previous_turns.append(UserMessage(content=[text_content]))
@@ -67,11 +65,17 @@ class TraceExtractor:
                     logger.warning(f"Failed to create user message: {e}")
                     continue
 
-                # Include tool executions in session history
-                if tool_spans:
+                # Include only tool executions owned by this agent
+                ownership_assigned = any(ts.owning_agent_span_id for ts in tool_spans)
+                if len(agent_spans) > 1 and ownership_assigned:
+                    owned_tools = [ts for ts in tool_spans if ts.owning_agent_span_id == span.span_info.span_id]
+                else:
+                    owned_tools = tool_spans
+
+                if owned_tools:
                     try:
                         tool_executions = [
-                            ToolExecution(tool_call=ts.tool_call, tool_result=ts.tool_result) for ts in tool_spans
+                            ToolExecution(tool_call=ts.tool_call, tool_result=ts.tool_result) for ts in owned_tools
                         ]
                         previous_turns.append(tool_executions)
                     except (AttributeError, TypeError, ValueError) as e:
@@ -103,14 +107,31 @@ class TraceExtractor:
         available_tools: list[ToolConfig] = []
 
         for trace in session.traces:
-            agent_span = self._find_agent_invocation_span(trace)
+            agent_spans = self._find_agent_invocation_spans(trace)
             tool_spans = self._find_tool_execution_spans(trace)
 
-            if agent_span and agent_span.available_tools:
-                available_tools = agent_span.available_tools
+            # Determine root agent for session history
+            agent_span: AgentInvocationSpan | None = None
+            if agent_spans:
+                agent_span = next(
+                    (
+                        s
+                        for s in agent_spans
+                        if s.span_info.parent_span_id is None and (s.user_prompt or s.agent_response)
+                    ),
+                    next(
+                        (s for s in agent_spans if s.span_info.parent_span_id is None),
+                        agent_spans[0],
+                    ),
+                )
 
-            if agent_span and agent_span.user_prompt:
-                session_history.append(UserMessage(content=[TextContent(text=agent_span.user_prompt)]))
+                if agent_span.available_tools:
+                    available_tools = agent_span.available_tools
+                if agent_span.user_prompt:
+                    session_history.append(UserMessage(content=[TextContent(text=agent_span.user_prompt)]))
+
+            # Build agent lookup for multi-agent scoping
+            agent_by_id = {s.span_info.span_id: s for s in agent_spans if s.span_info.span_id}
 
             tool_executions = [
                 ToolExecution(tool_call=span.tool_call, tool_result=span.tool_result) for span in tool_spans
@@ -130,10 +151,16 @@ class TraceExtractor:
                     and (tool_end_times[position] < target_start or position < index)
                 ]
 
+                if tool_span.owning_agent_span_id and len(agent_spans) > 1:
+                    owning_agent = agent_by_id.get(tool_span.owning_agent_span_id)
+                    scoped_tools = owning_agent.available_tools if owning_agent and owning_agent.available_tools else []
+                else:
+                    scoped_tools = available_tools
+
                 evaluator_inputs.append(
                     ToolLevelInput(
                         span_info=tool_span.span_info,
-                        available_tools=available_tools,
+                        available_tools=scoped_tools,
                         tool_execution_details=tool_span,
                         session_history=list(session_history) + ([prior_executions] if prior_executions else []),
                     )
@@ -147,12 +174,9 @@ class TraceExtractor:
 
         return evaluator_inputs
 
-    def _find_agent_invocation_span(self, trace) -> AgentInvocationSpan | None:
-        """Find the AgentInvocationSpan in a trace."""
-        for span in trace.spans:
-            if isinstance(span, AgentInvocationSpan):
-                return span
-        return None
+    def _find_agent_invocation_spans(self, trace) -> list[AgentInvocationSpan]:
+        """Find all AgentInvocationSpans in a trace."""
+        return [span for span in trace.spans if isinstance(span, AgentInvocationSpan)]
 
     def _find_tool_execution_spans(self, trace) -> list[ToolExecutionSpan]:
         """Find all ToolExecutionSpans in a trace."""

--- a/src/strands_evals/mappers/adk_otel_session_mapper.py
+++ b/src/strands_evals/mappers/adk_otel_session_mapper.py
@@ -93,28 +93,17 @@ class ADKOtelSessionMapper(SessionMapper):
 
         result_traces: list[Trace] = []
         for trace_id, trace_spans in grouped.items():
-            traces = self._build_traces(trace_id, trace_spans, session_id)
-            result_traces.extend(t for t in traces if t.spans)
+            trace = self._build_trace(trace_id, trace_spans, session_id)
+            if trace.spans:
+                result_traces.append(trace)
 
         # Sort traces chronologically by earliest span start_time
         result_traces.sort(key=lambda t: min(s.span_info.start_time for s in t.spans))
 
         return Session(session_id=session_id, traces=result_traces)
 
-    def _build_traces(self, trace_id: str, spans: list[dict], session_id: str) -> list[Trace]:
-        """Build Trace objects from spans sharing the same trace_id.
-
-        In multi-agent scenarios (e.g. coordinator -> specialist), a single OTel
-        trace contains multiple ``invoke_agent`` spans. The TraceExtractor expects
-        one AgentInvocationSpan per Trace so that each tool call is evaluated
-        against the correct agent's available_tools. This method splits the spans
-        into one Trace per agent invocation, grouping each agent's descendant
-        inference and tool execution spans with it.
-
-        When only 0 or 1 ``invoke_agent`` spans exist, the original single-Trace
-        behavior is preserved.
-        """
-        # Index spans for parent-child lookups
+    def _build_trace(self, trace_id: str, spans: list[dict], session_id: str) -> Trace:
+        """Build a Trace from spans sharing the same trace_id."""
         spans_by_id: dict[str, dict] = {}
         children_by_parent: dict[str, list[dict]] = defaultdict(list)
 
@@ -126,70 +115,6 @@ class ADKOtelSessionMapper(SessionMapper):
             if parent_span_id:
                 children_by_parent[parent_span_id].append(span)
 
-        # Identify invoke_agent spans
-        agent_spans_raw = [s for s in spans if self._get_operation_name(s) == "invoke_agent"]
-
-        # If 0 or 1 agent invocations, build a single trace (original behavior)
-        if len(agent_spans_raw) <= 1:
-            trace = self._build_single_trace(trace_id, spans, session_id, spans_by_id, children_by_parent)
-            return [trace]
-
-        # Multiple agent invocations — split into per-agent traces.
-        # Sort agent spans by start_time so child agents come after parents.
-        agent_spans_raw.sort(key=lambda s: self.parse_timestamp(s.get("start_time")))
-
-        # Build a mapping: span_id -> owning invoke_agent span_id.
-        # Process agent spans from innermost (latest start) to outermost so
-        # that a tool span nested under a child agent is assigned to that child,
-        # not the parent coordinator.
-        agent_span_ids = {self._extract_span_id(s) for s in agent_spans_raw}
-        span_to_agent: dict[str, str] = {}
-
-        for agent_raw in reversed(agent_spans_raw):
-            agent_id = self._extract_span_id(agent_raw)
-            descendants = self._get_descendants(agent_id, children_by_parent)
-            for desc in descendants:
-                desc_id = self._extract_span_id(desc)
-                # Skip other invoke_agent spans — they form their own traces
-                if desc_id in agent_span_ids:
-                    continue
-                # Only assign if not already claimed by a more specific (inner) agent
-                if desc_id and desc_id not in span_to_agent:
-                    span_to_agent[desc_id] = agent_id
-
-        # Group non-agent spans by their owning agent
-        agent_groups: dict[str, list[dict]] = {self._extract_span_id(a): [] for a in agent_spans_raw}
-        first_agent_id = self._extract_span_id(agent_spans_raw[0])
-        for span in spans:
-            span_id = self._extract_span_id(span)
-            if span_id in agent_span_ids:
-                continue
-            owning_agent = span_to_agent.get(span_id)
-            if owning_agent and owning_agent in agent_groups:
-                agent_groups[owning_agent].append(span)
-            else:
-                # Unclaimed spans go to the earliest agent rather than being dropped
-                agent_groups[first_agent_id].append(span)
-
-        # Build one Trace per agent invocation
-        traces: list[Trace] = []
-        for agent_raw in agent_spans_raw:
-            agent_id = self._extract_span_id(agent_raw)
-            group_spans = [agent_raw] + agent_groups.get(agent_id, [])
-            trace = self._build_single_trace(trace_id, group_spans, session_id, spans_by_id, children_by_parent)
-            traces.append(trace)
-
-        return traces
-
-    def _build_single_trace(
-        self,
-        trace_id: str,
-        spans: list[dict],
-        session_id: str,
-        spans_by_id: dict[str, dict],
-        children_by_parent: dict[str, list[dict]],
-    ) -> Trace:
-        """Build a single Trace from a set of spans."""
         converted_spans: list[InferenceSpan | ToolExecutionSpan | AgentInvocationSpan] = []
 
         for span in spans:
@@ -213,8 +138,7 @@ class ADKOtelSessionMapper(SessionMapper):
                 span_id = self._extract_span_id(span) or "unknown"
                 logger.warning("span_id=<%s>, error=<%s> | failed to convert ADK span", span_id, e)
 
-        # Sort spans chronologically by start_time so downstream consumers
-        # that treat list order as chronology get correct results.
+        # Sort spans chronologically by start_time
         converted_spans.sort(key=lambda s: s.span_info.start_time)
 
         return Trace(spans=converted_spans, trace_id=trace_id, session_id=session_id)

--- a/src/strands_evals/types/trace.py
+++ b/src/strands_evals/types/trace.py
@@ -8,7 +8,7 @@ from datetime import datetime, timezone
 from enum import Enum
 
 from pydantic import BaseModel, field_serializer
-from typing_extensions import Mapping, Sequence, TypeAlias
+from typing_extensions import Any, Mapping, Sequence, TypeAlias
 
 
 class Role(str, Enum):
@@ -111,6 +111,7 @@ class ToolExecutionSpan(BaseSpan):
     span_type: SpanType = SpanType.TOOL_EXECUTION
     tool_call: ToolCall
     tool_result: ToolResult
+    owning_agent_span_id: str | None = None
 
 
 class AgentInvocationSpan(BaseSpan):
@@ -125,9 +126,71 @@ SpanUnion: TypeAlias = InferenceSpan | ToolExecutionSpan | AgentInvocationSpan
 
 
 class Trace(BaseModel):
+    """A single trace within a session.
+
+    A Trace may contain multiple ``AgentInvocationSpan`` instances in multi-agent systems.
+    """
+
     spans: list[SpanUnion]
     trace_id: str
     session_id: str
+
+    def model_post_init(self, __context: Any) -> None:
+        """Assign owning_agent_span_id on tool spans if not already set.
+
+        Note: mutates span objects in place; reusing a span across multiple
+        Trace constructions will keep the first assignment.
+        """
+        tool_spans = [s for s in self.spans if isinstance(s, ToolExecutionSpan) and not s.owning_agent_span_id]
+        if not tool_spans:
+            return
+
+        agent_by_id: dict[str, AgentInvocationSpan] = {}
+        span_by_id: dict[str, BaseSpan] = {}
+        for span in self.spans:
+            sid = span.span_info.span_id
+            if sid:
+                span_by_id[sid] = span
+                if isinstance(span, AgentInvocationSpan):
+                    agent_by_id[sid] = span
+
+        if not agent_by_id:
+            return
+
+        # Root agent: prefer parentless with content, then any parentless, then first
+        root_agent_id: str | None = None
+        for sid, agent in agent_by_id.items():
+            if agent.span_info.parent_span_id is None and (agent.user_prompt or agent.agent_response):
+                root_agent_id = sid
+                break
+        if root_agent_id is None:
+            for sid, agent in agent_by_id.items():
+                if agent.span_info.parent_span_id is None:
+                    root_agent_id = sid
+                    break
+        if root_agent_id is None:
+            root_agent_id = next(iter(agent_by_id))
+
+        owner_cache: dict[str, str | None] = {}
+        for span in tool_spans:
+            current_id = span.span_info.parent_span_id
+            visited: list[str] = []
+            seen: set[str] = set()
+            found: str | None = None
+            while current_id and current_id not in owner_cache and current_id not in seen:
+                if current_id in agent_by_id:
+                    found = current_id
+                    break
+                seen.add(current_id)
+                visited.append(current_id)
+                parent = span_by_id.get(current_id)
+                current_id = parent.span_info.parent_span_id if parent else None
+            else:
+                if current_id and current_id in owner_cache:
+                    found = owner_cache[current_id]
+            for vid in visited:
+                owner_cache[vid] = found
+            span.owning_agent_span_id = found or root_agent_id
 
 
 class Session(BaseModel):

--- a/tests/strands_evals/extractors/test_trace_extractor.py
+++ b/tests/strands_evals/extractors/test_trace_extractor.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 
 import pytest
 
@@ -17,6 +17,22 @@ from strands_evals.types.trace import (
     Trace,
     TraceLevelInput,
 )
+
+
+def _span_info(
+    span_id: str | None = None,
+    parent_span_id: str | None = None,
+    session_id: str = "test",
+) -> SpanInfo:
+    """Helper to create a SpanInfo with minimal boilerplate."""
+    now = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    return SpanInfo(
+        session_id=session_id,
+        span_id=span_id,
+        parent_span_id=parent_span_id,
+        start_time=now,
+        end_time=now,
+    )
 
 
 @pytest.fixture
@@ -54,6 +70,46 @@ def session_with_tools():
         tool_result=ToolResult(content="4"),
     )
     trace = Trace(spans=[agent_span, tool_span], trace_id="trace1", session_id="test")
+    return Session(traces=[trace], session_id="test")
+
+
+@pytest.fixture
+def multi_agent_session():
+    """Coordinator delegates to a specialist with its own tools."""
+    coordinator = AgentInvocationSpan(
+        span_info=_span_info(span_id="coordinator", parent_span_id=None),
+        user_prompt="sqrt(16) * 2 and weather in Paris",
+        agent_response="8, sunny.",
+        available_tools=[ToolConfig(name="ask_math"), ToolConfig(name="ask_research")],
+    )
+    math_agent = AgentInvocationSpan(
+        span_info=_span_info(span_id="math-agent", parent_span_id="coordinator"),
+        user_prompt="sqrt(16) * 2",
+        agent_response="8",
+        available_tools=[ToolConfig(name="square_root"), ToolConfig(name="multiply")],
+    )
+    # Tool directly under coordinator (delegation call)
+    tool_delegate = ToolExecutionSpan(
+        span_info=_span_info(span_id="tool-delegate", parent_span_id="coordinator"),
+        tool_call=ToolCall(name="ask_math", arguments={"query": "sqrt(16)*2"}),
+        tool_result=ToolResult(content="8"),
+        owning_agent_span_id="coordinator",
+    )
+    tool_sqrt = ToolExecutionSpan(
+        span_info=_span_info(span_id="tool-sqrt", parent_span_id="math-agent"),
+        tool_call=ToolCall(name="square_root", arguments={"n": 16}),
+        tool_result=ToolResult(content="4.0"),
+        owning_agent_span_id="math-agent",
+    )
+    tool_mult = ToolExecutionSpan(
+        span_info=_span_info(span_id="tool-mult", parent_span_id="math-agent"),
+        tool_call=ToolCall(name="multiply", arguments={"a": 4, "b": 2}),
+        tool_result=ToolResult(content="8"),
+        owning_agent_span_id="math-agent",
+    )
+    trace = Trace(
+        spans=[coordinator, math_agent, tool_delegate, tool_sqrt, tool_mult], trace_id="t1", session_id="test"
+    )
     return Session(traces=[trace], session_id="test")
 
 
@@ -314,3 +370,86 @@ def test_extract_tool_level_mixed_tz_timestamps():
     assert prior_names == ["tool_x"], (
         f"expected only ['tool_x'] as prior for tool_y (tool_long still running), got {prior_names}"
     )
+
+
+def test_tool_ownership_resolves_to_nearest_agent(multi_agent_session):
+    """Tools resolve to nearest ancestor agent; coordinator's tools are not leaked."""
+    extractor = TraceExtractor(EvaluationLevel.TOOL_LEVEL)
+    result = extractor.extract(multi_agent_session)
+
+    assert len(result) == 3
+    delegate = next(r for r in result if r.tool_execution_details.tool_call.name == "ask_math")
+    sqrt_r = next(r for r in result if r.tool_execution_details.tool_call.name == "square_root")
+    mult_r = next(r for r in result if r.tool_execution_details.tool_call.name == "multiply")
+
+    # Coordinator-owned tool gets coordinator's tool list
+    assert {t.name for t in delegate.available_tools} == {"ask_math", "ask_research"}
+    # Specialist-owned tools get specialist's tool list
+    assert {t.name for t in sqrt_r.available_tools} == {"square_root", "multiply"}
+    assert {t.name for t in mult_r.available_tools} == {"square_root", "multiply"}
+
+
+def test_trace_level_scopes_tools_per_agent(multi_agent_session):
+    """Each agent's turn only includes tool executions owned by that agent."""
+    extractor = TraceExtractor(EvaluationLevel.TRACE_LEVEL)
+    result = extractor.extract(multi_agent_session)
+
+    assert len(result) == 2
+    coord_turn = next(r for r in result if r.span_info.span_id == "coordinator")
+    math_turn = next(r for r in result if r.span_info.span_id == "math-agent")
+
+    # coordinator's turn has only its own delegation tool
+    coord_tools = [h for h in coord_turn.session_history if isinstance(h, list)]
+    assert len(coord_tools) == 1
+    assert coord_tools[0][0].tool_call.name == "ask_math"
+
+    # math_agent's turn includes its own tools (plus coordinator's from history)
+    math_tools = [h for h in math_turn.session_history if isinstance(h, list)]
+    assert len(math_tools) == 2
+    assert math_tools[0][0].tool_call.name == "ask_math"  # accumulated from coordinator's turn
+    assert {te.tool_call.name for te in math_tools[1]} == {"square_root", "multiply"}
+
+
+def test_span_id_none_does_not_collide():
+    """Two tool spans with span_id=None under different agents resolve independently."""
+    coordinator = AgentInvocationSpan(
+        span_info=_span_info(span_id="coordinator", parent_span_id=None),
+        user_prompt="Do two things",
+        agent_response="Done.",
+        available_tools=[ToolConfig(name="delegate")],
+    )
+    spec_a = AgentInvocationSpan(
+        span_info=_span_info(span_id="spec-a", parent_span_id="coordinator"),
+        user_prompt="A",
+        agent_response="A done",
+        available_tools=[ToolConfig(name="tool_a")],
+    )
+    spec_b = AgentInvocationSpan(
+        span_info=_span_info(span_id="spec-b", parent_span_id="coordinator"),
+        user_prompt="B",
+        agent_response="B done",
+        available_tools=[ToolConfig(name="tool_b")],
+    )
+    tool_a = ToolExecutionSpan(
+        span_info=_span_info(span_id=None, parent_span_id="spec-a"),
+        tool_call=ToolCall(name="tool_a", arguments={}),
+        tool_result=ToolResult(content="a"),
+        owning_agent_span_id="spec-a",
+    )
+    tool_b = ToolExecutionSpan(
+        span_info=_span_info(span_id=None, parent_span_id="spec-b"),
+        tool_call=ToolCall(name="tool_b", arguments={}),
+        tool_result=ToolResult(content="b"),
+        owning_agent_span_id="spec-b",
+    )
+
+    trace = Trace(spans=[coordinator, spec_a, spec_b, tool_a, tool_b], trace_id="t1", session_id="test")
+    session = Session(traces=[trace], session_id="test")
+
+    extractor = TraceExtractor(EvaluationLevel.TOOL_LEVEL)
+    result = extractor.extract(session)
+
+    result_a = next(r for r in result if r.tool_execution_details.tool_call.name == "tool_a")
+    result_b = next(r for r in result if r.tool_execution_details.tool_call.name == "tool_b")
+    assert [t.name for t in result_a.available_tools] == ["tool_a"]
+    assert [t.name for t in result_b.available_tools] == ["tool_b"]

--- a/tests/strands_evals/mappers/test_adk_otel_session_mapper.py
+++ b/tests/strands_evals/mappers/test_adk_otel_session_mapper.py
@@ -672,6 +672,24 @@ class TestDataFormatCompatibility:
         """Spans in to_json format (context.trace_id, parent_id with 0x prefix) are parsed."""
         spans = [
             {
+                "name": "invoke_agent my_agent",
+                "context": {"trace_id": "0xabc123", "span_id": "0x789abc"},
+                "start_time": "2026-07-22T16:34:19.900000Z",
+                "end_time": "2026-07-22T16:34:19.920000Z",
+                "attributes": {
+                    "gen_ai.operation.name": "invoke_agent",
+                    "gen_ai.agent.name": "my_agent",
+                    "gcp.vertex.agent.llm_request": "",
+                },
+                "events": [
+                    {
+                        "name": "gen_ai.user.message",
+                        "timestamp": "2026-07-22T16:34:19.900000Z",
+                        "attributes": {"content": "hello"},
+                    }
+                ],
+            },
+            {
                 "name": "execute_tool calculator",
                 "context": {"trace_id": "0xabc123", "span_id": "0xdef456"},
                 "parent_id": "0x789abc",
@@ -684,10 +702,12 @@ class TestDataFormatCompatibility:
                     "gcp.vertex.agent.tool_call_args": '{"x": 1}',
                     "gcp.vertex.agent.tool_response": "result",
                 },
-            }
+            },
         ]
         session = self.mapper.map_to_session(spans, SESSION_ID)
-        tool = session.traces[0].spans[0]
+        tool_spans = [s for s in session.traces[0].spans if isinstance(s, ToolExecutionSpan)]
+        assert len(tool_spans) == 1
+        tool = tool_spans[0]
         assert tool.span_info.trace_id == "abc123"
         assert tool.span_info.span_id == "def456"
         assert tool.span_info.parent_span_id == "789abc"
@@ -788,13 +808,13 @@ class TestErrorHandling:
 
 
 class TestMultiAgentSplitting:
-    """Tests for per-agent trace splitting in multi-agent scenarios."""
+    """Tests that multi-agent traces are kept as a single Trace (scoping handled by TraceExtractor)."""
 
     def setup_method(self):
         self.mapper = ADKOtelSessionMapper()
 
-    def test_coordinator_specialist_produces_separate_traces(self):
-        """Two invoke_agent spans in one trace produce one Trace per agent with correct tools."""
+    def test_coordinator_specialist_produces_single_trace(self):
+        """Two invoke_agent spans in one OTel trace produce a single Trace with both agents."""
         spans = [
             # Coordinator agent
             make_span(
@@ -863,43 +883,27 @@ class TestMultiAgentSplitting:
 
         session = self.mapper.map_to_session(spans, SESSION_ID)
 
-        # Should produce two traces — one per agent
-        assert len(session.traces) == 2
+        # Single trace containing both agents
+        assert len(session.traces) == 1
+        trace = session.traces[0]
 
-        # Find each agent's trace
-        coord_trace = next(
-            t
-            for t in session.traces
-            if any(
-                isinstance(s, AgentInvocationSpan) and s.metadata.get("agent_name") == "coordinator" for s in t.spans
-            )
-        )
-        spec_trace = next(
-            t
-            for t in session.traces
-            if any(isinstance(s, AgentInvocationSpan) and s.metadata.get("agent_name") == "specialist" for s in t.spans)
-        )
+        # Both agent spans present
+        agent_spans = [s for s in trace.spans if isinstance(s, AgentInvocationSpan)]
+        assert len(agent_spans) == 2
 
-        # Coordinator should have its own tools, not the specialist's
-        coord_agent = [s for s in coord_trace.spans if isinstance(s, AgentInvocationSpan)][0]
+        # Each agent retains its own available_tools
+        coord_agent = next(s for s in agent_spans if s.metadata.get("agent_name") == "coordinator")
+        spec_agent = next(s for s in agent_spans if s.metadata.get("agent_name") == "specialist")
         assert coord_agent.available_tools[0].name == "delegate"
-        # Coordinator should NOT leak the specialist's tool response
-        assert "SPECIALIST_TOOL_OUTPUT" not in coord_agent.agent_response
-
-        # Specialist should have its own tools and response
-        spec_agent = [s for s in spec_trace.spans if isinstance(s, AgentInvocationSpan)][0]
         assert spec_agent.available_tools[0].name == "book_flight"
-        assert spec_agent.agent_response == "Booked seat 4A."
 
-        # Tool execution span should only appear in the specialist's trace
-        coord_tools = [s for s in coord_trace.spans if isinstance(s, ToolExecutionSpan)]
-        spec_tools = [s for s in spec_trace.spans if isinstance(s, ToolExecutionSpan)]
-        assert len(coord_tools) == 0
-        assert len(spec_tools) == 1
-        assert spec_tools[0].tool_call.name == "book_flight"
+        # Tool execution span present in the trace
+        tool_spans = [s for s in trace.spans if isinstance(s, ToolExecutionSpan)]
+        assert len(tool_spans) == 1
+        assert tool_spans[0].tool_call.name == "book_flight"
 
-    def test_unclaimed_spans_assigned_to_earliest_agent(self):
-        """Spans not nested under any invoke_agent go to the earliest agent's trace."""
+    def test_unclaimed_spans_in_single_trace(self):
+        """Spans not nested under any invoke_agent remain in the single trace."""
         spans = [
             # Orphan tool span — not parented to either agent
             make_span(
@@ -955,26 +959,17 @@ class TestMultiAgentSplitting:
         ]
 
         session = self.mapper.map_to_session(spans, SESSION_ID)
-        assert len(session.traces) == 2
 
-        # The orphan tool should appear in the earliest agent's trace (alpha)
-        alpha_trace = next(
-            t
-            for t in session.traces
-            if any(isinstance(s, AgentInvocationSpan) and s.metadata.get("agent_name") == "alpha" for s in t.spans)
-        )
-        beta_trace = next(
-            t
-            for t in session.traces
-            if any(isinstance(s, AgentInvocationSpan) and s.metadata.get("agent_name") == "beta" for s in t.spans)
-        )
+        # Single trace with everything
+        assert len(session.traces) == 1
+        trace = session.traces[0]
 
-        alpha_tools = [s for s in alpha_trace.spans if isinstance(s, ToolExecutionSpan)]
-        beta_tools = [s for s in beta_trace.spans if isinstance(s, ToolExecutionSpan)]
-
-        assert len(alpha_tools) == 1
-        assert alpha_tools[0].tool_call.name == "audit"
-        assert len(beta_tools) == 0
+        # Both agents and the orphan tool are in the same trace
+        agent_spans = [s for s in trace.spans if isinstance(s, AgentInvocationSpan)]
+        tool_spans = [s for s in trace.spans if isinstance(s, ToolExecutionSpan)]
+        assert len(agent_spans) == 2
+        assert len(tool_spans) == 1
+        assert tool_spans[0].tool_call.name == "audit"
 
 
 # ============================================================================

--- a/tests/strands_evals/types/test_trace.py
+++ b/tests/strands_evals/types/test_trace.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 
 from strands_evals.types.trace import (
     AgentInvocationSpan,
@@ -179,3 +179,120 @@ def test_context_creation():
     assert context.user_prompt.text == "What is 2+2?"
     assert context.agent_response.text == "4"
     assert context.tool_execution_history is None
+
+
+def _info(span_id: str, parent_span_id: str | None = None) -> SpanInfo:
+    """Helper to create SpanInfo with minimal boilerplate."""
+    now = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    return SpanInfo(
+        session_id="s1",
+        span_id=span_id,
+        parent_span_id=parent_span_id,
+        start_time=now,
+        end_time=now,
+    )
+
+
+class TestTraceToolOwnership:
+    """Tests for automatic tool ownership assignment in Trace.model_post_init."""
+
+    def test_single_agent_assigns_ownership(self):
+        """With one agent, all tools are owned by it."""
+        agent = AgentInvocationSpan(
+            span_info=_info("agent-1"), user_prompt="hi", agent_response="hello", available_tools=[]
+        )
+        tool = ToolExecutionSpan(
+            span_info=_info("tool-1", parent_span_id="agent-1"),
+            tool_call=ToolCall(name="calc", arguments={}),
+            tool_result=ToolResult(content="42"),
+        )
+
+        Trace(spans=[agent, tool], trace_id="t1", session_id="s1")
+
+        assert tool.owning_agent_span_id == "agent-1"
+
+    def test_multi_agent_assigns_to_nearest_ancestor(self):
+        """Each tool is owned by the nearest agent in its parent chain."""
+        root = AgentInvocationSpan(span_info=_info("root"), user_prompt="hi", agent_response="hey", available_tools=[])
+        child = AgentInvocationSpan(
+            span_info=_info("child", parent_span_id="root"),
+            user_prompt="sub",
+            agent_response="done",
+            available_tools=[],
+        )
+        tool_of_root = ToolExecutionSpan(
+            span_info=_info("t-root", parent_span_id="root"),
+            tool_call=ToolCall(name="a", arguments={}),
+            tool_result=ToolResult(content="1"),
+        )
+        tool_of_child = ToolExecutionSpan(
+            span_info=_info("t-child", parent_span_id="child"),
+            tool_call=ToolCall(name="b", arguments={}),
+            tool_result=ToolResult(content="2"),
+        )
+
+        Trace(spans=[root, child, tool_of_root, tool_of_child], trace_id="t1", session_id="s1")
+
+        assert tool_of_root.owning_agent_span_id == "root"
+        assert tool_of_child.owning_agent_span_id == "child"
+
+    def test_orphan_tool_falls_back_to_root_agent(self):
+        """A tool whose parent chain doesn't reach any agent falls back to root."""
+        agent = AgentInvocationSpan(
+            span_info=_info("agent-1"), user_prompt="hi", agent_response="hello", available_tools=[]
+        )
+        tool = ToolExecutionSpan(
+            span_info=_info("tool-1", parent_span_id="nonexistent"),
+            tool_call=ToolCall(name="x", arguments={}),
+            tool_result=ToolResult(content="y"),
+        )
+
+        Trace(spans=[agent, tool], trace_id="t1", session_id="s1")
+
+        assert tool.owning_agent_span_id == "agent-1"
+
+    def test_no_agents_leaves_ownership_none(self):
+        """With no agents in the trace, ownership is not set."""
+        tool = ToolExecutionSpan(
+            span_info=_info("tool-1"),
+            tool_call=ToolCall(name="x", arguments={}),
+            tool_result=ToolResult(content="y"),
+        )
+
+        Trace(spans=[tool], trace_id="t1", session_id="s1")
+
+        assert tool.owning_agent_span_id is None
+
+    def test_skips_when_already_set(self):
+        """If ownership is already populated, model_post_init is a no-op."""
+        agent = AgentInvocationSpan(
+            span_info=_info("agent-1"), user_prompt="hi", agent_response="hello", available_tools=[]
+        )
+        tool = ToolExecutionSpan(
+            span_info=_info("tool-1", parent_span_id="agent-1"),
+            tool_call=ToolCall(name="x", arguments={}),
+            tool_result=ToolResult(content="y"),
+            owning_agent_span_id="custom-override",
+        )
+
+        Trace(spans=[agent, tool], trace_id="t1", session_id="s1")
+
+        assert tool.owning_agent_span_id == "custom-override"
+
+    def test_idempotent_on_deserialization(self):
+        """Deserializing a Trace with ownership already set doesn't re-walk."""
+        agent = AgentInvocationSpan(
+            span_info=_info("agent-1"), user_prompt="hi", agent_response="hello", available_tools=[]
+        )
+        tool = ToolExecutionSpan(
+            span_info=_info("tool-1", parent_span_id="agent-1"),
+            tool_call=ToolCall(name="x", arguments={}),
+            tool_result=ToolResult(content="y"),
+        )
+        trace = Trace(spans=[agent, tool], trace_id="t1", session_id="s1")
+        assert tool.owning_agent_span_id == "agent-1"
+
+        # Round-trip through JSON
+        restored = Trace.model_validate_json(trace.model_dump_json())
+        restored_tool = next(s for s in restored.spans if isinstance(s, ToolExecutionSpan))
+        assert restored_tool.owning_agent_span_id == "agent-1"


### PR DESCRIPTION
## Description

`ToolSelectionAccuracyEvaluator` produces false negatives for multi-agent systems because all tool calls are evaluated against a single merged `available_tools` list. This PR fixes the scoping so each tool call is evaluated against only its owning agent's tools.

The fix resolves tool ownership by walking each tool span's parent chain to its nearest agent, rather than assuming one agent per trace. This also removes the per-agent trace splitting that was added to the ADK mapper in #326 — that splitting was a workaround for the extractor's single-agent assumption, and is no longer needed now that the extractor handles multi-agent traces directly. The mapper now emits one faithful Trace per OTel trace and re-parents spans to the nearest converted ancestor, or to the root agent span if no converted ancestors were found.

Additionally, when a framework doesn't emit tool metadata in its spans, the judge previously had no `available_tools` context and no basis for evaluating selection accuracy. A fallback prompt now tells the judge to evaluate based on the conversation context instead, handling the case where multi-agent scoping leaves a child agent's tool list empty.

Note: This PR does not integrate the Langchain OTel and OpenInference mappers because they currently collapse traces to one agent span. Fixing them would require a major overhaul and is deferred to a follow-up.

## Related Issue

Partially addresses #332

## Documentation PR

N/A

## Type of Change

Bug fix

## Testing

I ran `hatch run prepare`

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.