### PR TITLE
fix(test): clarify tool-selection prompt in flaky Claude integration test

### DIFF
--- a/tests_integ/test_claude_openinference_eval.py
+++ b/tests_integ/test_claude_openinference_eval.py
@@ -202,7 +202,7 @@ def test_claude_multi_agent_evaluation(telemetry):
     test_cases = [
         Case[str, str](
             name="multi-agent-weather",
-            input="What is the weather for Seattle according to the local weather dataset?",
+            input="Use the weather-specialist agent to get the weather for Seattle from the local weather dataset.",
             expected_assertion=(
                 "The agent delegated to the weather-specialist and responded with "
                 "the weather in Seattle, which is Rainy and 55F."


### PR DESCRIPTION
## Description

The `test_claude_multi_agent_evaluation` integration test was flaky due to a non-deterministic `ToolSelectionAccuracyEvaluator` score. The original prompt:

> "What is the weather for Seattle according to the local weather dataset?"

is ambiguous when both `Agent` and `Bash` are in the available tool list. The phrase "local weather dataset" is a plausible hint that `Bash` is the right tool, causing the judge to vote No on the orchestrator's `Agent` delegation call. The `AgentDefinition.description` and `prompt` fields — which contain the "always delegate" constraint — are runtime instructions to the Claude model only. They do not appear anywhere in the evaluation pipeline's judge prompt.

This PR changes the test case `input` to explicitly name the weather-specialist agent. With this wording, calling `Agent(weather-specialist)` is the unambiguous correct action at the orchestrator level. The judge can no longer reasonably vote No on the delegation call.

## Type of Change

Bug fix

## Testing

How have you tested the change? Verify that the changes do not break functionality or introduce new warnings.

- [x] I ran `hatch run prepare`
- [x] I ran the CI integration tests 3 times and they all passed.

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
