### PR TITLE
ci: update opentelemetry-instrumentation-langchain requirement from <0.62.0,>=0.40.0 to >=0.40.0,<0.63.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ langchain = [
     "langchain-aws>=0.2.0",
     "langgraph>=0.2.0",
     "openinference-instrumentation-langchain>=0.1.0",
-    "opentelemetry-instrumentation-langchain>=0.40.0,<0.62.0",
+    "opentelemetry-instrumentation-langchain>=0.40.0,<0.63.0",
 ]
 adk = ["google-adk>=2.0.0,<3.0.0"]
 claude = [


### PR DESCRIPTION
Rebase of #288 onto the latest `main`.

Updates the `opentelemetry-instrumentation-langchain` requirement to permit the latest version:

```
- "opentelemetry-instrumentation-langchain>=0.40.0,<0.62.0",
+ "opentelemetry-instrumentation-langchain>=0.40.0,<0.63.0",
```

The original Dependabot PR (#288) had automatic rebases disabled after being open for over 30 days, so this PR recreates the change on top of current `main`.