### PR TITLE
fix: skip non-serializable tools in OutputEvaluator serialization

### DIFF
--- a/src/strands_evals/evaluators/output_evaluator.py
+++ b/src/strands_evals/evaluators/output_evaluator.py
@@ -77,9 +77,11 @@ class OutputEvaluator(Evaluator[InputT, OutputT]):
                 try:
                     json.dumps(tool)
                 except (TypeError, ValueError):
-                    tool_name = getattr(tool, "tool_name", None) or repr(tool)
+                    tool_name = (
+                        getattr(tool, "tool_name", None) or getattr(tool, "__name__", None) or type(tool).__name__
+                    )
                     logger.warning(
-                        "skipping non-JSON-serializable tool <%s> during serialization; "
+                        "tool_name=<%s> | skipping non-JSON-serializable tool during serialization, "
                         "re-attach it via the `tools` attribute after loading",
                         tool_name,
                     )

--- a/src/strands_evals/evaluators/output_evaluator.py
+++ b/src/strands_evals/evaluators/output_evaluator.py
@@ -1,3 +1,5 @@
+import json
+import logging
 from typing import Any, cast
 
 from strands import Agent
@@ -7,6 +9,8 @@ from ..types.evaluation import EvaluationData, EvaluationOutput, InputT, OutputT
 from .evaluator import Evaluator
 from .prompt_templates.case_prompt_template import compose_test_prompt
 from .prompt_templates.prompt_templates import judge_output_template as SYSTEM_PROMPT
+
+logger = logging.getLogger(__name__)
 
 
 class OutputEvaluator(Evaluator[InputT, OutputT]):
@@ -40,7 +44,50 @@ class OutputEvaluator(Evaluator[InputT, OutputT]):
         self.include_inputs = include_inputs
         self.system_prompt = system_prompt
         self.uses_environment_state = uses_environment_state
-        self.tools = tools
+        # Stored privately so the base to_dict() skips it; to_dict() below re-adds
+        # the JSON-serializable subset so tools like module path strings round-trip.
+        self._tools = tools
+
+    @property
+    def tools(self) -> list[Any] | None:
+        """Optional tools for the evaluator agent.
+
+        Only JSON-serializable entries (e.g. module path strings) survive `to_dict()`;
+        callables are skipped with a warning and must be re-attached after `from_dict()`.
+        """
+        return self._tools
+
+    @tools.setter
+    def tools(self, value: list[Any] | None) -> None:
+        self._tools = value
+
+    def to_dict(self) -> dict:
+        """
+        Convert the evaluator into a dictionary.
+
+        Returns:
+            dict: A dictionary containing the evaluator's information. Includes only the
+            JSON-serializable tools; non-serializable tools (e.g. decorated functions)
+            are skipped with a warning since `from_dict()` cannot reconstruct them.
+        """
+        _dict = super().to_dict()
+        if self._tools:
+            serializable_tools = []
+            for tool in self._tools:
+                try:
+                    json.dumps(tool)
+                except (TypeError, ValueError):
+                    tool_name = getattr(tool, "tool_name", None) or repr(tool)
+                    logger.warning(
+                        "skipping non-JSON-serializable tool <%s> during serialization; "
+                        "re-attach it via the `tools` attribute after loading",
+                        tool_name,
+                    )
+                else:
+                    serializable_tools.append(tool)
+            if serializable_tools:
+                _dict["tools"] = serializable_tools
+        return _dict
 
     def _build_prompt(self, evaluation_case: EvaluationData[InputT, OutputT]) -> str | list:
         """Build the evaluation prompt for a test case.

--- a/tests/strands_evals/evaluators/test_output_evaluator.py
+++ b/tests/strands_evals/evaluators/test_output_evaluator.py
@@ -1,3 +1,5 @@
+import json
+import logging
 from unittest.mock import Mock, patch
 
 import pytest
@@ -281,6 +283,63 @@ def test_output_evaluator_init_without_tools_defaults_to_none():
     evaluator = OutputEvaluator(rubric="Test rubric")
 
     assert evaluator.tools is None
+
+
+def test_output_evaluator_to_dict_skips_non_serializable_tools(caplog):
+    """Test that to_dict() output is JSON-serializable when callable tools are set (issue #373)"""
+
+    def verify_claim(claim: str) -> str:
+        return "verified"
+
+    evaluator = OutputEvaluator(rubric="Test rubric", tools=[verify_claim])
+    with caplog.at_level(logging.WARNING):
+        evaluator_dict = evaluator.to_dict()
+
+    assert "tools" not in evaluator_dict
+    json.dumps(evaluator_dict)
+    assert "skipping non-JSON-serializable tool" in caplog.text
+
+
+def test_output_evaluator_to_dict_keeps_serializable_tools(caplog):
+    """Test that serializable tools survive to_dict() while callables are skipped"""
+
+    def verify_claim(claim: str) -> str:
+        return "verified"
+
+    evaluator = OutputEvaluator(rubric="Test rubric", tools=["my_pkg.calculator", verify_claim])
+    with caplog.at_level(logging.WARNING):
+        evaluator_dict = evaluator.to_dict()
+
+    assert evaluator_dict["tools"] == ["my_pkg.calculator"]
+    json.dumps(evaluator_dict)
+    assert "skipping non-JSON-serializable tool" in caplog.text
+
+
+def test_output_evaluator_to_dict_skips_circular_reference_tools(caplog):
+    """Test that tools raising ValueError (circular reference) are skipped, not crashed on"""
+    circular: dict = {"name": "circular_tool"}
+    circular["self"] = circular
+
+    evaluator = OutputEvaluator(rubric="Test rubric", tools=[circular, "my_pkg.calculator"])
+    with caplog.at_level(logging.WARNING):
+        evaluator_dict = evaluator.to_dict()
+
+    assert evaluator_dict["tools"] == ["my_pkg.calculator"]
+    json.dumps(evaluator_dict)
+    assert "skipping non-JSON-serializable tool" in caplog.text
+
+
+def test_output_evaluator_tools_setter():
+    """Test that tools can be reassigned after initialization"""
+
+    def verify_claim(claim: str) -> str:
+        return "verified"
+
+    evaluator = OutputEvaluator(rubric="Test rubric")
+    evaluator.tools = [verify_claim]
+
+    assert evaluator.tools == [verify_claim]
+    assert "tools" not in evaluator.to_dict()
 
 
 @patch("strands_evals.evaluators.output_evaluator.Agent")

--- a/tests/strands_evals/evaluators/test_output_evaluator.py
+++ b/tests/strands_evals/evaluators/test_output_evaluator.py
@@ -313,6 +313,9 @@ def test_output_evaluator_to_dict_keeps_serializable_tools(caplog):
     assert evaluator_dict["tools"] == ["my_pkg.calculator"]
     json.dumps(evaluator_dict)
     assert "skipping non-JSON-serializable tool" in caplog.text
+    warnings = [record for record in caplog.records if record.levelno == logging.WARNING]
+    assert len(warnings) == 1  # the serializable tool must not warn
+    assert "verify_claim" in warnings[0].getMessage()  # names which tool to re-attach
 
 
 def test_output_evaluator_to_dict_skips_circular_reference_tools(caplog):

--- a/tests/strands_evals/test_experiment.py
+++ b/tests/strands_evals/test_experiment.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from botocore.exceptions import ClientError
+from strands import tool as strands_tool
 from strands.models.model import Model
 from strands.types.exceptions import EventLoopException, ModelThrottledException
 
@@ -794,6 +795,28 @@ def test_experiment_from_dict_builtin_evaluators_round_trip(evaluator_type):
     experiment = Experiment.from_dict({"cases": [], "evaluators": [serialized]})
     assert len(experiment.evaluators) == 1
     assert isinstance(experiment.evaluators[0], cls)
+
+
+def test_experiment_to_file_round_trip_with_evaluator_tools(tmp_path):
+    """OutputEvaluator with tools survives to_file/from_file: string tools round-trip,
+    decorated-function tools are skipped instead of crashing serialization (issue #373)."""
+
+    @strands_tool
+    def verify_claim(claim: str) -> str:
+        """Verify a claim."""
+        return "verified"
+
+    cases = [Case(name="test", input="hello")]
+    evaluator = OutputEvaluator(rubric="rubric", tools=[verify_claim, "my_pkg.calculator"])
+    experiment = Experiment(cases=cases, evaluators=[evaluator])
+    file_path = tmp_path / "experiment.json"
+
+    experiment.to_file(str(file_path))
+    loaded = Experiment.from_file(str(file_path))
+
+    assert len(loaded.evaluators) == 1
+    assert isinstance(loaded.evaluators[0], OutputEvaluator)
+    assert loaded.evaluators[0].tools == ["my_pkg.calculator"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Description

Fixes a `TypeError: Object of type DecoratedFunctionTool is not JSON serializable` when calling `to_dict()` on an `OutputEvaluator` configured with `tools=`, which also broke `Experiment.to_file()` / `to_dict()` for any experiment containing such an evaluator.

**Root cause:** `Evaluator.to_dict()` serializes every public non-default attribute. `OutputEvaluator` stored `self.tools` publicly, so callable tools (e.g. `@tool`-decorated functions) leaked into the serialized dict and crashed `json.dumps`. `TrajectoryEvaluator` already avoided this by storing `self._tools` privately.

**Fix:**
- `OutputEvaluator` now stores tools privately as `self._tools`, with a public `tools` property + setter so the documented API from #324 is unchanged (`evaluator.tools` reads and `evaluator.tools = [...]` writes as before).
- `OutputEvaluator.to_dict()` is overridden to re-add the JSON-serializable subset of tools (e.g. module path strings), so those still round-trip through `to_file()` / `from_file()`. Non-serializable tools are skipped with a `logger.warning` naming the tool (`tool_name` → `__name__` → type name, never `repr()`) and instructing how to re-attach it after loading. The check catches both `TypeError` and `ValueError` (circular references).
- Since callables cannot round-trip through JSON, users re-attach them after loading:

```python
loaded = Experiment.from_file("experiment.json")
for evaluator in loaded.evaluators:
    if isinstance(evaluator, OutputEvaluator):
        evaluator.tools = [*(evaluator.tools or []), verify_claim]
```

This one change also fixes the whole `Multimodal*` evaluator family (`MultimodalOutputEvaluator`, `MultimodalCorrectnessEvaluator`, `MultimodalFaithfulnessEvaluator`, `MultimodalInstructionFollowingEvaluator`, `MultimodalOverallQualityEvaluator`), since they all pass `tools` through `OutputEvaluator.__init__`.

**Not a breaking change:** the constructor, `evaluator.tools` reads/writes, and loading of previously saved JSON files (including ones with a `tools` key) all behave as before. Serializable tools still round-trip; callable tools previously crashed serialization, so nothing working is lost. One exactness note: `tools=[]` used to serialize as `"tools": []` and now the key is omitted, so it reloads as `None` — behaviorally inert since both mean "no tools" to the evaluator agent.

**Accepted tradeoff:** the skip warning fires at save time, not load time — a reloaded evaluator runs without its callable tools and only the save-side log signals it. Warning at load time isn't structurally possible today because `from_dict` passes every JSON key as a constructor kwarg, so a marker key would raise `TypeError`. Deliberate, documented in the `tools` property docstring.

## Related Issues

Fixes #373
Related: #324, #343

## Documentation PR

N/A — behavior documented in docstrings; no docs changes needed.

## Type of Change

Bug fix

## Testing

How have you tested the change? Verify that the changes do not break functionality or introduce new warnings.

- [ ] I ran `hatch run prepare`
- Added regression tests: callable-only tools produce JSON-serializable `to_dict()` output with no `tools` key plus a warning; mixed tools keep serializable entries and skip callables with exactly one warning naming the dropped tool; circular-reference tools are skipped instead of crashing; `tools` setter works after construction.
- Added an `Experiment`-level regression test pinning #373 where it was reported: `to_file()` → `from_file()` with a real `@tool`-decorated function plus a module path string asserts the string tool survives the round-trip.
- Ran the issue's exact repro: `json.dumps(evaluator.to_dict())` now succeeds while `evaluator.tools` remains usable by `evaluate()` / `evaluate_async()`.
- `hatch test` passes across the output, multimodal, base evaluator, and experiment suites; `hatch fmt --check` (ruff, ruff format, mypy) clean.

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
