### PR TITLE
fix: change bridge_parent_gaps to return new spans instead of mutating in place

### DIFF
--- a/src/strands_evals/mappers/adk_otel_session_mapper.py
+++ b/src/strands_evals/mappers/adk_otel_session_mapper.py
@@ -144,7 +144,7 @@ class ADKOtelSessionMapper(SessionMapper):
         }
 
         converted_spans.sort(key=lambda s: s.span_info.start_time)
-        bridge_parent_gaps(converted_spans, raw_parent_map)
+        converted_spans = bridge_parent_gaps(converted_spans, raw_parent_map)
 
         return Trace(spans=converted_spans, trace_id=trace_id, session_id=session_id)
 

--- a/src/strands_evals/mappers/generic_gen_ai_session_mapper.py
+++ b/src/strands_evals/mappers/generic_gen_ai_session_mapper.py
@@ -30,7 +30,7 @@ from ..types.trace import (
     UserMessage,
 )
 from .session_mapper import SessionMapper
-from .utils import join_tool_result_content
+from .utils import bridge_parent_gaps, join_tool_result_content
 
 logger = logging.getLogger(__name__)
 
@@ -149,6 +149,12 @@ class GenericGenAISessionMapper(SessionMapper):
                     span.get("span_id", "?"),
                     e,
                 )
+
+        # Fix parent_span_id on converted spans that point to skipped intermediaries
+        raw_parent_map: dict[str, str | None] = {
+            sid: s.get("parent_span_id") for s in spans if (sid := s.get("span_id"))
+        }
+        converted_spans = bridge_parent_gaps(converted_spans, raw_parent_map)
 
         return Trace(spans=converted_spans, trace_id=trace_id, session_id=session_id)
 

--- a/src/strands_evals/mappers/openinference_session_mapper.py
+++ b/src/strands_evals/mappers/openinference_session_mapper.py
@@ -42,7 +42,7 @@ from .constants import (
     SCOPES_OPENINFERENCE_FAMILY,
 )
 from .session_mapper import SessionMapper
-from .utils import safe_json_parse
+from .utils import bridge_parent_gaps, safe_json_parse
 
 logger = logging.getLogger(__name__)
 
@@ -298,6 +298,12 @@ class OpenInferenceSessionMapper(SessionMapper):
             for converted in converted_spans:
                 if isinstance(converted, AgentInvocationSpan) and not converted.available_tools:
                     converted.available_tools = tools_list
+
+        # Fix parent_span_id on converted spans that point to skipped intermediaries
+        raw_parent_map: dict[str, str | None] = {
+            sid: s.get("parent_span_id") for s in spans if (sid := s.get("span_id"))
+        }
+        converted_spans = bridge_parent_gaps(converted_spans, raw_parent_map)
 
         return Trace(spans=converted_spans, trace_id=trace_id, session_id=session_id)
 

--- a/src/strands_evals/mappers/openinference_session_mapper.py
+++ b/src/strands_evals/mappers/openinference_session_mapper.py
@@ -42,7 +42,7 @@ from .constants import (
     SCOPES_OPENINFERENCE_FAMILY,
 )
 from .session_mapper import SessionMapper
-from .utils import bridge_parent_gaps, safe_json_parse
+from .utils import safe_json_parse
 
 logger = logging.getLogger(__name__)
 
@@ -298,12 +298,6 @@ class OpenInferenceSessionMapper(SessionMapper):
             for converted in converted_spans:
                 if isinstance(converted, AgentInvocationSpan) and not converted.available_tools:
                     converted.available_tools = tools_list
-
-        # Fix parent_span_id on converted spans that point to skipped intermediaries
-        raw_parent_map: dict[str, str | None] = {
-            sid: s.get("parent_span_id") for s in spans if (sid := s.get("span_id"))
-        }
-        converted_spans = bridge_parent_gaps(converted_spans, raw_parent_map)
 
         return Trace(spans=converted_spans, trace_id=trace_id, session_id=session_id)
 

--- a/src/strands_evals/mappers/opensearch_session_mapper.py
+++ b/src/strands_evals/mappers/opensearch_session_mapper.py
@@ -100,7 +100,7 @@ class OpenSearchSessionMapper(SessionMapper):
             r.span_id: (r.parent_span_id or None) for r in sorted_records if r.span_id
         }
 
-        bridge_parent_gaps(spans, raw_parent_map)
+        spans = bridge_parent_gaps(spans, raw_parent_map)
 
         return Trace(spans=spans, trace_id=trace_id, session_id=session_id)
 

--- a/src/strands_evals/mappers/strands_in_memory_session_mapper.py
+++ b/src/strands_evals/mappers/strands_in_memory_session_mapper.py
@@ -162,7 +162,7 @@ class StrandsInMemorySessionMapper(SessionMapper):
             parent_id = format(span.parent.span_id, "016x") if span.parent else None
             raw_parent_map[span_id] = parent_id
 
-        bridge_parent_gaps(converted_spans, raw_parent_map)
+        converted_spans = bridge_parent_gaps(converted_spans, raw_parent_map)
 
         return Trace(spans=converted_spans, trace_id=trace_id, session_id=session_id)
 

--- a/src/strands_evals/mappers/utils.py
+++ b/src/strands_evals/mappers/utils.py
@@ -278,30 +278,40 @@ def readable_spans_to_dicts(spans: Any) -> list[dict]:
 def bridge_parent_gaps(
     converted_spans: list[SpanUnion],
     raw_parent_map: dict[str, str | None],
-) -> None:
-    """Patch parent_span_id on converted spans to skip unconverted intermediates.
+) -> list[SpanUnion]:
+    """Return spans with parent_span_id adjusted to skip unconverted intermediates.
 
-    When a converted span's parent_span_id points to a span that wasn't
-    converted (e.g. execute_event_loop_cycle in Strands SDK, call_llm in ADK),
-    this walks up via raw_parent_map until it finds a converted ancestor — or
-    sets parent_span_id to None if no converted ancestor exists.
+    Walks up `raw_parent_map` to find the nearest converted ancestor. Sets
+    parent_span_id to None if no converted ancestor exists.
 
     Args:
-        converted_spans: Flat list of converted spans from a single trace.
-        raw_parent_map: span_id -> parent_span_id for ALL raw spans, including
-            unconverted ones.
+        converted_spans: Converted spans from a single trace.
+        raw_parent_map: span_id -> parent_span_id for all raw spans (including unconverted).
+
+    Returns:
+        New list of spans with corrected parent_span_id values.
     """
     converted_ids = {s.span_info.span_id for s in converted_spans if s.span_info.span_id}
+    result: list[SpanUnion] = []
     for span in converted_spans:
         parent_id = span.span_info.parent_span_id
-        if parent_id and parent_id not in converted_ids:
-            visited: set[str] = set()
-            current: str | None = parent_id
-            while current and current not in visited:
-                visited.add(current)
-                if current in converted_ids:
-                    span.span_info.parent_span_id = current
-                    break
-                current = raw_parent_map.get(current)
-            else:
-                span.span_info.parent_span_id = None
+        # No-op if the parent id points to no span or a converted span
+        if not parent_id or parent_id in converted_ids:
+            result.append(span)
+            continue
+
+        # Walk up to find converted ancestor
+        visited: set[str] = set()
+        current: str | None = parent_id
+        new_parent: str | None = None
+        while current and current not in visited:
+            visited.add(current)
+            if current in converted_ids:
+                new_parent = current
+                break
+            current = raw_parent_map.get(current)
+        patched = span.model_copy(
+            update={"span_info": span.span_info.model_copy(update={"parent_span_id": new_parent})}
+        )
+        result.append(patched)
+    return result

--- a/src/strands_evals/mappers/utils.py
+++ b/src/strands_evals/mappers/utils.py
@@ -281,12 +281,15 @@ def bridge_parent_gaps(
 ) -> list[SpanUnion]:
     """Return spans with parent_span_id adjusted to skip unconverted intermediates.
 
-    Walks up `raw_parent_map` to find the nearest converted ancestor. Sets
-    parent_span_id to None if no converted ancestor exists.
+    When a converted span's parent_span_id points to a span that wasn't
+    converted (e.g. execute_event_loop_cycle in Strands SDK, call_llm in ADK),
+    this walks up via raw_parent_map until it finds a converted ancestor — or
+    sets parent_span_id to None if no converted ancestor exists.
 
     Args:
-        converted_spans: Converted spans from a single trace.
-        raw_parent_map: span_id -> parent_span_id for all raw spans (including unconverted).
+        converted_spans: Flat list of converted spans from a single trace.
+        raw_parent_map: span_id -> parent_span_id for ALL raw spans, including
+            unconverted ones.
 
     Returns:
         New list of spans with corrected parent_span_id values.
@@ -295,7 +298,7 @@ def bridge_parent_gaps(
     result: list[SpanUnion] = []
     for span in converted_spans:
         parent_id = span.span_info.parent_span_id
-        # No-op if the parent id points to no span or a converted span
+        # Nothing to bridge: no parent, or the parent was converted
         if not parent_id or parent_id in converted_ids:
             result.append(span)
             continue

--- a/tests/strands_evals/mappers/test_generic_gen_ai_session_mapper.py
+++ b/tests/strands_evals/mappers/test_generic_gen_ai_session_mapper.py
@@ -1462,3 +1462,78 @@ class TestOtelConventionIntegration:
         # Wrong session_id → no traces
         session_wrong = mapper.map_to_session(otel_convention_spans, session_id="wrong-id")
         assert len(session_wrong.traces) == 0
+
+
+class TestUnconvertedSpanReparenting:
+    """Tool nested under an unconverted span reparents to the converted agent."""
+
+    def setup_method(self):
+        self.mapper = GenericGenAISessionMapper()
+
+    def test_tool_under_unconverted_span_reparents_to_agent(self):
+        """Tool whose raw parent is an unconverted workflow span gets reparented to the agent."""
+        agent = make_span(span_id="agent-1", operation_name="invoke_agent")
+        workflow = make_span(span_id="workflow-1", parent_span_id="agent-1", name="my_flow.workflow")
+        tool = make_span(
+            span_id="tool-1",
+            parent_span_id="workflow-1",
+            operation_name="execute_tool",
+            attributes={
+                "gen_ai.tool.name": "calculator",
+                "gen_ai.tool.call.id": "call-1",
+                "gen_ai.tool.input": '{"expr": "2+2"}',
+                "gen_ai.tool.output": "4",
+                "gen_ai.tool.status": "success",
+            },
+        )
+        session = self.mapper.map_to_session([agent, workflow, tool], "sess-1")
+
+        spans = session.traces[0].spans
+        assert [s.span_info.span_id for s in spans] == ["agent-1", "tool-1"]
+        tool_span = next(s for s in spans if isinstance(s, ToolExecutionSpan))
+        assert tool_span.span_info.parent_span_id == "agent-1"
+        assert tool_span.agent_span_id == "agent-1"
+
+    def test_deeply_nested_unconverted_spans_bridged(self):
+        """Tool under multiple unconverted intermediaries still reaches the converted agent."""
+        agent = make_span(span_id="agent-1", operation_name="invoke_agent")
+        mid_1 = make_span(span_id="mid-1", parent_span_id="agent-1", name="orchestrator")
+        mid_2 = make_span(span_id="mid-2", parent_span_id="mid-1", name="sub-orchestrator")
+        tool = make_span(
+            span_id="tool-1",
+            parent_span_id="mid-2",
+            operation_name="execute_tool",
+            attributes={
+                "gen_ai.tool.name": "search",
+                "gen_ai.tool.call.id": "call-2",
+                "gen_ai.tool.input": '{"q": "test"}',
+                "gen_ai.tool.output": "found",
+                "gen_ai.tool.status": "success",
+            },
+        )
+        session = self.mapper.map_to_session([agent, mid_1, mid_2, tool], "sess-1")
+
+        spans = session.traces[0].spans
+        tool_span = next(s for s in spans if isinstance(s, ToolExecutionSpan))
+        assert tool_span.span_info.parent_span_id == "agent-1"
+
+    def test_no_converted_ancestor_sets_parent_none(self):
+        """Tool whose ancestry chain has no converted span gets parent_span_id=None."""
+        workflow = make_span(span_id="workflow-1", name="background_task")
+        tool = make_span(
+            span_id="tool-1",
+            parent_span_id="workflow-1",
+            operation_name="execute_tool",
+            attributes={
+                "gen_ai.tool.name": "notify",
+                "gen_ai.tool.call.id": "call-3",
+                "gen_ai.tool.input": "{}",
+                "gen_ai.tool.output": "ok",
+                "gen_ai.tool.status": "success",
+            },
+        )
+        session = self.mapper.map_to_session([workflow, tool], "sess-1")
+
+        spans = session.traces[0].spans
+        assert len(spans) == 1
+        assert spans[0].span_info.parent_span_id is None

--- a/tests/strands_evals/mappers/test_utils.py
+++ b/tests/strands_evals/mappers/test_utils.py
@@ -374,9 +374,10 @@ class TestBridgeParentGaps:
         # call_llm is unconverted but its parent is the converted agent
         raw_parent_map = {"agent": None, "call_llm": "agent", "tool": "call_llm"}
 
-        bridge_parent_gaps([agent, tool], raw_parent_map)
+        result = bridge_parent_gaps([agent, tool], raw_parent_map)
 
-        assert tool.span_info.parent_span_id == "agent"
+        assert result[1].span_info.parent_span_id == "agent"
+        assert tool.span_info.parent_span_id == "call_llm"
 
     def test_sets_none_when_no_converted_ancestor(self):
         """Tool whose chain never reaches a converted span gets parent_span_id=None."""
@@ -387,6 +388,7 @@ class TestBridgeParentGaps:
         )
         raw_parent_map = {"orphan": "also_gone", "also_gone": None, "tool": "orphan"}
 
-        bridge_parent_gaps([tool], raw_parent_map)
+        result = bridge_parent_gaps([tool], raw_parent_map)
 
-        assert tool.span_info.parent_span_id is None
+        assert result[0].span_info.parent_span_id is None
+        assert tool.span_info.parent_span_id == "orphan"


### PR DESCRIPTION
## Description
`bridge_parent_gaps` currently mutates its input spans in-place. This hides the dependency between it and downstream consumers like `model_post_init`. This PR makes `bridge_parent_gaps` return the modified spans so that call sites explicitly operate on the result.

This PR also adds a `bridge_parent_gaps` call to `GenericGenAISessionMapper` in preparation for OpenAI Agents support. OpenAI Agents add unconverted workflow spans (Traceloop/gen_ai) between converted spans, which make their parent span ids incorrect.

## Related Issues

https://github.com/strands-agents/evals/pull/365

## Documentation PR

## Type of Change

Bug fix

## Testing

How have you tested the change? Verify that the changes do not break functionality or introduce new warnings.

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.