### PR TITLE
ci: update mypy requirement from <2.0.0 to <3.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ test = [
 
 dev = [
     "hatch>=1.0.0,<2.0.0",
-    "mypy>=1.15.0,<2.0.0",
+    "mypy>=1.15.0,<3.0.0",
     "pre-commit>=3.2.0,<4.7.0",
     "ruff>=0.13.0,<0.17.0",
 ]
@@ -121,7 +121,7 @@ prepare = [
 installer = "uv"
 features = ["otel", "langfuse", "langchain", "opensearch"]
 dependencies = [
-  "mypy>=1.15.0,<2.0.0",
+  "mypy>=1.15.0,<3.0.0",
   "ruff>=0.13.0,<0.17.0",
   # Include required pacakge dependencies for mypy
   "strands-agents-evals @ {root:uri}",
@@ -190,7 +190,7 @@ dependencies = [
 ]
 extra-dependencies = [
     "hatch>=1.0.0,<2.0.0",
-    "mypy>=1.15.0,<2.0.0",
+    "mypy>=1.15.0,<3.0.0",
     "pre-commit>=3.2.0,<4.7.0",
     "ruff>=0.13.0,<0.17.0",
 ]


### PR DESCRIPTION
Relaxes the mypy version constraint from `>=1.15.0,<2.0.0` to `>=1.15.0,<3.0.0` across all three declarations in `pyproject.toml` (`dev` optional-deps, `hatch-static-analysis` env, and `default` env extra-deps).

This mirrors the change from Dependabot PR #282, opened as a standalone PR because the dependabot pr was having weird issues with the dependabot.yaml file validation