### PR TITLE
fix: make Experiment.to_file() reject non-strict JSON instead of writing invalid files

### DIFF
--- a/src/strands_evals/cli/commands/generate.py
+++ b/src/strands_evals/cli/commands/generate.py
@@ -91,7 +91,9 @@ def _run(args: argparse.Namespace) -> int:
         # `Experiment.from_file` round-trips.
         experiment.to_file(args.output)
     else:
-        write_text_output(json.dumps(experiment.to_dict(), indent=2, ensure_ascii=False), None)
+        # allow_nan=False matches Experiment.to_file, so stdout and -o accept the
+        # same experiments. Neither can emit a literal NaN, which is not valid JSON.
+        write_text_output(json.dumps(experiment.to_dict(), indent=2, ensure_ascii=False, allow_nan=False), None)
 
     print(  # noqa: T201
         f"generated {len(experiment.cases)} case(s), {len(experiment.evaluators)} evaluator(s)",

--- a/src/strands_evals/evaluators/output_evaluator.py
+++ b/src/strands_evals/evaluators/output_evaluator.py
@@ -52,8 +52,10 @@ class OutputEvaluator(Evaluator[InputT, OutputT]):
     def tools(self) -> list[Any] | None:
         """Optional tools for the evaluator agent.
 
-        Only JSON-serializable entries (e.g. module path strings) survive `to_dict()`;
-        callables are skipped with a warning and must be re-attached after `from_dict()`.
+        Only tools that can be written as valid JSON in a utf-8 file survive `to_dict()`,
+        for example module path strings. Tools that cannot (callables, NaN or Infinity
+        floats, strings with unpaired surrogates) are skipped with a warning and must be
+        re-attached after `from_dict()`.
         """
         return self._tools
 
@@ -66,25 +68,31 @@ class OutputEvaluator(Evaluator[InputT, OutputT]):
         Convert the evaluator into a dictionary.
 
         Returns:
-            dict: A dictionary containing the evaluator's information. Includes only the
-            JSON-serializable tools; non-serializable tools (e.g. decorated functions)
-            are skipped with a warning since `from_dict()` cannot reconstruct them.
+            dict: A dictionary containing the evaluator's information. Includes only tools
+            that can be written as valid JSON in a utf-8 file. Tools that cannot (decorated
+            functions, NaN or Infinity floats, strings with unpaired surrogates) are skipped
+            with a warning and must be re-attached after `from_dict()`.
         """
         _dict = super().to_dict()
         if self._tools:
             serializable_tools = []
             for tool in self._tools:
                 try:
-                    # Probe with the same strictness as Experiment.to_file()'s utf-8 writer:
-                    # the encode rejects unpaired surrogates, allow_nan=False rejects
-                    # NaN/Infinity (invalid per RFC 8259). UnicodeEncodeError is a ValueError.
+                    # Check each tool with the same settings Experiment.to_file() uses.
+                    # The utf-8 encode rejects unpaired surrogates. allow_nan=False
+                    # rejects NaN and Infinity, which are not allowed in valid JSON.
+                    # UnicodeEncodeError is a subclass of ValueError.
                     json.dumps(tool, ensure_ascii=False, allow_nan=False).encode("utf-8")
                 except (TypeError, ValueError):
-                    tool_name = (
-                        getattr(tool, "tool_name", None) or getattr(tool, "__name__", None) or type(tool).__name__
-                    )
+                    tool_name = getattr(tool, "tool_name", None) or getattr(tool, "__name__", None)
+                    if not isinstance(tool_name, str):
+                        # The tool may be a plain string or a dict with no name attribute.
+                        # A short ascii() preview identifies it better than a type name.
+                        tool_name = ascii(tool)
+                        if len(tool_name) > 80:
+                            tool_name = tool_name[:77] + "..."
                     logger.warning(
-                        "tool_name=<%s> | skipping non-JSON-serializable tool during serialization, "
+                        "tool_name=<%s> | skipping tool that cannot be written as valid utf-8 JSON, "
                         "re-attach it via the `tools` attribute after loading",
                         tool_name,
                     )

--- a/src/strands_evals/evaluators/output_evaluator.py
+++ b/src/strands_evals/evaluators/output_evaluator.py
@@ -75,7 +75,10 @@ class OutputEvaluator(Evaluator[InputT, OutputT]):
             serializable_tools = []
             for tool in self._tools:
                 try:
-                    json.dumps(tool)
+                    # Probe with the same strictness as Experiment.to_file()'s utf-8 writer:
+                    # the encode rejects unpaired surrogates, allow_nan=False rejects
+                    # NaN/Infinity (invalid per RFC 8259). UnicodeEncodeError is a ValueError.
+                    json.dumps(tool, ensure_ascii=False, allow_nan=False).encode("utf-8")
                 except (TypeError, ValueError):
                     tool_name = (
                         getattr(tool, "tool_name", None) or getattr(tool, "__name__", None) or type(tool).__name__

--- a/src/strands_evals/experiment.py
+++ b/src/strands_evals/experiment.py
@@ -744,8 +744,10 @@ class Experiment(Generic[InputT, OutputT]):
 
         Raises:
             ValueError: If the path has a non-JSON extension, or if the experiment contains
-                values that cannot be represented as strict JSON (e.g. NaN/Infinity floats
-                or strings with unpaired surrogates).
+                values that are not allowed in valid JSON, such as NaN or Infinity floats,
+                or strings with unpaired surrogates.
+            TypeError: If the experiment contains objects that are not JSON-serializable,
+                such as a custom class instance in case data or metadata.
         """
         file_path = Path(path)
 
@@ -758,15 +760,22 @@ class Experiment(Generic[InputT, OutputT]):
         else:
             file_path = file_path.with_suffix(".json")
 
+        # Serialize before touching the file. If the data cannot become valid JSON,
+        # the error is raised here and any existing file stays intact.
+        experiment_dict = self.to_dict()
+        try:
+            data = json.dumps(experiment_dict, indent=2, ensure_ascii=False, allow_nan=False).encode("utf-8")
+        except ValueError as e:
+            # UnicodeEncodeError is a subclass of ValueError, so this also catches
+            # unpaired surrogates. The original error stays attached as __cause__.
+            raise ValueError(
+                f"Cannot write experiment to {file_path}: it contains values that are not "
+                f"allowed in valid JSON, such as NaN or Infinity floats, or strings with "
+                f"unpaired surrogates. Check the case inputs, outputs, metadata, and evaluator fields."
+            ) from e
+
         file_path.parent.mkdir(parents=True, exist_ok=True)
-
-        # Serialize and encode before opening the file so a failure (NaN/Infinity via
-        # allow_nan=False, unpaired surrogates via the utf-8 encode) raises loudly
-        # without leaving a truncated, invalid JSON artifact behind.
-        data = json.dumps(self.to_dict(), indent=2, ensure_ascii=False, allow_nan=False).encode("utf-8")
-
-        with open(file_path, "wb") as f:
-            f.write(data)
+        file_path.write_bytes(data)
 
     @classmethod
     def from_dict(cls, data: dict, custom_evaluators: list[type[Evaluator]] | None = None):

--- a/src/strands_evals/experiment.py
+++ b/src/strands_evals/experiment.py
@@ -743,7 +743,9 @@ class Experiment(Generic[InputT, OutputT]):
                   Only .json format is supported.
 
         Raises:
-            ValueError: If the path has a non-JSON extension.
+            ValueError: If the path has a non-JSON extension, or if the experiment contains
+                values that cannot be represented as strict JSON (e.g. NaN/Infinity floats
+                or strings with unpaired surrogates).
         """
         file_path = Path(path)
 
@@ -758,8 +760,13 @@ class Experiment(Generic[InputT, OutputT]):
 
         file_path.parent.mkdir(parents=True, exist_ok=True)
 
-        with open(file_path, "w", encoding="utf-8") as f:
-            json.dump(self.to_dict(), f, indent=2, ensure_ascii=False)
+        # Serialize and encode before opening the file so a failure (NaN/Infinity via
+        # allow_nan=False, unpaired surrogates via the utf-8 encode) raises loudly
+        # without leaving a truncated, invalid JSON artifact behind.
+        data = json.dumps(self.to_dict(), indent=2, ensure_ascii=False, allow_nan=False).encode("utf-8")
+
+        with open(file_path, "wb") as f:
+            f.write(data)
 
     @classmethod
     def from_dict(cls, data: dict, custom_evaluators: list[type[Evaluator]] | None = None):

--- a/tests/strands_evals/evaluators/test_output_evaluator.py
+++ b/tests/strands_evals/evaluators/test_output_evaluator.py
@@ -297,7 +297,7 @@ def test_output_evaluator_to_dict_skips_non_serializable_tools(caplog):
 
     assert "tools" not in evaluator_dict
     json.dumps(evaluator_dict)
-    assert "skipping non-JSON-serializable tool" in caplog.text
+    assert "skipping tool that cannot be written as valid utf-8 JSON" in caplog.text
 
 
 def test_output_evaluator_to_dict_keeps_serializable_tools(caplog):
@@ -312,7 +312,7 @@ def test_output_evaluator_to_dict_keeps_serializable_tools(caplog):
 
     assert evaluator_dict["tools"] == ["my_pkg.calculator"]
     json.dumps(evaluator_dict)
-    assert "skipping non-JSON-serializable tool" in caplog.text
+    assert "skipping tool that cannot be written as valid utf-8 JSON" in caplog.text
     warnings = [record for record in caplog.records if record.levelno == logging.WARNING]
     assert len(warnings) == 1  # the serializable tool must not warn
     assert "verify_claim" in warnings[0].getMessage()  # names which tool to re-attach
@@ -329,24 +329,24 @@ def test_output_evaluator_to_dict_skips_circular_reference_tools(caplog):
 
     assert evaluator_dict["tools"] == ["my_pkg.calculator"]
     json.dumps(evaluator_dict)
-    assert "skipping non-JSON-serializable tool" in caplog.text
+    assert "skipping tool that cannot be written as valid utf-8 JSON" in caplog.text
 
 
 def test_output_evaluator_to_dict_skips_unpaired_surrogate_tools(caplog):
-    """Test that string tools with unpaired surrogates are skipped so the utf-8 writer
-    in Experiment.to_file() cannot crash on them (issue #380)"""
+    """Test that string tools with unpaired surrogates are skipped, so writing the
+    experiment to a utf-8 file cannot crash on them (issue #380)"""
     evaluator = OutputEvaluator(rubric="Test rubric", tools=["my_pkg.calc_\udcff", "my_pkg.calculator"])
     with caplog.at_level(logging.WARNING):
         evaluator_dict = evaluator.to_dict()
 
     assert evaluator_dict["tools"] == ["my_pkg.calculator"]
     json.dumps(evaluator_dict, ensure_ascii=False, allow_nan=False).encode("utf-8")
-    assert "skipping non-JSON-serializable tool" in caplog.text
+    assert "skipping tool that cannot be written as valid utf-8 JSON" in caplog.text
 
 
 def test_output_evaluator_to_dict_skips_nan_tools(caplog):
-    """Test that dict tools containing NaN/Infinity are skipped so serialized output
-    stays RFC 8259-valid JSON (issue #380)"""
+    """Test that dict tools containing NaN or Infinity are skipped, so the serialized
+    output stays valid JSON (issue #380)"""
     nan_tool = {"name": "t", "default": float("nan")}
     evaluator = OutputEvaluator(rubric="Test rubric", tools=[nan_tool, "my_pkg.calculator"])
     with caplog.at_level(logging.WARNING):
@@ -354,7 +354,7 @@ def test_output_evaluator_to_dict_skips_nan_tools(caplog):
 
     assert evaluator_dict["tools"] == ["my_pkg.calculator"]
     json.dumps(evaluator_dict, ensure_ascii=False, allow_nan=False).encode("utf-8")
-    assert "skipping non-JSON-serializable tool" in caplog.text
+    assert "skipping tool that cannot be written as valid utf-8 JSON" in caplog.text
 
 
 def test_output_evaluator_tools_setter():

--- a/tests/strands_evals/evaluators/test_output_evaluator.py
+++ b/tests/strands_evals/evaluators/test_output_evaluator.py
@@ -332,6 +332,31 @@ def test_output_evaluator_to_dict_skips_circular_reference_tools(caplog):
     assert "skipping non-JSON-serializable tool" in caplog.text
 
 
+def test_output_evaluator_to_dict_skips_unpaired_surrogate_tools(caplog):
+    """Test that string tools with unpaired surrogates are skipped so the utf-8 writer
+    in Experiment.to_file() cannot crash on them (issue #380)"""
+    evaluator = OutputEvaluator(rubric="Test rubric", tools=["my_pkg.calc_\udcff", "my_pkg.calculator"])
+    with caplog.at_level(logging.WARNING):
+        evaluator_dict = evaluator.to_dict()
+
+    assert evaluator_dict["tools"] == ["my_pkg.calculator"]
+    json.dumps(evaluator_dict, ensure_ascii=False, allow_nan=False).encode("utf-8")
+    assert "skipping non-JSON-serializable tool" in caplog.text
+
+
+def test_output_evaluator_to_dict_skips_nan_tools(caplog):
+    """Test that dict tools containing NaN/Infinity are skipped so serialized output
+    stays RFC 8259-valid JSON (issue #380)"""
+    nan_tool = {"name": "t", "default": float("nan")}
+    evaluator = OutputEvaluator(rubric="Test rubric", tools=[nan_tool, "my_pkg.calculator"])
+    with caplog.at_level(logging.WARNING):
+        evaluator_dict = evaluator.to_dict()
+
+    assert evaluator_dict["tools"] == ["my_pkg.calculator"]
+    json.dumps(evaluator_dict, ensure_ascii=False, allow_nan=False).encode("utf-8")
+    assert "skipping non-JSON-serializable tool" in caplog.text
+
+
 def test_output_evaluator_tools_setter():
     """Test that tools can be reassigned after initialization"""
 

--- a/tests/strands_evals/test_experiment.py
+++ b/tests/strands_evals/test_experiment.py
@@ -819,6 +819,32 @@ def test_experiment_to_file_round_trip_with_evaluator_tools(tmp_path):
     assert loaded.evaluators[0].tools == ["my_pkg.calculator"]
 
 
+def test_experiment_to_file_rejects_nan_without_corrupting_existing_file(tmp_path):
+    """to_file() raises on NaN values instead of writing RFC 8259-invalid JSON,
+    and leaves an existing file untouched (issue #380)."""
+    file_path = tmp_path / "experiment.json"
+    Experiment(cases=[Case(name="ok", input="hello")]).to_file(str(file_path))
+    original = file_path.read_bytes()
+
+    bad = Experiment(cases=[Case(name="bad", input=float("nan"))])
+    with pytest.raises(ValueError):
+        bad.to_file(str(file_path))
+
+    assert file_path.read_bytes() == original
+
+
+def test_experiment_to_file_rejects_unpaired_surrogates_without_writing(tmp_path):
+    """to_file() raises on strings with unpaired surrogates instead of leaving a
+    truncated, invalid JSON file behind (issue #380)."""
+    file_path = tmp_path / "experiment.json"
+    bad = Experiment(cases=[Case(name="bad", input="path_\udcff")])
+
+    with pytest.raises(ValueError):  # UnicodeEncodeError is a ValueError subclass
+        bad.to_file(str(file_path))
+
+    assert not file_path.exists()
+
+
 @pytest.mark.asyncio
 async def test_experiment_run_evaluations_async():
     """Test run_evaluations_async with a simple task"""

--- a/tests/strands_evals/test_experiment.py
+++ b/tests/strands_evals/test_experiment.py
@@ -820,14 +820,14 @@ def test_experiment_to_file_round_trip_with_evaluator_tools(tmp_path):
 
 
 def test_experiment_to_file_rejects_nan_without_corrupting_existing_file(tmp_path):
-    """to_file() raises on NaN values instead of writing RFC 8259-invalid JSON,
-    and leaves an existing file untouched (issue #380)."""
+    """to_file() raises on NaN values instead of writing invalid JSON, and leaves an
+    existing file untouched (issue #380)."""
     file_path = tmp_path / "experiment.json"
     Experiment(cases=[Case(name="ok", input="hello")]).to_file(str(file_path))
     original = file_path.read_bytes()
 
     bad = Experiment(cases=[Case(name="bad", input=float("nan"))])
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Cannot write experiment"):
         bad.to_file(str(file_path))
 
     assert file_path.read_bytes() == original
@@ -839,10 +839,28 @@ def test_experiment_to_file_rejects_unpaired_surrogates_without_writing(tmp_path
     file_path = tmp_path / "experiment.json"
     bad = Experiment(cases=[Case(name="bad", input="path_\udcff")])
 
-    with pytest.raises(ValueError):  # UnicodeEncodeError is a ValueError subclass
+    # The UnicodeEncodeError is wrapped in the same ValueError as the NaN case.
+    with pytest.raises(ValueError, match="Cannot write experiment"):
         bad.to_file(str(file_path))
 
     assert not file_path.exists()
+
+
+def test_experiment_to_file_round_trips_after_skipping_unwritable_tools(tmp_path):
+    """An experiment whose bad evaluator tools were skipped by to_dict() must save and
+    reload cleanly. This guards against the tool check and the file writer drifting
+    apart again (issue #380)."""
+    evaluator = OutputEvaluator(
+        rubric="rubric",
+        tools=[{"name": "t", "default": float("nan")}, "my_pkg.calc_\udcff", "my_pkg.calculator"],
+    )
+    experiment = Experiment(cases=[Case(name="ok", input="hello")], evaluators=[evaluator])
+    file_path = tmp_path / "experiment.json"
+
+    experiment.to_file(str(file_path))
+    loaded = Experiment.from_file(str(file_path))
+
+    assert loaded.evaluators[0].tools == ["my_pkg.calculator"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Description

`Experiment.to_file()` writes JSON with `ensure_ascii=False` into a utf-8 file. The tool serialization check in `OutputEvaluator.to_dict()` (added in #379) used `json.dumps(tool)` with default settings, which accept some values the file writer cannot handle. Two kinds of values passed the check and still broke the file:

- A string with an unpaired surrogate character (for example a file path decoded with `surrogateescape`) crashed the write with `UnicodeEncodeError` and left behind a truncated, invalid JSON file.
- A `NaN` or `Infinity` float was written as the literal text `NaN`, which is not valid JSON and is rejected by strict parsers such as `jq` and JavaScript's `JSON.parse`.

### Changes

- `OutputEvaluator.to_dict()` now checks each tool with the same settings the file writer uses: `json.dumps(tool, ensure_ascii=False, allow_nan=False).encode("utf-8")`. Tools containing unpaired surrogates or NaN/Infinity are skipped with the existing warning instead of breaking the file later. No new exception handling was needed because `UnicodeEncodeError` is a subclass of `ValueError`.
- `Experiment.to_file()` now converts the experiment to JSON bytes before opening the file, and passes `allow_nan=False`. Bad values raise `ValueError` before the file is touched, so a failure can no longer truncate or corrupt an existing file.

## Related Issues

Fixes #380

## Documentation PR

N/A (the `to_file()` docstring is updated in this PR)

## Type of Change

Bug fix

## Testing

How have you tested the change? Verify that the changes do not break functionality or introduce new warnings.

- [x] I ran `hatch run prepare` (lint, format, and the full py3.10–3.14 test matrix pass)
- Added 4 unit tests: surrogate and NaN tools are skipped by `to_dict()`, and `to_file()` raises `ValueError` on bad case data while leaving the destination file untouched.
- Ran both examples from #380. Each now produces a valid, loadable JSON file instead of a crash or a file containing `NaN`.

## Checklist
- [ ] I have read the CONTRIBUTING document
- [ ] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
